### PR TITLE
[MSFT:14576675] Stack walker should use _AddressOfReturnAddress to detect script-entry frames. 

### DIFF
--- a/lib/Runtime/Base/LeaveScriptObject.cpp
+++ b/lib/Runtime/Base/LeaveScriptObject.cpp
@@ -7,7 +7,7 @@
 namespace Js
 {
     EnterScriptObject::EnterScriptObject(ScriptContext* scriptContext, ScriptEntryExitRecord* entryExitRecord,
-        void * returnAddress, bool doCleanup, bool isCallRoot, bool hasCaller)
+        void * addrOfReturnAddress, bool doCleanup, bool isCallRoot, bool hasCaller)
     {
         Assert(scriptContext);
 
@@ -35,7 +35,7 @@ namespace Js
             false;
 
         // Initialize the entry exit record
-        entryExitRecord->returnAddrOfScriptEntryFunction = returnAddress;
+        entryExitRecord->addrOfReturnAddrOfScriptEntryFunction = addrOfReturnAddress;
         entryExitRecord->hasCaller = hasCaller;
         entryExitRecord->scriptContext = scriptContext;
 #ifdef EXCEPTION_CHECK

--- a/lib/Runtime/Base/LeaveScriptObject.h
+++ b/lib/Runtime/Base/LeaveScriptObject.h
@@ -21,7 +21,7 @@
             Js::ScriptEntryExitRecord __entryExitRecord = {0}; \
             SAVE_FS0(); \
             Js::EnterScriptObject __enterScriptObject = Js::EnterScriptObject(__localScriptContext, &__entryExitRecord, \
-                _ReturnAddress(), doCleanup, isCallRoot, hasCaller); \
+                _AddressOfReturnAddress(), doCleanup, isCallRoot, hasCaller); \
             __localScriptContext->OnScriptStart(isCallRoot, isScript); \
             __enterScriptObject.VerifyEnterScript();
 
@@ -137,7 +137,7 @@ namespace Js
         JavascriptLibrary* library;  // stack pin the library.
     public:
         EnterScriptObject(ScriptContext* scriptContext, ScriptEntryExitRecord* entryExitRecord,
-            void * returnAddress, bool doCleanup, bool isCallRoot, bool hasCaller);
+            void * addrOfReturnAddress, bool doCleanup, bool isCallRoot, bool hasCaller);
 
         void VerifyEnterScript();
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -370,7 +370,7 @@ namespace Js
 #endif
         Js::ImplicitCallFlags savedImplicitCallFlags;
 
-        void * returnAddrOfScriptEntryFunction;
+        void * addrOfReturnAddrOfScriptEntryFunction;
         void * frameIdOfScriptExitFunction; // the frameAddres in x86, the return address in amd64/arm_soc
         ScriptContext * scriptContext;
         struct ScriptEntryExitRecord * next;

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -737,7 +737,7 @@ namespace Js
         }
 
         // If we're at the entry from a host frame, hop to the frame from which we left the script.
-        if (this->currentFrame.GetInstructionPointer() == this->entryExitRecord->returnAddrOfScriptEntryFunction)
+        if (this->currentFrame.GetAddressOfInstructionPointer() == this->entryExitRecord->addrOfReturnAddrOfScriptEntryFunction)
         {
             BOOL hasCaller = this->entryExitRecord->hasCaller || this->forceFullWalk;
 


### PR DESCRIPTION
Currently we use _ReturnAddress to identify a frame that entered the script and to skip walking of non-script frames. But _ReturnAddress is not unique to a given frame, so use _AddressOfReturnAddress instead.