### PR TITLE
OS#14711878: Add STACK_PROBE in Parser::ConstructNameHint

### DIFF
--- a/test/StackTrace/dotChainNameHint.js
+++ b/test/StackTrace/dotChainNameHint.js
@@ -1,0 +1,44 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+if (typeof (WScript) != "undefined") {
+    WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "OS#14711878: Throw SOE (not crash) in Parser::ConstructNameHint (OSS-Fuzz test case)",
+        body: function ()
+        {
+            assert.throws(function () {
+                // This block is derived directly from the OSS-Fuzz test case.
+                const M = 1e6;
+                var u;
+                for (var i = 0; i < M; i++) {
+                    u = u + ".prototype";
+                }
+                eval(u);
+            }, Error, "Should throw SOE (not crash with SOE) in Parser::ConstructNameHint", "Out of stack space");
+        }
+    },
+    {
+        name: "OS#14711878: Throw SOE (not crash) in Parser::ConstructNameHint (more 'normal' test case)",
+        body: function ()
+        {
+            assert.throws(function () {
+                // There is nothing special about the names/patterns used in the above test case.
+                // This bug is strictly about SOE caused by stack depth from chaining the dot `.` operator.
+                const M = 1e6;
+                var u = "foo"; // explicit name
+                for (var i = 0; i < M; i++) {
+                    u = u + ".a"; // not a special property
+                }
+                eval(u);
+            }, Error, "Should throw SOE (not crash with SOE) in Parser::ConstructNameHint", "Out of stack space");
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/StackTrace/rlexe.xml
+++ b/test/StackTrace/rlexe.xml
@@ -135,4 +135,10 @@
       <compile-flags>-ExtendedErrorStackForTestHost -loopinterpretcount:1</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>dotChainNameHint.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Parser::ConstructNameHint recursively visits nodes in the AST and could cause
an SOE crash for long knopDot chains.  Although this method could be made
non-recursive, Emit (ByteCodeEmitter.cpp) hits a stack probe for shorter chains
than which cause SOE here, so add a stack probe to throw SOE rather than crash
on SOE.  Because of that correspondence, use
Js::Constants::MinStackByteCodeVisitor (which is used in Emit) for the stack
probe here.

Fixes OS#14711878

Found by OSS-Fuzz
