### PR TITLE
Initialize propId on all MoveAndGetNext paths

### DIFF
--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
@@ -58,6 +58,7 @@ namespace Js
     // enumeration order: 9.4.6.10 (sorted) exports first, followed by symbols
     JavascriptString * ModuleNamespaceEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Js::Constants::NoProperty;
         if (attributes != nullptr)
         {
             // all the attribute should have the same setting here in namespace object.

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
@@ -18,13 +18,13 @@ namespace Js
 
     JavascriptString * ArgumentsObjectPrefixEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         if (!doneFormalArgs)
         {
             formalArgIndex = argumentsObject->GetNextFormalArgIndex(formalArgIndex, !!(flags & EnumeratorFlags::EnumNonEnumerable), attributes);
             if (formalArgIndex != JavascriptArray::InvalidIndex
                 && formalArgIndex < argumentsObject->GetNumberOfArguments())
             {
-                propertyId = Constants::NoProperty;
                 return this->GetScriptContext()->GetIntegerString(formalArgIndex);
             }
 

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -270,6 +270,7 @@ namespace Js
 
     JavascriptString * DynamicObjectPropertyEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes * attributes)
     {
+        propertyId = Js::Constants::NoProperty;
         if (this->cachedData && this->initialType == this->object->GetDynamicType())
         {
             return MoveAndGetNextWithCache(propertyId, attributes);

--- a/lib/Runtime/Types/JavascriptEnumerator.h
+++ b/lib/Runtime/Types/JavascriptEnumerator.h
@@ -28,7 +28,8 @@ namespace Js {
         //
         // Moves to the next element and gets the current value.
         // PropertyId: Sets the propertyId of the current value.
-        // In some cases, i.e. arrays, propertyId is not returned successfully.
+        //     In some cases, i.e. arrays, propertyId is not returned successfully.
+        //     Must be initialized to at least NoProperty on all paths.
         // Returns: NULL if there are no more elements.
         //
         // Note: in the future we  might want to enumerate specialPropertyIds


### PR DESCRIPTION
Fixes OS: 15099548

Enumerators do not have to return a valid property on all MoveAndGetNext paths, but they should always initialize it. Fix those missed paths.
