### PR TITLE
Add ProcessContexts for OOP JIT

### DIFF
--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -8,27 +8,26 @@
 #if ENABLE_OOP_NATIVE_CODEGEN
 #include "JITServer/JITServer.h"
 
-ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data, HANDLE processHandle) :
-    m_autoProcessHandle(processHandle),
-    m_processHandle(processHandle),
+ServerThreadContext::ServerThreadContext(ThreadContextDataIDL* data, ProcessContext* processContext) :
     m_threadContextData(*data),
     m_refCount(0),
     m_numericPropertyBV(nullptr),
-    m_preReservedSectionAllocator(processHandle),
-    m_sectionAllocator(processHandle),
-    m_thunkPageAllocators(nullptr, /* allocXData */ false, &m_sectionAllocator, nullptr, processHandle),
-    m_codePageAllocators(nullptr, ALLOC_XDATA, &m_sectionAllocator, &m_preReservedSectionAllocator, processHandle),
+    m_preReservedSectionAllocator(processContext->processHandle),
+    m_sectionAllocator(processContext->processHandle),
+    m_thunkPageAllocators(nullptr, /* allocXData */ false, &m_sectionAllocator, nullptr, processContext->processHandle),
+    m_codePageAllocators(nullptr, ALLOC_XDATA, &m_sectionAllocator, &m_preReservedSectionAllocator, processContext->processHandle),
 #if defined(_CONTROL_FLOW_GUARD) && !defined(_M_ARM)
-    m_jitThunkEmitter(this, &m_sectionAllocator, processHandle),
+    m_jitThunkEmitter(this, &m_sectionAllocator, processContext->processHandle),
 #endif
-    m_codeGenAlloc(nullptr, nullptr, this, &m_codePageAllocators, processHandle),
+    m_codeGenAlloc(nullptr, nullptr, this, &m_codePageAllocators, processContext->processHandle),
     m_pageAlloc(nullptr, Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
         AutoSystemInfo::Data.IsLowMemoryProcess() ?
         PageAllocator::DefaultLowMaxFreePageCount :
         PageAllocator::DefaultMaxFreePageCount
-    )
+    ),
+    processContext(processContext)
 {
-    m_pid = GetProcessId(processHandle);
+    m_pid = GetProcessId(processContext->processHandle);
 
 #if !TARGET_64 && _CONTROL_FLOW_GUARD
     m_codeGenAlloc.canCreatePreReservedSegment = data->allowPrereserveAlloc != FALSE;
@@ -38,6 +37,7 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data, HANDLE pro
 
 ServerThreadContext::~ServerThreadContext()
 {
+    processContext->Release();
     if (this->m_numericPropertyBV != nullptr)
     {
         HeapDelete(m_numericPropertyBV);
@@ -112,7 +112,7 @@ ServerThreadContext::IsThreadBound() const
 HANDLE
 ServerThreadContext::GetProcessHandle() const
 {
-    return m_autoProcessHandle.GetHandle();
+    return this->processContext->processHandle;
 }
 
 CustomHeap::OOPCodePageAllocators *
@@ -150,13 +150,13 @@ ServerThreadContext::GetJITThunkEmitter()
 intptr_t
 ServerThreadContext::GetRuntimeChakraBaseAddress() const
 {
-    return static_cast<intptr_t>(m_threadContextData.chakraBaseAddress);
+    return this->processContext->chakraBaseAddress;
 }
 
 intptr_t
 ServerThreadContext::GetRuntimeCRTBaseAddress() const
 {
-    return static_cast<intptr_t>(m_threadContextData.crtBaseAddress);
+    return this->processContext->crtBaseAddress;
 }
 
 /* static */
@@ -215,4 +215,31 @@ void ServerThreadContext::Close()
     ServerContextManager::RecordCloseContext(this);
 #endif
 }
+
+ProcessContext::ProcessContext(HANDLE processHandle, intptr_t chakraBaseAddress, intptr_t crtBaseAddress) :
+    processHandle(processHandle),
+    chakraBaseAddress(chakraBaseAddress),
+    crtBaseAddress(crtBaseAddress),
+    refCount(0)
+{
+}
+ProcessContext::~ProcessContext()
+{
+    CloseHandle(processHandle);
+}
+
+void ProcessContext::AddRef()
+{
+    InterlockedExchangeAdd(&this->refCount, 1);
+}
+void ProcessContext::Release()
+{
+    InterlockedExchangeSubtract(&this->refCount, 1);
+}
+
+bool ProcessContext::HasRef()
+{
+    return this->refCount != 0;
+}
+
 #endif

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -5,13 +5,31 @@
 
 #pragma once
 
+#if ENABLE_OOP_NATIVE_CODEGEN
+class ProcessContext
+{
+private:
+    uint refCount;
+
+public:
+    HANDLE processHandle;
+    intptr_t chakraBaseAddress;
+    intptr_t crtBaseAddress;
+
+    ProcessContext(HANDLE processHandle, intptr_t chakraBaseAddress, intptr_t crtBaseAddress);
+    ~ProcessContext();
+    void AddRef();
+    void Release();
+    bool HasRef();
+
+};
+
 class ServerThreadContext : public ThreadContextInfo
 {
-#if ENABLE_OOP_NATIVE_CODEGEN
 public:
     typedef BVSparseNode<JitArenaAllocator> BVSparseNode;
 
-    ServerThreadContext(ThreadContextDataIDL * data, HANDLE processHandle);
+    ServerThreadContext(ThreadContextDataIDL * data, ProcessContext* processContext);
     ~ServerThreadContext();
 
     virtual HANDLE GetProcessHandle() const override;
@@ -58,7 +76,7 @@ public:
     static intptr_t GetJITCRTBaseAddress();
 
 private:
-    AutoCloseHandle m_autoProcessHandle;
+    ProcessContext* processContext;
 
     BVSparse<HeapAllocator> * m_numericPropertyBV;
 
@@ -72,12 +90,11 @@ private:
 #endif
     // only allocate with this from foreground calls (never from CodeGen calls)
     PageAllocator m_pageAlloc;
-    HANDLE m_processHandle;
     ThreadContextDataIDL m_threadContextData;
 
     DWORD m_pid; //save client process id for easier diagnose
 
     CriticalSection m_cs;
     uint m_refCount;
-#endif
 };
+#endif

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -33,9 +33,6 @@ public:
 
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,
-#ifdef USE_RPC_HANDLE_MARSHALLING
-        __in HANDLE processHandle,
-#endif
         __out PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
         __out intptr_t * prereservedRegionAddr,
         __out intptr_t * jitThunkAddr);
@@ -122,6 +119,8 @@ private:
         __in UUID* connectionUuid,
         __out RPC_BINDING_HANDLE* bindingHandle);
 
+    HRESULT ConnectProcess();
+
     RPC_BINDING_HANDLE m_rpcBindingHandle;
     UUID m_jitConnectionId;
     bool m_oopJitEnabled;
@@ -148,9 +147,6 @@ public:
 
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,
-#ifdef USE_RPC_HANDLE_MARSHALLING
-        __in HANDLE processHandle,
-#endif
         __out PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
         __out intptr_t *prereservedRegionAddr,
         __out intptr_t * jitThunkAddr)

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -25,15 +25,22 @@ interface IChakraJIT
 {
     HRESULT Shutdown([in] handle_t binding);
 
-    HRESULT InitializeThreadContext(
+    HRESULT ConnectProcess(
         [in] handle_t binding,
-        [in] ThreadContextDataIDL * threadData,
 #ifdef USE_RPC_HANDLE_MARSHALLING
         [in, system_handle(sh_process, PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_LIMITED_INFORMATION)] HANDLE processHandle,
 #endif
+        [in] CHAKRA_PTR chakraBaseAddress,
+        [in] CHAKRA_PTR crtBaseAddress
+    );
+
+    HRESULT InitializeThreadContext(
+        [in] handle_t binding,
+        [in] ThreadContextDataIDL * threadData,
         [out] PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
         [out] CHAKRA_PTR * prereservedRegionAddr,
         [out] CHAKRA_PTR * jitThunkAddr);
+
 
     HRESULT CleanupThreadContext(
         [in] handle_t binding,

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -314,8 +314,6 @@ typedef struct ThreadContextDataIDL
 
     IDL_PAD2(0)
     X64_PAD4(1)
-    CHAKRA_PTR chakraBaseAddress;
-    CHAKRA_PTR crtBaseAddress;
     CHAKRA_PTR threadStackLimitAddr;
     CHAKRA_PTR scriptStackLimit;
     CHAKRA_PTR bailOutRegisterSaveSpaceAddr;

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -3,10 +3,23 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+class ProcessContextManager
+{
+private:
+
+    static BaseDictionary<DWORD, ProcessContext*, HeapAllocator> ProcessContexts;
+    static CriticalSection cs;
+
+public:
+    static HRESULT RegisterNewProcess(DWORD pid, HANDLE processHandle, intptr_t chakraBaseAddress, intptr_t crtBaseAddress);
+    static ProcessContext* GetProcessContext(DWORD pid);
+};
+
 class ServerContextManager
 {
 public:
     static void RegisterThreadContext(ServerThreadContext* threadContext);
+
     static void UnRegisterThreadContext(ServerThreadContext* threadContext);
 
     static void RegisterScriptContext(ServerScriptContext* scriptContext);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1986,18 +1986,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
         return true;
     }
 
-#ifdef USE_RPC_HANDLE_MARSHALLING
-    HANDLE processHandle;
-    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentProcess(), GetCurrentProcess(), &processHandle, 0, false, DUPLICATE_SAME_ACCESS))
-    {
-        return false;
-    }
-    AutoCloseHandle autoClose(processHandle);
-#endif
-
     ThreadContextDataIDL contextData;
-    contextData.chakraBaseAddress = (intptr_t)AutoSystemInfo::Data.GetChakraBaseAddr();
-    contextData.crtBaseAddress = (intptr_t)AutoSystemInfo::Data.GetCRTHandle();
     contextData.threadStackLimitAddr = reinterpret_cast<intptr_t>(GetAddressOfStackLimitForCurrentThread());
     contextData.bailOutRegisterSaveSpaceAddr = (intptr_t)bailOutRegisterSaveSpace;
     contextData.disableImplicitFlagsAddr = (intptr_t)GetAddressOfDisableImplicitFlags();
@@ -2022,9 +2011,6 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 
     HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(
         &contextData,
-#ifdef USE_RPC_HANDLE_MARSHALLING
-        processHandle,
-#endif
         &m_remoteThreadContextInfo,
         &m_prereservedRegionAddr,
         &m_jitThunkStartAddr);


### PR DESCRIPTION
Adds early handshake to pass in runtime process addresses, with the assurance that this handshake is only done once per runtime process.

OS:14980597