### PR TITLE
Uint8ClampedArray,Int32Array.set does not clamp correctly when virtual

### DIFF
--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -762,7 +762,7 @@ namespace Js
     bool JavascriptArrayBuffer::IsValidVirtualBufferLength(uint length) const
     {
 #if ENABLE_FAST_ARRAYBUFFER
-        return !PHASE_OFF1(Js::TypedArrayVirtualPhase) && IsValidAsmJsBufferLengthAlgo(length, true);
+        return PHASE_FORCE1(Js::TypedArrayVirtualPhase) || (!PHASE_OFF1(Js::TypedArrayVirtualPhase) && IsValidAsmJsBufferLengthAlgo(length, true));
 #else
         return false;
 #endif

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -1147,11 +1147,13 @@ namespace Js
         // types of the same size are compatible, with the following exceptions:
         // - we cannot memmove between float and int arrays, due to different bit pattern
         // - we cannot memmove to a uint8 clamped array from an int8 array, due to negatives rounding to 0
-        if (GetTypeId() == source->GetTypeId()
-            || (GetBytesPerElement() == source->GetBytesPerElement()
-            && !(Uint8ClampedArray::Is(this) && Int8Array::Is(source))
-            && !Float32Array::Is(this) && !Float32Array::Is(source)
-            && !Float64Array::Is(this) && !Float64Array::Is(source)))
+        if (GetTypeId() == source->GetTypeId() ||
+            (GetBytesPerElement() == source->GetBytesPerElement()
+             && !((Uint8ClampedArray::Is(this) || Uint8ClampedVirtualArray::Is(this)) && (Int8Array::Is(source) || Int8VirtualArray::Is(source)))
+             && !Float32Array::Is(this) && !Float32Array::Is(source) 
+             && !Float32VirtualArray::Is(this) && !Float32VirtualArray::Is(source)
+             && !Float64Array::Is(this) && !Float64Array::Is(source)
+             && !Float64VirtualArray::Is(this) && !Float64VirtualArray::Is(source)))
         {
             const size_t offsetInBytes = offset * BYTES_PER_ELEMENT;
             memmove_s(buffer + offsetInBytes,

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -114,6 +114,14 @@
   </test>
   <test>
     <default>
+      <files>objectproperty.js</files>
+      <baseline>objectproperty_es6.baseline</baseline>
+      <compile-flags>-force:typedarrayvirtual</compile-flags>
+      <tags>typedarray</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>nan.js</files>
       <baseline>nan.baseline</baseline>
       <tags>typedarray,exclude_nonrazzle</tags>
@@ -142,6 +150,14 @@
     <default>
       <files>set.js</files>
       <baseline>set.baseline</baseline>
+      <tags>typedarray</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>set.js</files>
+      <baseline>set.baseline</baseline>
+      <compile-flags>-force:typedarrayvirtual</compile-flags>
       <tags>typedarray</tags>
     </default>
   </test>
@@ -287,6 +303,14 @@ Below test fails with difference in space. Investigate the cause and re-enable t
     <default>
       <files>setDifferentTypes.js</files>
       <baseline>setDifferentTypes.baseline</baseline>
+      <tags>typedarray</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>setDifferentTypes.js</files>
+      <baseline>setDifferentTypes.baseline</baseline>
+      <compile-flags>-force:typedarrayvirtual</compile-flags>
       <tags>typedarray</tags>
     </default>
   </test>


### PR DESCRIPTION
Some TypedArrays can become virtual when they meet a set of requirements (defined in JavascriptArrayBuffer::IsValidAsmJsBufferLengthAlgo). These TypedArrays become a separate type with a separate VTable at runtime. Because of this difference, virtual array checks are missing in TypedArrayBase::Set for the fast path of setting the buffer, resulting in numerical type mismatch when copying. This change fixes the check to also account for virtual TypedArrays.
An additional force check is added to make the host always allocate TypedArrays as virtual. A few tests are updated with this flag to prevent future regressions.
