### PR TITLE
Initialize propId before calling enumerator

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1175,7 +1175,7 @@ namespace Js
         }
 
         JavascriptString * propertyName = nullptr;
-        PropertyId propertyId;
+        PropertyId propertyId = Js::Constants::NoProperty;
         uint32 propertyIndex = 0;
         uint32 symbolIndex = 0;
         const PropertyRecord* propertyRecord;


### PR DESCRIPTION
Fixes OS: 15099548

Some enumerators don't initialize the propId in JavascriptObject::CreateKeysHelper. For consistency, initialize to NoProperty.
