### PR TITLE
fix a GC NewTrackBit assertion

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1251,7 +1251,7 @@ public:
 #define DEFINE_RECYCLER_NOTHROW_ALLOC(AllocFunc, attributes) DEFINE_RECYCLER_NOTHROW_ALLOC_BASE(AllocFunc, AllocWithAttributes, attributes)
 #define DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocFunc, attributes) DEFINE_RECYCLER_NOTHROW_ALLOC_BASE(AllocFunc, AllocZeroWithAttributes, attributes)
 
-#if GLOBAL_ENABLE_WRITE_BARRIER && !defined(_WIN32)
+#if GLOBAL_ENABLE_WRITE_BARRIER
     DEFINE_RECYCLER_ALLOC(Alloc, WithBarrierBit);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocZero, WithBarrierBit);
     DEFINE_RECYCLER_ALLOC(AllocFinalized, FinalizableWithBarrierObjectBits);


### PR DESCRIPTION
In RECYCLER_STATS (debug) mode a newly allocated finalizable heap block has
NewFinalizeBit on (aliased with NewTrackBit and used for finalizable object
counting). This bit is supposed to be cleared later after mark processing.
However these may occur in reversed order. We could falsely mark an address
before the owner heap block allocation, resulting in newly allocated
address marked and NewTrackBit (NewFinalizeBit) on.

This did not repro on Windows because the object usually triggers default
write watch and re-mark of the address. Change the related code to trigger
software write barrier on the address to work around on xplat.

Fix #3280
