### PR TITLE
Remove now extraneous assert

### DIFF
--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -1328,7 +1328,6 @@ namespace UnifiedRegex
                 uniqueEquivs[i] = cs[0];
             }
             CharCount uniqueEquivCount = FindUniqueEquivs(cs, uniqueEquivs);
-            AssertOrFailFastMsg(uniqueEquivCount >= 2, "Equivalence classes should have at least two entries!");
             switch (uniqueEquivCount)
             {
             case 1:


### PR DESCRIPTION
The case that this assert was initially intended to guard against is
now properly handled.
