### PR TITLE
Tell PREfast about iterator bounds.

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -239,6 +239,7 @@ void WasmBinaryReader::PrintOps()
     int i = 0;
     while (iter.IsValid())
     {
+        __analysis_assume(i < count);
         ops[i] = iter.CurrentKey();
         iter.MoveNext();
         ++i;


### PR DESCRIPTION
We know that the iterator will iterate over Count() elements, so we
can tell PREfast to assume that.
