### PR TITLE
Fixes an issue with x86 stack walking in the presence of doubly aligned frames

### DIFF
--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -737,7 +737,7 @@ namespace Js
         }
 
         // If we're at the entry from a host frame, hop to the frame from which we left the script.
-        if (this->currentFrame.GetAddressOfInstructionPointer() == this->entryExitRecord->addrOfReturnAddrOfScriptEntryFunction)
+        if (AlignAndCheckAddressOfReturnAddressMatch(this->currentFrame.GetAddressOfInstructionPointer(), this->entryExitRecord->addrOfReturnAddrOfScriptEntryFunction))
         {
             BOOL hasCaller = this->entryExitRecord->hasCaller || this->forceFullWalk;
 
@@ -874,7 +874,7 @@ namespace Js
         return false;
     }
 
-    bool AlignAndCheckAddressOfReturnAddressMatch(void* addressOfReturnAddress, void* nativeLibraryEntryAddress)
+    bool JavascriptStackWalker::AlignAndCheckAddressOfReturnAddressMatch(void* addressOfReturnAddress, void* nativeLibraryEntryAddress)
     {
         return addressOfReturnAddress == nativeLibraryEntryAddress
 #if defined(_M_IX86)
@@ -883,7 +883,7 @@ namespace Js
             // return address offset by 4, 8, or 12.
             || (((uint)nativeLibraryEntryAddress - (uint)addressOfReturnAddress < 0x10) &&
                 *(void**)addressOfReturnAddress == *(void**)nativeLibraryEntryAddress
-               )
+                )
 #endif
             ;
     }

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -231,6 +231,7 @@ namespace Js
         bool GetSourcePosition(const WCHAR** sourceFileName, ULONG* line, LONG* column);
 
         static bool TryIsTopJavaScriptFrameNative(ScriptContext* scriptContext, bool* istopFrameNative, bool ignoreLibraryCode = false);
+        static bool AlignAndCheckAddressOfReturnAddressMatch(void* addressOfReturnAddress, void* nativeLibraryEntryAddress);
 
 #if ENABLE_NATIVE_CODEGEN
         void ClearCachedInternalFrameInfo();


### PR DESCRIPTION
This was in particular hitting the JSRT interface which had a doubly
aligned frame and caused crashes on stack walks.