### PR TITLE
Ensure WithScopeObject is unwrapped for scoped __proto__ stores

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2947,6 +2947,11 @@ CommonNumber:
                 {
                     if (setterValueOrProxy)
                     {
+                        if (WithScopeObject::Is(object))
+                        {
+                            object = (RecyclableObject::FromVar(object))->GetThisObjectOrUnWrap();
+                        }
+
                         JavascriptFunction* func = (JavascriptFunction*)setterValueOrProxy;
                         Assert(info.GetFlags() == InlineCacheSetterFlag || info.GetPropertyIndex() == Constants::NoSlot);
                         CacheOperators::CachePropertyWrite(object, false, type, propertyId, &info, scriptContext);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -674,6 +674,18 @@ namespace Js
         static BOOL PropertyReferenceWalk_Impl(Var instance, RecyclableObject** propertyObject, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext);
         static Var TypeofFld_Internal(Var instance, const bool isRoot, PropertyId propertyId, ScriptContext* scriptContext);
 
+        static bool SetAccessorOrNonWritableProperty(
+            Var receiver,
+            RecyclableObject* object,
+            PropertyId propertyId,
+            Var newValue,
+            PropertyValueInfo * info,
+            ScriptContext* requestContext,
+            PropertyOperationFlags propertyOperationFlags,
+            bool isRoot,
+            bool allowUndecInConsoleScope,
+            BOOL *result);
+
         template <bool unscopables>
         static BOOL SetProperty_Internal(Var instance, RecyclableObject* object, const bool isRoot, PropertyId propertyId, Var newValue, PropertyValueInfo * info, ScriptContext* requestContext, PropertyOperationFlags flags);
 

--- a/lib/Runtime/Library/RuntimeLibraryPch.h
+++ b/lib/Runtime/Library/RuntimeLibraryPch.h
@@ -52,6 +52,7 @@
 #include "Library/JavascriptWeakMap.h"
 #include "Library/JavascriptWeakSet.h"
 
+#include "Types/WithScopeObject.h"
 #include "Types/PropertyIndexRanges.h"
 #include "Types/DictionaryPropertyDescriptor.h"
 #include "Types/DictionaryTypeHandler.h"

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -2,7 +2,17 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+//
+// The WithScopeObject is a psuedo-object that provides us with convenience. By wrapping a normal object in this class,
+// we can intercept object operations requiring checks to @@unscopables. For all other operations, the object needs to be
+// unwrapped. The caller is responsible for unwrapping, which must happen only once the @@unscopables check has happened.
+// For example, a getter needs to have the propId checked against @@unscopables, but for the actual getter call the
+// object passed needs to be unwrapped.
+//
 #pragma once
+
+#define UNWRAP_FAILFAST() AssertOrFailFastMsg(false, "This WithScopeObject must be unwrapped by the caller handling the scope before performing this operation.")
+
 namespace Js
 {
     class WithScopeObject : public RecyclableObject
@@ -10,7 +20,6 @@ namespace Js
         private:
             Field(RecyclableObject *) wrappedObject;
 
-            void AssertAndFailFast() { AssertMsg(false, "This function should not be invoked"); Js::Throw::InternalError(); }
         protected:
             DEFINE_VTABLE_CTOR(WithScopeObject, RecyclableObject);
 
@@ -29,43 +38,43 @@ namespace Js
             virtual DescriptorFlags GetSetter(PropertyId propertyId, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
 
             // A WithScopeObject should never call the Functions defined below this comment
-            virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
-            virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
-            virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
-            virtual int GetPropertyCount() override { AssertAndFailFast(); return 0; };
-            virtual PropertyId GetPropertyId(PropertyIndex index) override { AssertAndFailFast();  return Constants::NoProperty; };
-            virtual PropertyId GetPropertyId(BigPropertyIndex index) override { AssertAndFailFast(); return Constants::NoProperty;; };
-            virtual BOOL SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { AssertAndFailFast(); return FALSE; };
+            virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { UNWRAP_FAILFAST(); return PropertyQueryFlags::Property_NotFound; };
+            virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override { UNWRAP_FAILFAST(); return None; };
+            virtual int GetPropertyCount() override { UNWRAP_FAILFAST(); return 0; };
+            virtual PropertyId GetPropertyId(PropertyIndex index) override { UNWRAP_FAILFAST();  return Constants::NoProperty; };
+            virtual PropertyId GetPropertyId(BigPropertyIndex index) override { UNWRAP_FAILFAST(); return Constants::NoProperty;; };
+            virtual BOOL SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { UNWRAP_FAILFAST(); return FALSE; };
 #if ENABLE_FIXED_FIELDS
-            virtual BOOL IsFixedProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
+            virtual BOOL IsFixedProperty(PropertyId propertyId) override { UNWRAP_FAILFAST(); return FALSE; };
 #endif
-            virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
-            virtual BOOL HasOwnItem(uint32 index) override { AssertAndFailFast(); return FALSE; };
-            virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
-            virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
-            virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
-            virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsWritable(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsConfigurable(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsEnumerable(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetEnumerable(PropertyId propertyId, BOOL value) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetWritable(PropertyId propertyId, BOOL value) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetConfigurable(PropertyId propertyId, BOOL value) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL SetAttributes(PropertyId propertyId, PropertyAttributes attributes) override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsExtensible() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL PreventExtensions() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL Seal() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL Freeze() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsSealed() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL IsFrozen() override { AssertAndFailFast(); return FALSE; };
-            virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override { AssertAndFailFast(); return FALSE; };
-            virtual Var GetTypeOfString(ScriptContext * requestContext) override { AssertAndFailFast(); return RecyclableObject::GetTypeOfString(requestContext); };
+            virtual PropertyQueryFlags HasItemQuery(uint32 index) override { UNWRAP_FAILFAST(); return PropertyQueryFlags::Property_NotFound; };
+            virtual BOOL HasOwnItem(uint32 index) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return PropertyQueryFlags::Property_NotFound; };
+            virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return PropertyQueryFlags::Property_NotFound; };
+            virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { UNWRAP_FAILFAST(); return None; };
+            virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsWritable(PropertyId propertyId) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsConfigurable(PropertyId propertyId) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsEnumerable(PropertyId propertyId) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetEnumerable(PropertyId propertyId, BOOL value) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetWritable(PropertyId propertyId, BOOL value) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetConfigurable(PropertyId propertyId, BOOL value) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL SetAttributes(PropertyId propertyId, PropertyAttributes attributes) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsExtensible() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL PreventExtensions() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL Seal() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL Freeze() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsSealed() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL IsFrozen() override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual Var GetTypeOfString(ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return RecyclableObject::GetTypeOfString(requestContext); };
     };
 } // namespace Js

--- a/test/es6/unscopablesWithScopeTest.js
+++ b/test/es6/unscopablesWithScopeTest.js
@@ -626,6 +626,30 @@ var tests = [
             assert.isTrue(p.configurable, "Object.getOwnPropertyDescriptor(Array.prototype, Symbol.unscopables).configurable === true");
         }
     },
+    {
+        name: "__proto__ on a WithScopeObject",
+        body: function () {
+            var originalProto = Object.__proto__;
+            var o = {};
+
+            with (Object) {
+                assert.areEqual(Object.__proto__, __proto__, "With scoped load of Object.__proto__ matches explicit Object.__proto__");
+                __proto__ = o;
+                assert.areEqual(o, __proto__,        "Object.__proto__ change in scoped 'with' matches new __proto object");
+            }
+            Object.__proto__ = originalProto;
+
+            with (Object) {
+                assert.areEqual(Object.__proto__, __proto__,         "With scoped load of Object.__proto__ matches explicit Object.__proto__");
+                assert.areEqual(Object.__proto__, eval('__proto__'), "Eval with scoped load of Object.__proto__ matches explicit Object.__proto__");
+                eval('__proto__ = o');
+                assert.areEqual(o, __proto__,         "With scoped load of Object.__proto__ has changed after eval Object.__proto__ override");
+                assert.areEqual(o, eval('__proto__'), "Eval with scoped load of Object.__proto__ has changed after eval Object.__proto__ override");
+            }
+
+            Object.__proto__ = originalProto;
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fixes OS: 14291082

Setting __proto__ inside an eval inside a with takes us down a weird path. Usually we would have unwrapped the WithScopeObject automatically by using SetProperty or similar, but __proto__ is special cased (along with some other things like HostDispatch) and will directly fetch the setter function and call it, bypassing the WithScopeObject:: methods (although still keeping the @@unscopables check.)

Fix is to unwrap the object after the @@unscopables object check has finished when getting the __proto__ setter. I tried several other paths but they end up going through the WithScopeObject shims.
