### PR TITLE
Adding an option to provide a timeout value through command line in RL

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -379,6 +379,7 @@ static const char *ProgramName;
 static const char *LogName;
 static const char *FullLogName;
 static const char *ResultsLogName;
+static const char *TestTimeout; // Stores timeout in seconds for all tests
 
 // NOTE: this might be unused now
 static char TempPath[MAX_PATH] = ""; // Path for temporary files
@@ -2890,6 +2891,11 @@ ParseArg(
             break;
          }
 
+         if (!_stricmp(&arg[1], "timeout")) {
+             TestTimeout = ComplainIfNoArg(arg, s);
+             break;
+         }
+
 #ifndef NODEBUG
          if (!_stricmp(&arg[1], "debug")) {
             FDebug = FVerbose = TRUE;
@@ -3491,6 +3497,12 @@ GetTestInfoFromNode
                      "Invalid timeout specified. Cannot parse or too large.\n", NULL);
                   childNode->Dump();
                   return FALSE;
+               }
+
+               if (TestTimeout != NULL)
+               {
+                   // Overriding the timeout value with the command line value
+                   testInfo->data[i] = TestTimeout;
                }
             }
 

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -185,6 +185,9 @@ goto :main
   if /i "%1" == "-DumpOnCrash"      set _DumpOnCrash=1&                                         goto :ArgOk
   if /i "%1" == "-CrashOnException" set _CrashOnException=1&                                    goto :ArgOk
 
+  ::Timeout flag
+  if /i "%1" == "-timeout"          set _TestTimeout=%~2&                                       goto : ArgOkShift2
+
   if /i "%1" == "-extraVariants" (
     :: Extra variants are specified by the user but not run by default.
     if "%_ExtraVariants%" == "" (
@@ -452,6 +455,9 @@ goto :main
     set EXTRA_CC_FLAGS=%EXTRA_CC_FLAGS% -LargeByteCodeLayout -forceserialized
     set EXTRA_RL_FLAGS=-nottags:exclude_bytecodelayout -nottags:exclude_forceserialized
     set _exclude_serialized=-nottags:exclude_serialized
+  )
+  if not "%_TestTimeout%" == "" (
+    set EXTRA_RL_FLAGS=%EXTRA_RL_FLAGS% -timeout:%_TestTimeout%
   )
 
   echo.


### PR DESCRIPTION
When tests run on lower configuration machines the timeout values specified in the XML does not seem to be valid. This change is to provide a way to specify a timeout value for all tests cases in such cases. This will override the value from the XML file.
