### PR TITLE
remove overly aggressive asm.js assert

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -982,10 +982,10 @@ namespace Js
         }
         else
         {
-            AssertOrFailFast(UNREACHED);
+            // Vars must have concrete type, so any "-ish" or "maybe" type
+            // cannot be in a var location
             return false;
         }
-
     }
 
     RegSlot AsmJSByteCodeGenerator::EmitIndirectCallIndex(ParseNode* identifierNode, ParseNode* indexNode)

--- a/test/AsmJs/maybecallbug.baseline
+++ b/test/AsmJs/maybecallbug.baseline
@@ -1,0 +1,6 @@
+
+maybecallbug.js(10, 3)
+	Asm.js Compilation Error function : None::foo
+	Function bar doesn't support arguments
+
+Asm.js compilation failed.

--- a/test/AsmJs/maybecallbug.js
+++ b/test/AsmJs/maybecallbug.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var module = (function(stdlib, foreign, heap) {
+  "use asm";
+  var bar = foreign.bar;
+  var Float32ArrayView = new stdlib.Float32Array(heap);
+  function foo() {
+    return +bar(Float32ArrayView[0])
+  }
+  return foo;
+})(this, {bar: function(){}}, new ArrayBuffer(1 << 20));
+
+module();

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -1039,4 +1039,11 @@
       <files>argassignbug.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>maybecallbug.js</files>
+      <baseline>maybecallbug.baseline</baseline>
+      <compile-flags>-testtrace:asmjs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
I added IsVarLocationGeneric with failfast to ensure that you only pass concrete types to the method, but seems reasonable to allow other types as well and since only concrete types can be stored to locals we can return back a good answer.

OS:14979462