### PR TITLE
Devirtualize FunctionInfo

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -5438,7 +5438,21 @@ namespace Js
         return ScopeType_WithScope;
     }
 
+    // ScopeSlots
+    bool ScopeSlots::IsDebuggerScopeSlotArray() 
+    {
+        return DebuggerScope::Is(slotArray[ScopeMetadataSlotIndex]);
+    }
+
     // DebuggerScope
+    bool DebuggerScope::Is(void* ptr)
+    {
+        if (!ptr)
+        {
+            return false;
+        }
+        return VirtualTableInfo<DebuggerScope>::HasVirtualTable(ptr);
+    }
 
     // Get the sibling for the current debugger scope.
     DebuggerScope * DebuggerScope::GetSiblingScope(RegSlot location, FunctionBody *functionBody)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -3582,20 +3582,17 @@ namespace Js
         {
         }
 
-        bool IsFunctionScopeSlotArray()
-        {
-            return FunctionInfo::Is(slotArray[ScopeMetadataSlotIndex]);
-        }
+        bool IsDebuggerScopeSlotArray();
 
         FunctionInfo* GetFunctionInfo()
         {
-            Assert(IsFunctionScopeSlotArray());
+            Assert(!IsDebuggerScopeSlotArray());
             return (FunctionInfo*)PointerValue(slotArray[ScopeMetadataSlotIndex]);
         }
 
         DebuggerScope* GetDebuggerScope()
         {
-            Assert(!IsFunctionScopeSlotArray());
+            Assert(IsDebuggerScopeSlotArray());
             return (DebuggerScope*)PointerValue(slotArray[ScopeMetadataSlotIndex]);
         }
 
@@ -3921,6 +3918,9 @@ namespace Js
     // Used to track with, catch, and block scopes for the debugger to determine context.
     class DebuggerScope
     {
+    protected:
+        DEFINE_VTABLE_CTOR_NOBASE(DebuggerScope);
+
     public:
         typedef JsUtil::List<DebuggerScopeProperty> DebuggerScopePropertyList;
 
@@ -3936,6 +3936,9 @@ namespace Js
             this->range.end = -1;
         }
 
+        virtual ~DebuggerScope() {}
+
+        static bool Is(void* ptr);
         DebuggerScope * GetSiblingScope(RegSlot location, FunctionBody *functionBody);
         void AddProperty(RegSlot location, Js::PropertyId propertyId, DebuggerScopePropertyFlags flags);
         bool GetPropertyIndex(Js::PropertyId propertyId, int& i);
@@ -3997,10 +4000,10 @@ namespace Js
         void EnsurePropertyListIsAllocated();
 
     private:
+        FieldNoBarrier(Recycler*) recycler;
         Field(DebuggerScope*) parentScope;
         Field(regex::Interval) range; // The start and end byte code writer offsets used when comparing where the debugger is currently stopped at (breakpoint location).
         Field(RegSlot) scopeLocation;
-        FieldNoBarrier(Recycler*) recycler;
     };
 
     class ScopeObjectChain

--- a/lib/Runtime/Base/FunctionInfo.cpp
+++ b/lib/Runtime/Base/FunctionInfo.cpp
@@ -29,15 +29,6 @@ namespace Js
 
     }
 
-    bool FunctionInfo::Is(void* ptr)
-    {
-        if(!ptr)
-        {
-            return false;
-        }
-        return VirtualTableInfo<FunctionInfo>::HasVirtualTable(ptr);
-    }
-
     void FunctionInfo::VerifyOriginalEntryPoint() const
     {
         Assert(!this->HasBody() || this->IsDeferredParseFunction() || this->IsDeferredDeserializeFunction() || this->GetFunctionProxy()->HasValidEntryPoint());

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -9,13 +9,11 @@ namespace Js
     class ParseableFunctionInfo;
     class DeferDeserializeFunctionInfo;
 
-    class FunctionInfo: public FinalizableObject
+    class FunctionInfo
     {
         friend class RemoteFunctionBody;
-    protected:
-        DEFINE_VTABLE_CTOR_NOBASE(FunctionInfo);
-    public:
 
+    public:
         enum Attributes : uint32
         {
             None                           = 0x00000,
@@ -46,7 +44,6 @@ namespace Js
         FunctionInfo(JavascriptMethod entryPoint, _no_write_barrier_tag, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
         FunctionInfo(FunctionInfo& that); // Todo: (leish)(swb) find a way to prevent non-static initializer calling this ctor
 
-        static bool Is(void *ptr);
         static DWORD GetFunctionBodyImplOffset() { return offsetof(FunctionInfo, functionBodyImpl); }
         static BYTE GetOffsetOfFunctionProxy()
         {
@@ -115,16 +112,6 @@ namespace Js
 
         uint GetCompileCount() const { return compileCount; }
         void SetCompileCount(uint count) { compileCount = count; }
-
-        virtual void Finalize(bool isShutdown) override
-        {
-        }
-
-        virtual void Dispose(bool isShutdown) override
-        {
-        }
-
-        virtual void Mark(Recycler *recycler) override { AssertMsg(false, "Mark called on object that isn't TrackableObject"); }
 
         BOOL IsDeferredDeserializeFunction() const { return ((this->attributes & DeferredDeserialize) == DeferredDeserialize); }
         BOOL IsDeferredParseFunction() const { return ((this->attributes & DeferredParse) == DeferredParse); }

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -610,7 +610,7 @@ namespace Js
             ArenaAllocator *arena = pFrame->GetArena();
             ScopeSlots slotArray = GetSlotArray();
 
-            if (slotArray.IsFunctionScopeSlotArray())
+            if (!slotArray.IsDebuggerScopeSlotArray())
             {
                 DebuggerScope *formalScope = GetScopeWhenHaltAtFormals();
                 bool isInParamScope = IsInParamScope(formalScope, pFrame);
@@ -4083,15 +4083,15 @@ namespace Js
             // The scope is defined by a slot array object so grab the function body out to get the function name.
             ScopeSlots slotArray = ScopeSlots(reinterpret_cast<Var*>(instance));
 
-            if(slotArray.IsFunctionScopeSlotArray())
-            {
-                Js::FunctionBody *functionBody = slotArray.GetFunctionInfo()->GetFunctionBody();
-                return functionBody->GetDisplayName();
-            }
-            else
+            if(slotArray.IsDebuggerScopeSlotArray())
             {
                 // handling for block/catch scope
                 return _u("");
+            }
+            else
+            {
+                Js::FunctionBody *functionBody = slotArray.GetFunctionInfo()->GetFunctionBody();
+                return functionBody->GetDisplayName();
             }
         }
     }

--- a/lib/Runtime/Debug/TTSnapshotExtractor.cpp
+++ b/lib/Runtime/Debug/TTSnapshotExtractor.cpp
@@ -107,7 +107,7 @@ namespace TTD
                 slotInfo->Slots[j] = slots.Get(j);
             }
 
-            if(slots.IsFunctionScopeSlotArray())
+            if(!slots.IsDebuggerScopeSlotArray())
             {
                 Js::FunctionBody* fb = slots.GetFunctionInfo()->GetFunctionBody();
 
@@ -324,7 +324,7 @@ namespace TTD
                     {
                         Js::ScopeSlots slotArray = (Js::Var*)scope;
                         uint slotArrayCount = static_cast<uint>(slotArray.GetCount());
-                        if(slotArray.IsFunctionScopeSlotArray())
+                        if(!slotArray.IsDebuggerScopeSlotArray())
                         {
                             this->MarkFunctionBody(slotArray.GetFunctionInfo()->GetFunctionBody());
                         }

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -578,13 +578,13 @@ namespace Js
                 uint slotArrayCount = static_cast<uint>(slotArray.GetCount());
 
                 //get the function body associated with the scope
-                if(slotArray.IsFunctionScopeSlotArray())
+                if (slotArray.IsDebuggerScopeSlotArray())
                 {
-                    rctxInfo->EnqueueNewFunctionBodyObject(this, slotArray.GetFunctionInfo()->GetFunctionBody(), scopePathString.GetStrValue());
+                    rctxInfo->AddWellKnownDebuggerScopePath(this, slotArray.GetDebuggerScope(), i);
                 }
                 else
                 {
-                    rctxInfo->AddWellKnownDebuggerScopePath(this, slotArray.GetDebuggerScope(), i);
+                    rctxInfo->EnqueueNewFunctionBodyObject(this, slotArray.GetFunctionInfo()->GetFunctionBody(), scopePathString.GetStrValue());
                 }
 
                 for(uint j = 0; j < slotArrayCount; j++)

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -357,13 +357,17 @@ namespace Js
                     for (i = 0; i < frameDisplay->GetLength(); i++)
                     {
                         Var *slotArray = (Var*)frameDisplay->GetItem(i);
-                        ScopeSlots slots(slotArray);
-                        if (slots.IsFunctionScopeSlotArray())
+
+                        if (ScopeSlots::Is(slotArray))
                         {
-                            FunctionProxy *functionProxy = slots.GetFunctionInfo()->GetFunctionProxy();
-                            if (functionProxy->IsFunctionBody() && this->NeedBoxFrame(functionProxy->GetFunctionBody()))
+                            ScopeSlots slots(slotArray);
+                            if (!slots.IsDebuggerScopeSlotArray())
                             {
-                                break;
+                                FunctionProxy *functionProxy = slots.GetFunctionInfo()->GetFunctionProxy();
+                                if (functionProxy->IsFunctionBody() && this->NeedBoxFrame(functionProxy->GetFunctionBody()))
+                                {
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
With the changes to the FunctionBody hierarchy for redeferral, FunctionInfo
no longer needs to inherit from FinalizableObject. Removing the base class
gets rid of the vtable pointer and shrinks it by 8 bytes and into the 32 byte
bucket in the Recycler. This saves ~500k on Gmail.
