### PR TITLE
RL: Apply the timeout to all tests

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -3499,15 +3499,13 @@ GetTestInfoFromNode
                   return FALSE;
                }
 
-               if (TestTimeout != NULL)
-               {
-                   // Overriding the timeout value with the command line value
-                   testInfo->data[i] = TestTimeout;
-               }
             }
-
-            
          }
+      }
+      if (i == TIK_TIMEOUT && TestTimeout != NULL)
+      {
+          // Overriding the timeout value with the command line value
+          testInfo->data[i] = TestTimeout;
       }
    }
 


### PR DESCRIPTION
In the PR https://github.com/Microsoft/ChakraCore/pull/4384 the timeout value was geting applied to only those test cases which has timeout entries in the xml. But from the Nightly runs it looks like tests without a timoeut entry can also timeout. So making this change to apply the timeout to all tests.
