### PR TITLE
Fix loop backedge removal in lowerer

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -10094,7 +10094,14 @@ Lowerer::LowerEqualityBranch(IR::Instr* instr, IR::JnHelperMethod helper)
     }
     if (!needHelper)
     {
-        instr->Remove();
+        if (instr->AsBranchInstr()->GetTarget()->m_isLoopTop)
+        {
+            LowerBrCMem(instr, helper, false, hasStrFastPath);
+        }
+        else
+        {
+            instr->Remove();
+        }
     }
 
     return instrPrev;

--- a/test/Optimizer/noedgebug.js
+++ b/test/Optimizer/noedgebug.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function test0() {
+  var obj0 = {};
+  if (!obj0) {
+    for (var _strvar0 of aliasOfIntArr0) {
+    }
+    do {
+      uniqobj4.prop1 = !-222;
+    } while (-444256680 == uniqobj4.prop1);
+  }
+}
+test0();
+test0();
+test0();
+WScript.Echo("Passed");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1479,4 +1479,10 @@
       <tags>exclude_dynapogo,exclude_serialized,exclude_nonative</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>noedgebug.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -oopjit- -off:bailonnoprofile -loopinterpretcount:0 -OOPJITMissingOpts- </compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We can end up removing loop backedge in lowerer instead of globopt under some flags.
In this case we don't unmark the loop top. This change unmarks it, so that sccliveness does not complain later on.

Fixes OS#14634783
