### PR TITLE
Fixing a value type check when folding branches based on value numbers.

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6597,7 +6597,7 @@ GlobOpt::OptConstFoldBranch(IR::Instr *instr, Value *src1Val, Value*src2Val, Val
     {
         // NaN !== NaN, and objects can have valueOf/toString
         return val1->IsEqualTo(val2) &&
-            val1->GetValueInfo()->IsPrimitive() && !val1->GetValueInfo()->IsFloat();
+            val1->GetValueInfo()->IsPrimitive() && val1->GetValueInfo()->IsNotFloat();
     };
 
     // Make sure GetConstantVar only returns primitives.

--- a/lib/Backend/ValueInfo.h
+++ b/lib/Backend/ValueInfo.h
@@ -89,6 +89,7 @@ public:
 
     using ValueType::HasBeenFloat;
     using ValueType::IsFloat;
+    using ValueType::IsNotFloat;
     using ValueType::IsLikelyFloat;
 
     using ValueType::HasBeenNumber;

--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -311,6 +311,13 @@ bool ValueType::IsFloat() const
             ));
 }
 
+bool ValueType::IsNotFloat() const
+{
+    return
+        AnyOnExcept(Bits::Likely | Bits::Object | Bits::CanBeTaggedValue | Bits::Float | Bits::Number) ||
+        OneOnOneOff(Bits::Object, Bits::Likely);
+}
+
 bool ValueType::IsLikelyFloat() const
 {
     return

--- a/lib/Runtime/Language/ValueType.h
+++ b/lib/Runtime/Language/ValueType.h
@@ -126,6 +126,7 @@ public:
 
     bool HasBeenFloat() const;
     bool IsFloat() const;
+    bool IsNotFloat() const;
     bool IsLikelyFloat() const;
 
     bool HasBeenNumber() const;


### PR DESCRIPTION
When folding branches based on value numbers, we need to be careful with NaN as NaN !== NaN. To do this, I was checking `!valueType->IsFloat()` but that's not correct as result of a math operation could be an int or a float to the globopt, but at runtime be NaN. 

Introducing a new API, `IsNotFloat` on `ValueType` which will return true if the value being checked cannot be float. (IsNotFloat is not the same as !IsFloat)