### PR TITLE
SwitchOpt determined by AggressiveIntTypeSpec breaks repeated String cases

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2917,7 +2917,7 @@ GlobOpt::TypeSpecializeBailoutExpectedInteger(IR::Instr* instr, Value* src1Val, 
     {
         if (!src1Val || !src1Val->GetValueInfo()->IsLikelyInt() || instr->GetSrc1()->AsRegOpnd()->m_sym->m_isNotInt)
         {
-            Assert(IsSwitchOptEnabled());
+            Assert(IsSwitchOptEnabledForIntTypeSpec());
             throw Js::RejitException(RejitReason::DisableSwitchOptExpectingInteger);
         }
 
@@ -11365,7 +11365,7 @@ GlobOpt::ToTypeSpecUse(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Valu
                         // restarted with aggressive int type specialization disabled.
                         if(bailOutKind == IR::BailOutExpectingInteger)
                         {
-                            Assert(IsSwitchOptEnabled());
+                            Assert(IsSwitchOptEnabledForIntTypeSpec());
                             throw Js::RejitException(RejitReason::DisableSwitchOptExpectingInteger);
                         }
                         else
@@ -11709,7 +11709,7 @@ GlobOpt::ToTypeSpecUse(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Valu
                     // need to bail out.
                     if (bailOutKind == IR::BailOutExpectingInteger)
                     {
-                        Assert(IsSwitchOptEnabled());
+                        Assert(IsSwitchOptEnabledForIntTypeSpec());
                     }
                     else
                     {
@@ -17193,8 +17193,13 @@ bool
 GlobOpt::IsSwitchOptEnabled(Func const * func)
 {
     Assert(func->IsTopFunc());
-    return !PHASE_OFF(Js::SwitchOptPhase, func) && !func->IsSwitchOptDisabled() && !IsTypeSpecPhaseOff(func)
-        && DoAggressiveIntTypeSpec(func) && func->DoGlobOpt();
+    return !PHASE_OFF(Js::SwitchOptPhase, func) && !func->IsSwitchOptDisabled() && func->DoGlobOpt();
+}
+
+bool
+GlobOpt::IsSwitchOptEnabledForIntTypeSpec(Func const * func)
+{
+    return IsSwitchOptEnabled(func) && !IsTypeSpecPhaseOff(func) && DoAggressiveIntTypeSpec(func);
 }
 
 bool

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -764,6 +764,7 @@ public:
     static bool             DoTypedArrayTypeSpec(Func const * func);
     static bool             DoNativeArrayTypeSpec(Func const * func);
     static bool             IsSwitchOptEnabled(Func const * func);
+    static bool             IsSwitchOptEnabledForIntTypeSpec(Func const * func);
     static bool             DoInlineArgsOpt(Func const * func);
     static bool             IsPREInstrCandidateLoad(Js::OpCode opcode);
     static bool             IsPREInstrCandidateStore(Js::OpCode opcode);
@@ -790,6 +791,7 @@ private:
     bool                    DoNativeArrayTypeSpec() const { return GlobOpt::DoNativeArrayTypeSpec(this->func); }
     bool                    DoLdLenIntSpec(IR::Instr * const instr, const ValueType baseValueType);
     bool                    IsSwitchOptEnabled() const { return GlobOpt::IsSwitchOptEnabled(this->func); }
+    bool                    IsSwitchOptEnabledForIntTypeSpec() const { return GlobOpt::IsSwitchOptEnabledForIntTypeSpec(this->func); }
     bool                    DoPathDependentValues() const;
     bool                    DoTrackRelativeIntBounds() const;
     bool                    DoBoundCheckElimination() const;

--- a/lib/Backend/GlobOptBlockData.cpp
+++ b/lib/Backend/GlobOptBlockData.cpp
@@ -1790,7 +1790,7 @@ GlobOptBlockData::IsTypeSpecialized(Sym const * sym) const
 bool
 GlobOptBlockData::IsSwitchInt32TypeSpecialized(IR::Instr const * instr) const
 {
-    return GlobOpt::IsSwitchOptEnabled(instr->m_func->GetTopFunc())
+    return GlobOpt::IsSwitchOptEnabledForIntTypeSpec(instr->m_func->GetTopFunc())
         && instr->GetSrc1()->IsRegOpnd()
         && this->IsInt32TypeSpecialized(instr->GetSrc1()->AsRegOpnd()->m_sym);
 }

--- a/lib/Backend/SwitchIRBuilder.h
+++ b/lib/Backend/SwitchIRBuilder.h
@@ -60,7 +60,9 @@ public:
 #endif
 
 /**
- * Handles construction of switch statements, with appropriate optimizations
+ * Handles construction of switch statements, with appropriate optimizations. Note that some of these
+ * optimizations occur during IR building (rather than GlobOpt) because the abstraction of a switch/case
+ * block is not maintained with the resulting IR. Thus, some optimizations must occur during this phase.
  */
 class SwitchIRBuilder {
 private:


### PR DESCRIPTION
This change fixes an issue where the function GlobOpt::IsSwitchOptEnabled was updated to add conditionsfor type specialization. This resulted in bad IR being produced, which impacted how type-specialized BailOutswere constructed and which registers were restored (or, not restored).
The fix is to apply align optimizationchecks in SwitchIRBuilder based on the types of the cases.
