### PR TITLE
OS#14980681: OS#14980691: Disable a number of OACR warnings whose signal-to-noise ratio is far too low

### DIFF
--- a/lib/Common/Warnings.h
+++ b/lib/Common/Warnings.h
@@ -38,6 +38,14 @@
 #pragma warning(disable:28112)      // A variable (processNativeCodeSize) which is accessed via an Interlocked function must always be accessed via an Interlocked function. See line 1024:  It is not always safe to access a variable which is accessed via the Interlocked* family of functions in any other way.
 #pragma warning(disable:28159)      // Consider using 'GetTickCount64' instead of 'GetTickCount'. Reason: GetTickCount overflows roughly every 49 days.  Code that does not take that into account can loop indefinitely.  GetTickCount64 operates on 64 bit values and does not have that problem
 
+#pragma warning(disable:6236)       // Logical-OR with non-zero constant, e.g., <expr> || 1.  We end up with a lot of these in release builds because certain macros (notably CONFIG_FLAG) expand to compile-time constants in release builds and not in debug builds.
+#pragma warning(disable:25037)      // True constant expr in AND, e.g., <expr> && 1.
+#pragma warning(disable:25038)      // False constant expr in AND, e.g., <expr> && 0.
+#pragma warning(disable:25039)      // True Constant Expr in OR.  Seems to be a duplicate of 6236.
+#pragma warning(disable:25040)      // False Constant Expr in OR, e.g., <expr> || 0.
+#pragma warning(disable:25041)      // 'if' condition is always true
+#pragma warning(disable:25042)      // 'if' condition is always false
+
 #ifndef NTBUILD
 // Would be nice to clean these up.
 #pragma warning(disable:6054)       // String 'dumpName' might not be zero-terminated.


### PR DESCRIPTION
These warnings typically involve conditional expressions and Boolean operators -- things like  _expr_ && 1, _expr_ || 1, 'if' condition known to be true, etc.  These can indicate problems, but we do these things intentionally more often than not -- or, at least, sufficiently often that we get a lot of irritating noise from OACR.  (For example, we frequently have _expr_ || MACRO(...), which can cause an OACR error (yes, error) if MACRO is defined to be a compile-time constant in release builds.)

I'm publishing this widely because I got a lot of pushback to #4455 and #4456, and because I know a lot of people have preferences in this matter.  I'd prefer to have this discussion and get feedback before I commit anything.

**Note:** I'm proposing this PR as an alternative to #4455 and #4456.  I'll either commit this PR, commit both of the others, or discard all 3 and do something else entirely.

One possible alternative: @sigatrev tells me that we can avoid the original OACR errors (see indicated OS bugs for details) but preserve the same compiler optimizations by defining `DEFAULT_CONFIG_OOPJITMissingOpts` to be `falseConstantFunction()`, where `falseConstantFunction` is a `constexpr` function that returns `false`.  It looks like this should be a very easy change to ConfigFlagsList.h, and I'm going to try this out, but of course this doesn't address the more general situation.