### PR TITLE
Sweep non-ASCII from ChakraCore sources: Remove BOM from test/$262/rlexe.xml

### DIFF
--- a/test/$262/rlexe.xml
+++ b/test/$262/rlexe.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <regress-exe>
   <test>
     <default>


### PR DESCRIPTION
Discovered by running `git grep -P "[\x80-\xff]" *.cpp *.h *.xml *.inl`