### PR TITLE
Disable Output::Print buffering on xplat

### DIFF
--- a/lib/Common/Core/Output.cpp
+++ b/lib/Common/Core/Output.cpp
@@ -355,8 +355,9 @@ Output::PrintBuffer(const char16 * buf, size_t size)
                     buf, (size + 1) * sizeof(char16));
                 bufferFreeSize -= size;
             }
-#endif
+#else
             DirectPrint(buf);
+#endif
         }
         else
         {

--- a/lib/Common/Core/Output.cpp
+++ b/lib/Common/Core/Output.cpp
@@ -36,9 +36,11 @@ unsigned int Output::s_traceEntryId = 0;
 #endif
 
 THREAD_ST FILE*    Output::s_file = nullptr;
+#ifdef _WIN32
 THREAD_ST char16* Output::buffer = nullptr;
 THREAD_ST size_t   Output::bufferAllocSize = 0;
 THREAD_ST size_t   Output::bufferFreeSize = 0;
+#endif
 THREAD_ST size_t   Output::s_Column  = 0;
 THREAD_ST WORD     Output::s_color = 0;
 THREAD_ST bool     Output::s_hasColor = false;
@@ -305,6 +307,7 @@ Output::PrintBuffer(const char16 * buf, size_t size)
     {
         if (s_file == nullptr || Output::s_capture)
         {
+#ifdef _WIN32
             bool addToBuffer = true;
             if (Output::bufferFreeSize < size + 1)
             {
@@ -352,6 +355,8 @@ Output::PrintBuffer(const char16 * buf, size_t size)
                     buf, (size + 1) * sizeof(char16));
                 bufferFreeSize -= size;
             }
+#endif
+            DirectPrint(buf);
         }
         else
         {
@@ -375,11 +380,13 @@ void Output::Flush()
     {
         return;
     }
+#ifdef _WIN32
     if (bufferFreeSize != bufferAllocSize)
     {
         DirectPrint(Output::buffer);
         bufferFreeSize = bufferAllocSize;
     }
+#endif
     if(s_outputFile != nullptr)
     {
         fflush(s_outputFile);
@@ -540,9 +547,14 @@ Output::CaptureEnd()
 {
     Assert(s_capture);
     s_capture = false;
+#ifdef _WIN32
     bufferFreeSize = 0;
     bufferAllocSize = 0;
     char16 * returnBuffer = buffer;
     buffer = nullptr;
+#else
+    char16 * returnBuffer = nullptr;
+#endif
+
     return returnBuffer;
 }

--- a/lib/Common/Core/Output.h
+++ b/lib/Common/Core/Output.h
@@ -136,9 +136,11 @@ private:
 
     THREAD_ST static bool s_capture;
     THREAD_ST static FILE * s_file;
+#ifdef _WIN32
     THREAD_ST static char16 * buffer;
     THREAD_ST static size_t bufferFreeSize;
     THREAD_ST static size_t bufferAllocSize;
+#endif
     THREAD_ST static size_t s_Column;
     THREAD_ST static WORD s_color;
     THREAD_ST static bool s_hasColor;


### PR DESCRIPTION
Output::buffer leaks, which ASAN can notice. Straightforward solutions
to getting per-thread buffers that properly clean up hit some compiler
issues. Following up and re-enabling the code is covered under #3651 
(although we're not getting much out of the buffering as-is).
