### PR TITLE
MSFT:14963804:Use correct sizes for BufferBuilder failfasts

### DIFF
--- a/lib/Common/DataStructures/BufferBuilder.h
+++ b/lib/Common/DataStructures/BufferBuilder.h
@@ -134,7 +134,7 @@ namespace Js
             {
                 if (UseOneByte())
                 {
-                    if (bufferSize - this->offset<sizeof(serialization_alignment byte))
+                    if (bufferSize - this->offset < sizeof(serialization_alignment byte))
                     {
                         Throw::FatalInternalError();
                     }
@@ -143,7 +143,7 @@ namespace Js
                 }
                 else if (UseTwoBytes())
                 {
-                    if (bufferSize - this->offset<sizeof(serialization_alignment uint16))
+                    if (bufferSize - this->offset < sizeof(serialization_alignment uint16) + sizeof(serialization_alignment byte))
                     {
                         Throw::FatalInternalError();
                     }
@@ -153,7 +153,7 @@ namespace Js
                 }
                 else
                 {
-                    if (bufferSize - this->offset<sizeof(serialization_alignment T))
+                    if (bufferSize - this->offset < sizeof(serialization_alignment T) + sizeof(serialization_alignment byte))
                     {
                         Throw::FatalInternalError();
                     }


### PR DESCRIPTION
We weren't hitting this case before (since there's only one place
that uses BufferBuilder, and it allocates space correctly), but a
future use should avoid unsafe usage of this code now.
