### PR TITLE
xplat: pthread_exit call needed to free TLS

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -8,6 +8,8 @@
 #include <winver.h>
 #include <process.h>
 #include <fcntl.h>
+#else
+#include <pthread.h>
 #endif
 
 #ifdef __linux__
@@ -1154,6 +1156,12 @@ return_cleanup:
     }
     delete[] argv;
     argv = nullptr;
-#endif
+#ifdef NO_SANITIZE_ADDRESS_CHECK
+    pthread_exit(&retval);
+#else
     return retval;
+#endif
+#else
+    return retval;
+#endif
 }

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -686,7 +686,7 @@
 #if __has_feature(address_sanitizer)
 #undef NO_SANITIZE_ADDRESS
 #define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
-#define NO_SANITIZE_ADDRESS_FIXVC
+#define NO_SANITIZE_ADDRESS_CHECK
 #endif
 #endif
 

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -226,8 +226,9 @@ Container BVFixed::GetRange(BVIndex start, BVIndex len) const
     return Container(range);
 }
 
+// the NO_SANITIZE_ADDRESS_CHECK ifdef is to work around a bug in some VC versions
 template<typename Container>
-#ifdef NO_SANITIZE_ADDRESS_FIXVC
+#ifdef NO_SANITIZE_ADDRESS_CHECK
 NO_SANITIZE_ADDRESS
 #endif
 void BVFixed::SetRange(Container* value, BVIndex start, BVIndex len)


### PR DESCRIPTION
Thread-local storage for pthreads don't get destructor calls unless
pthread_exit is called from their thread; this happens implicitly in
non-main threads, but needs to be explicitly done in main.
