### PR TITLE
WASM.SIMD: extra frontend checks

### DIFF
--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -5,13 +5,7 @@
 
 #include "Backend.h"
 
-static IR::Instr* removeInstr(IR::Instr* instr)
-{
-    IR::Instr* prevInstr;
-    prevInstr = instr->m_prev;
-    instr->Remove();
-    return prevInstr;
-}
+static IR::Instr* removeInstr(IR::Instr* instr);
 
 #ifdef ENABLE_SIMDJS
 // FromVar
@@ -447,6 +441,14 @@ IR::Instr* LowererMD::Simd128LowerSelect(IR::Instr *instr)
 #endif
 
 #if defined(ENABLE_SIMDJS) || defined(ENABLE_WASM_SIMD)
+
+static IR::Instr* removeInstr(IR::Instr* instr)
+{
+    IR::Instr* prevInstr;
+    prevInstr = instr->m_prev;
+    instr->Remove();
+    return prevInstr;
+}
 
 #define GET_SIMDOPCODE(irOpcode) m_simd128OpCodesMap[(uint32)(irOpcode - Js::OpCode::Simd128_Start)]
 

--- a/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
+++ b/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
@@ -282,6 +282,8 @@ EXDEF2_WMS( D1toD1Mem, PrintF64, WAsmJs::Tracing::PrintF64 )
 #endif
   //unary ops
 
+#if defined(ENABLE_SIMD_JS) || defined(ENABLE_WASM_SIMD)
+
 EXDEF2_WMS( SIMD_F4_1toF4_1  , Simd128_Ld_F4        , (AsmJsSIMDValue)                                   )
   DEF2_WMS( SIMD_I4_1toI4_1  , Simd128_Ld_I4        , (AsmJsSIMDValue)                                   )
 EXDEF2_WMS( SIMD_B4_1toB4_1  , Simd128_Ld_B4        , (AsmJsSIMDValue)                                   )
@@ -752,5 +754,6 @@ EXDEF3_WMS(CUSTOM_ASMJS, Simd128_LdArr_D2, OP_SimdLdArrGeneric, AsmSimdTypedArr)
 EXDEF3_WMS(CUSTOM_ASMJS, Simd128_LdArrConst_D2, OP_SimdLdArrConstIndex, AsmSimdTypedArr)
 EXDEF3_WMS(CUSTOM_ASMJS, Simd128_StArrConst_D2, OP_SimdStArrConstIndex, AsmSimdTypedArr)
 #endif // 0
+#endif
 
 #endif

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2081,7 +2081,7 @@ namespace Js
 #if defined(ENABLE_WASM_SIMD) || defined(ENABLE_SIMDJS)
 
 #ifdef ENABLE_WASM_SIMD
-            if (CONFIG_FLAG(WasmSimd))
+            if (Wasm::Simd::IsEnabled())
 #elif ENABLE_SIMDJS
             if (function->GetScriptContext()->GetConfig()->IsSimdjsEnabled())
 #endif
@@ -3126,7 +3126,7 @@ namespace Js
 #endif
 
 #ifdef ENABLE_WASM_SIMD
-                if (CONFIG_FLAG(WasmSimd) && i == 2) // last argument ?
+                if (Wasm::Simd::IsEnabled() && i == 2) // last argument ?
 #endif
 
 #if defined(ENABLE_SIMDJS) || defined(ENABLE_WASM_SIMD)
@@ -3198,7 +3198,7 @@ namespace Js
 #endif
 
 #ifdef ENABLE_WASM_SIMD
-            else if (CONFIG_FLAG(WasmSimd) && info->GetArgType(i).isSIMD())
+            else if (Wasm::Simd::IsEnabled() && info->GetArgType(i).isSIMD())
 #endif
 
 #if defined(ENABLE_SIMDJS) || defined(ENABLE_WASM_SIMD)

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -37,7 +37,7 @@ WebAssemblyModule::WebAssemblyModule(Js::ScriptContext* scriptContext, const byt
     m_customSections(nullptr)
 {
     m_alloc = HeapNew(ArenaAllocator, _u("WebAssemblyModule"), scriptContext->GetThreadContext()->GetPageAllocator(), Js::Throw::OutOfMemory);
-    //the first elm is the number of Vars in front of I32; makes for a nicer offset computation
+    // the first elem is the number of Vars in front of I32; makes for a nicer offset computation
     memset(m_globalCounts, 0, sizeof(uint) * Wasm::WasmTypes::Limit);
     m_functionsInfo = RecyclerNew(scriptContext->GetRecycler(), WasmFunctionInfosList, scriptContext->GetRecycler());
     m_imports = Anew(m_alloc, WasmImportsList, m_alloc);
@@ -881,7 +881,7 @@ uint
 WebAssemblyModule::GetOffsetForGlobal(Wasm::WasmGlobal* global) const
 {
     Wasm::WasmTypes::WasmType type = global->GetType();
-    if (type >= Wasm::WasmTypes::Limit)
+    if (!Wasm::WasmTypes::IsLocalType(type))
     {
         throw Wasm::WasmCompilationException(_u("Invalid Global type"));
     }
@@ -934,6 +934,10 @@ WebAssemblyModule::GetGlobalsByteSize() const
     uint32 size = 0;
     for (Wasm::WasmTypes::WasmType type = (Wasm::WasmTypes::WasmType)(Wasm::WasmTypes::Void + 1); type < Wasm::WasmTypes::Limit; type = (Wasm::WasmTypes::WasmType)(type + 1))
     {
+        if (!Wasm::WasmTypes::IsLocalType(type))
+        {
+            continue;
+        }
         size = AddGlobalByteSizeToOffset(type, size);
     }
     return size;

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -20,8 +20,16 @@ void EnsureSimdIsEnabled()
 {
     if (!Wasm::Simd::IsEnabled())
     {
-        throw WasmCompilationException(_u("Wasm.Simd is not supported"));
+        throw WasmCompilationException(_u("Wasm.Simd support is not enabled"));
     }
+}
+bool IsEnabled()
+{
+#ifdef ENABLE_WASM_SIMD
+    return CONFIG_FLAG(WasmSimd);
+#else
+    return false;
+#endif
 }
 }
 

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -12,6 +12,14 @@ namespace Wasm
         const size_t VEC_WIDTH = 4;
         typedef uint32 simdvec [VEC_WIDTH]; //TODO: maybe we should pull in SIMDValue?
         const size_t MAX_LANES = 16;
+        void EnsureSimdIsEnabled();
+        constexpr bool IsEnabled() {
+#ifdef ENABLE_WASM_SIMD
+            return CONFIG_FLAG(WasmSimd);
+#else
+            return false;
+#endif
+        }
     }
 
     namespace WasmTypes
@@ -24,7 +32,9 @@ namespace Wasm
             I64 = 2,
             F32 = 3,
             F64 = 4,
+#ifdef ENABLE_WASM_SIMD
             M128 = 5,
+#endif
             Limit,
             Ptr,
             Any

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -13,13 +13,7 @@ namespace Wasm
         typedef uint32 simdvec [VEC_WIDTH]; //TODO: maybe we should pull in SIMDValue?
         const size_t MAX_LANES = 16;
         void EnsureSimdIsEnabled();
-        constexpr bool IsEnabled() {
-#ifdef ENABLE_WASM_SIMD
-            return CONFIG_FLAG(WasmSimd);
-#else
-            return false;
-#endif
-        }
+        bool IsEnabled();
     }
 
     namespace WasmTypes

--- a/lib/WasmReader/WasmSignature.cpp
+++ b/lib/WasmReader/WasmSignature.cpp
@@ -115,10 +115,13 @@ Js::ArgSlot WasmSignature::GetParamSize(Js::ArgSlot index) const
         CompileAssert(sizeof(double) == sizeof(int64));
         return sizeof(int64);
         break;
+#ifdef ENABLE_WASM_SIMD
     case WasmTypes::M128:
+        Wasm::Simd::EnsureSimdIsEnabled();
         CompileAssert(sizeof(Simd::simdvec) == 16);
         return sizeof(Simd::simdvec);
         break;
+#endif
     default:
         throw WasmCompilationException(_u("Invalid param type"));
     }


### PR DESCRIPTION
Fix build of when wasm is enabled, but wasm.simd is disabled. 
Make sure we don't inadvertently allow Simd type to flow in the engine if it is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4426)
<!-- Reviewable:end -->
