### PR TITLE
PropertyString: don't cache property string at first use (Get)

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -3773,8 +3773,18 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Js::LiteralStringWithPropertyStringPtr>::HasVirtualTable(temp))
                 {
-                    LiteralStringWithPropertyStringPtr * propStr = (LiteralStringWithPropertyStringPtr *)temp;
-                    propertyString = propStr->GetOrAddPropertyString();
+                    LiteralStringWithPropertyStringPtr * strWithPtr = (LiteralStringWithPropertyStringPtr *)temp;
+                    if (!strWithPtr->HasPropertyRecord())
+                    {
+                        strWithPtr->GetPropertyRecord(); // lookup-cache propertyRecord
+                    }
+                    else
+                    {
+                        propertyString = strWithPtr->GetOrAddPropertyString();
+                        // this is the second time this property string is used
+                        // we already had created the propertyRecord..
+                        // now create the propertyString!
+                    }
                 }
 
                 if (propertyString != nullptr)

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -14,6 +14,7 @@ namespace Js
 
     public:
         virtual Js::PropertyRecord const * GetPropertyRecord(bool dontLookupFromDictionary = false) override;
+        bool HasPropertyRecord() const { return propertyRecord != nullptr; }
 
         PropertyString * GetPropertyString() const;
         PropertyString * GetOrAddPropertyString(); // Get if it's there, otherwise bring it in.


### PR DESCRIPTION
Fixes OS#14614887

The case below is ~20% faster.
```
var g_expandoNames = new Array();
var document = {};

var count = 100000;
for (i = 0; i < count; i++)
{
    g_expandoNames.push("expando" + i);
}

function RunTest()
{
    var i = 0;
    var temp = 0;
    var expandoNames = g_expandoNames;

    for (i = 0; i < count; i++)
    {
        // so we don't have to look it up twice
        temp = expandoNames[i];

        document[temp] = i;
        temp = document[temp];
    }
}

RunTest()
console.log('Done!')
```
