### PR TITLE
Stop trying to JIT if OOP JIT disconnected

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1870,9 +1870,19 @@ NativeCodeGenerator::Prioritize(JsUtil::Job *const job, const bool forceAddJobTo
     }
     else
     {
-        if(!forceAddJobToProcessor && !functionBody->TryTransitionToJitExecutionMode())
+        if (!forceAddJobToProcessor)
         {
-            return;
+            if (!functionBody->TryTransitionToJitExecutionMode())
+            {
+                return;
+            }
+#if ENABLE_OOP_NATIVE_CODEGEN
+            // If for some reason OOP JIT isn't connected (e.g. it crashed), don't attempt to JIT
+            if (JITManager::GetJITManager()->IsOOPJITEnabled() && !JITManager::GetJITManager()->IsConnected())
+            {
+                return;
+            }
+#endif
         }
 
         jitMode = functionBody->GetExecutionMode();

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -6084,6 +6084,13 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
             }
 
 #if ENABLE_NATIVE_CODEGEN
+#if ENABLE_OOP_NATIVE_CODEGEN
+            // If for some reason OOP JIT isn't connected (e.g. it crashed), don't attempt to JIT a loop body
+            if (JITManager::GetJITManager()->IsOOPJITEnabled() && !JITManager::GetJITManager()->IsConnected())
+            {
+                return nullptr;
+            }
+#endif
             // If the job is not scheduled then we need to schedule it now.
             // It is possible a job was scheduled earlier and we find ourselves looking at the same entry point
             // again. For example, if the function with the loop was JITed and bailed out then as we finish


### PR DESCRIPTION
Continuing to attempt to JIT makes the interpreter much slower than it would otherwise be, because you end up creating a work item every call/every loop top