### PR TITLE
WASM: Do not use StatementReader in IRBuilder

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -16,7 +16,7 @@ IRBuilderAsmJs::Build()
     m_tempAlloc = &localAlloc;
 
     uint32 offset;
-    uint32 statementIndex = m_statementReader.GetStatementIndex();
+    uint32 statementIndex = m_statementReader ? m_statementReader->GetStatementIndex() : Js::Constants::NoStatementIndex;
 
     m_argStack = JitAnew(m_tempAlloc, SListCounted<IR::Instr *>, m_tempAlloc);
     m_tempList = JitAnew(m_tempAlloc, SList<IR::Instr *>, m_tempAlloc);
@@ -124,7 +124,7 @@ IRBuilderAsmJs::Build()
         BuildImplicitArgIns();
     }
 
-    if (m_statementReader.AtStatementBoundary(&m_jnReader))
+    if (m_statementReader && m_statementReader->AtStatementBoundary(&m_jnReader))
     {
         statementIndex = AddStatementBoundary(statementIndex, offset);
     }
@@ -164,14 +164,14 @@ IRBuilderAsmJs::Build()
         }
         offset = m_jnReader.GetCurrentOffset();
 
-        if (m_statementReader.AtStatementBoundary(&m_jnReader))
+        if (m_statementReader && m_statementReader->AtStatementBoundary(&m_jnReader))
         {
             statementIndex = AddStatementBoundary(statementIndex, offset);
         }
 
     }
 
-    if (Js::Constants::NoStatementIndex != statementIndex)
+    if (m_statementReader && Js::Constants::NoStatementIndex != statementIndex)
     {
         statementIndex = AddStatementBoundary(statementIndex, Js::Constants::NoByteCodeOffset);
     }
@@ -422,14 +422,11 @@ IRBuilderAsmJs::BuildFieldSym(Js::RegSlot reg, Js::PropertyId propertyId, Proper
 uint
 IRBuilderAsmJs::AddStatementBoundary(uint statementIndex, uint offset)
 {
-    if (m_func->GetJITFunctionBody()->IsWasmFunction())
-    {
-        return 0;
-    }
+    AssertOrFailFast(m_statementReader);
     IR::PragmaInstr* pragmaInstr = IR::PragmaInstr::New(Js::OpCode::StatementBoundary, statementIndex, m_func);
     this->AddInstr(pragmaInstr, offset);
 
-    return m_statementReader.MoveNextStatementBoundary();
+    return m_statementReader->MoveNextStatementBoundary();
 }
 
 uint32 IRBuilderAsmJs::GetTypedRegFromRegSlot(Js::RegSlot reg, WAsmJs::Types type)

--- a/lib/Backend/IRBuilderAsmJs.h
+++ b/lib/Backend/IRBuilderAsmJs.h
@@ -81,7 +81,11 @@ public:
         , m_switchAdapter(this)
         , m_switchBuilder(&m_switchAdapter)
     {
-        func->m_workItem->InitializeReader(&m_jnReader, &m_statementReader, func->m_alloc);
+        if (!m_func->GetJITFunctionBody()->IsWasmFunction())
+        {
+            m_statementReader = Anew(func->m_alloc, Js::StatementReader<Js::FunctionBody::ArenaStatementMapList>);
+        }
+        func->m_workItem->InitializeReader(&m_jnReader, m_statementReader, func->m_alloc);
         m_asmFuncInfo = m_func->GetJITFunctionBody()->GetAsmJsInfo();
 #if 0
         // templatized JIT loop body
@@ -217,7 +221,7 @@ private:
     IR::Instr *             m_lastInstr;
     IR::Instr **            m_offsetToInstruction;
     Js::ByteCodeReader      m_jnReader;
-    Js::StatementReader<Js::FunctionBody::ArenaStatementMapList> m_statementReader;
+    Js::StatementReader<Js::FunctionBody::ArenaStatementMapList>* m_statementReader = nullptr;
     SListCounted<IR::Instr *> *m_argStack;
     SList<IR::Instr *> *    m_tempList;
     SList<int32> *          m_argOffsetStack;

--- a/lib/Backend/JITTimeWorkItem.cpp
+++ b/lib/Backend/JITTimeWorkItem.cpp
@@ -114,7 +114,10 @@ JITTimeWorkItem::InitializeReader(
 #endif
     bool hasSpanSequenceMap = m_jitBody.InitializeStatementMap(&m_statementMap, alloc);
     Js::SmallSpanSequence * spanSeq = hasSpanSequenceMap ? &m_statementMap : nullptr;
-    statementReader->Create(m_jitBody.GetByteCodeBuffer(), startOffset, spanSeq, m_fullStatementList);
+    if (statementReader)
+    {
+        statementReader->Create(m_jitBody.GetByteCodeBuffer(), startOffset, spanSeq, m_fullStatementList);
+    }
 }
 
 JITTimeFunctionBody *

--- a/lib/Runtime/ByteCode/StatementReader.h
+++ b/lib/Runtime/ByteCode/StatementReader.h
@@ -10,14 +10,14 @@ namespace Js
     class StatementReader
     {
     private:
-        const byte* m_startLocation;
-        SmallSpanSequence* m_statementMap;
+        const byte* m_startLocation = nullptr;
+        SmallSpanSequence* m_statementMap = nullptr;
         SmallSpanSequenceIter m_statementMapIter;
 
-        TStatementMapList * m_fullstatementMap;
-        const byte* m_nextStatementBoundary;
-        int m_statementIndex;
-        bool m_startOfStatement;
+        TStatementMapList * m_fullstatementMap = nullptr;
+        const byte* m_nextStatementBoundary = nullptr;
+        int m_statementIndex = 0;
+        bool m_startOfStatement = true;
 
     public:
         void Create(FunctionBody* functionRead, uint startOffset = 0);


### PR DESCRIPTION
Fix usage of Statement Reader in IRBuilderAsmJs to make sure we don't use uninitialized values. 
Don't even allocate a statement reader for wasm since there are no statements to use. 
OS#15089337

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4429)
<!-- Reviewable:end -->
