### PR TITLE
Clear inlinee callinfo from the catch of OP_TryFinally as well

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -174,6 +174,15 @@ namespace Js
 
         if (exception)
         {
+#if ENABLE_NATIVE_CODEGEN
+            if (scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr)
+            {
+                if (exception->GetExceptionContext() && exception->GetExceptionContext()->ThrowingFunction())
+                {
+                    WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, scriptContext->GetThreadContext()->GetTryCatchFrameAddr());
+                }
+            }
+#endif
             bool hasBailedOut = *(bool*)((char*)frame + hasBailedOutOffset); // stack offsets are negative
             if (hasBailedOut)
             {
@@ -182,6 +191,7 @@ namespace Js
                 // Re-throw!
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }
+
             scriptContext->GetThreadContext()->SetPendingFinallyException(exception);
             void *continuation = amd64_CallWithFakeFrame(finallyAddr, frame, spillSize, argsSize, exception);
             return continuation;
@@ -328,6 +338,15 @@ namespace Js
 
         if (exception)
         {
+#if ENABLE_NATIVE_CODEGEN
+            if (scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr)
+            {
+                if (exception->GetExceptionContext() && exception->GetExceptionContext()->ThrowingFunction())
+                {
+                    WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, scriptContext->GetThreadContext()->GetTryCatchFrameAddr());
+                }
+            }
+#endif
             // Clone static exception object early in case finally block overwrites it
             exception = exception->CloneIfStaticExceptionObject(scriptContext);
             bool hasBailedOut = *(bool*)((char*)localsPtr + hasBailedOutOffset); // stack offsets are sp relative
@@ -640,6 +659,15 @@ namespace Js
 
         if (pExceptionObject)
         {
+#if ENABLE_NATIVE_CODEGEN
+            if (scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr)
+            {
+                if (pExceptionObject->GetExceptionContext() && pExceptionObject->GetExceptionContext()->ThrowingFunction())
+                {
+                    WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, scriptContext->GetThreadContext()->GetTryCatchFrameAddr());
+                }
+            }
+#endif
             // Clone static exception object early in case finally block overwrites it
             pExceptionObject = pExceptionObject->CloneIfStaticExceptionObject(scriptContext);
             bool hasBailedOut = *(bool*)((char*)framePtr + hasBailedOutOffset); // stack offsets are negative

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -170,4 +170,10 @@
       <files>helperlabelbug2.js</files>
   </default>
   </test>
+  <test>
+    <default>
+      <files>tryfinallyinlineswbug.js</files>
+      <compile-flags> -force:inline </compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/EH/tryfinallyinlineswbug.js
+++ b/test/EH/tryfinallyinlineswbug.js
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test2() {
+  with ({})
+    try {
+      for (let nlvjnq in new Array(-3 / 0, -3 / 0, rzkvjs = {}, -3 / 0, rzkvjs = {}, -3 / 0, -3 / 0, rzkvjs = {}, rzkvjs = {}, -3 / 0, -3 / 0, rzkvjs = {}, rzkvjs = {}, rzkvjs = {}, -3 / 0, rzkvjs = {}, rzkvjs = {}, -3 / 0, rzkvjs = {}))
+        try {
+          try {
+            (function () {
+              return fxwkkq = this.zzz.zzz;
+            }());
+          } finally {
+          }
+        } catch (e) {
+        }
+    } catch (e) {
+    }
+}
+test2();
+test2();
+test2();
+
+WScript.Echo("Passed");

--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -32,6 +32,8 @@
     <default>
       <files>stack.js</files>
       <compile-flags>-JsBuiltIn- -off:inline </compile-flags>
+      <tags>Slow</tags>
+      <timeout>600</timeout>
     </default>
   </test>
   <test>


### PR DESCRIPTION

When we hit an exception and we have a try finally within a try catch. We will execute finally code by calling BailOnException.
Since we inline into functions with try now, we will end up in inconsistent inlinee callinfo when we call the bailout code from finally.
So add the walker and clear inlinee callinfo.

Also move tryCatchAddr ctor inside a scope, so that it executes before user catch code.

Fixes OS#14336922