### PR TITLE
OS#15116019 - fix uninitialized read in Date parsing code

### DIFF
--- a/lib/Common/PlatformAgnostic/DateTimeInternal.h
+++ b/lib/Common/PlatformAgnostic/DateTimeInternal.h
@@ -42,10 +42,16 @@ namespace DateTime
         void Update(const double time);
     };
 
-    struct DaylightTimeHelperPlatformData // DaylightHelper.cpp
+    class DaylightTimeHelperPlatformData // DaylightHelper.cpp
     {
+    public:
         TimeZoneInfo cache1, cache2;
         bool useFirstCache;
+
+        DaylightTimeHelperPlatformData() :
+            useFirstCache(true)
+        {
+        }
     };
 
     class UtilityPlatformData
@@ -71,9 +77,16 @@ namespace DateTime
         bool fInit;
         bool fHiResAvailable;
 
-        HiresTimerPlatformData(): fInit(false), dBaseTime(0),
-        baseMsCount(0),  fHiResAvailable(true),
-        dLastTime(0), dAdjustFactor(1), fReset(true) {}
+        HiresTimerPlatformData() :
+            fInit(false),
+            dBaseTime(0),
+            baseMsCount(0),
+            fHiResAvailable(true),
+            dLastTime(0),
+            dAdjustFactor(1),
+            fReset(true)
+        {
+        }
 
         void Reset() { fReset = true; }
     };

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/DateTime.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/DateTime.cpp
@@ -75,17 +75,25 @@ namespace DateTime
     // class TimeZoneInfo ******
 
     // Cache should be invalid at the moment of creation
-    // if january1 > nextJanuary1 cache is always invalid, so we don't care about other fields, because cache will be updated.
-    TimeZoneInfo::TimeZoneInfo()
+    // if january1 > nextJanuary1, the cache will be considered invalid
+    TimeZoneInfo::TimeZoneInfo() :
+        daylightDate(0.0),
+        standardDate(0.0),
+        january1(1.0),
+        nextJanuary1(0.0),
+        daylightBias(0),
+        standardBias(0),
+        bias(0),
+        lastUpdateTickCount(0),
+        isDaylightTimeApplicable(false),
+        isJanuary1Critical(false)
     {
-        january1 = 1;
-        nextJanuary1 = 0;
     }
 
     // Cache is valid for given time if this time is within a year for which cache was created, and cache was updated within 1 second of current moment
     bool TimeZoneInfo::IsValid(const double time)
     {
-        return GetTickCount() - lastUpdateTickCount < updatePeriod && time >= january1 && time < nextJanuary1;
+        return time >= january1 && time < nextJanuary1 && GetTickCount() - lastUpdateTickCount < updatePeriod;
     }
 
     void TimeZoneInfo::Update(const double inputTime)


### PR DESCRIPTION
Just enough was initialized before that this never caused an issue, but all fields should be initialized to be safe.