### PR TITLE
Improve Serialize WorkItemData

### DIFF
--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -695,7 +695,7 @@ JITManager::DeserializeRPCData(
             status = MesDecodeBufferHandleCreate((char*)buffer, bufferSize, &marshalHandle);
             if (status != RPC_S_OK)
             {
-                return status;
+                return HRESULT_FROM_WIN32(status);
             }
 
             pCodeGenWorkItemIDL_Decode(
@@ -712,7 +712,7 @@ JITManager::DeserializeRPCData(
     {
         MesHandleFree(marshalHandle);
     }
-    return status;
+    return HRESULT_FROM_WIN32(status);
 }
 
 HRESULT
@@ -734,7 +734,7 @@ JITManager::SerializeRPCData(_In_ CodeGenWorkItemIDL *workItemData, _Out_ size_t
                 &marshalHandle);
             if (status != RPC_S_OK)
             {
-                return status;
+                return HRESULT_FROM_WIN32(status);
             }
 
             MIDL_ES_CODE encodeType = MES_ENCODE;
@@ -751,7 +751,7 @@ JITManager::SerializeRPCData(_In_ CodeGenWorkItemIDL *workItemData, _Out_ size_t
             );
             if (status != RPC_S_OK)
             {
-                return status;
+                return HRESULT_FROM_WIN32(status);
             }
 #endif
 
@@ -776,7 +776,7 @@ JITManager::SerializeRPCData(_In_ CodeGenWorkItemIDL *workItemData, _Out_ size_t
             );
             if (status != RPC_S_OK)
             {
-                return status;
+                return HRESULT_FROM_WIN32(status);
             }
 
             pCodeGenWorkItemIDL_Encode(
@@ -796,6 +796,6 @@ JITManager::SerializeRPCData(_In_ CodeGenWorkItemIDL *workItemData, _Out_ size_t
         MesHandleFree(marshalHandle);
     }
 
-    return status;
+    return HRESULT_FROM_WIN32(status);
 }
 #endif

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -3470,7 +3470,7 @@ LABEL1:
         HRESULT hr = JitFromEncodedWorkItem(scriptContext->GetNativeCodeGenerator(), buffer, size);
         if (FAILED(hr))
         {
-            return JavascriptNumber::New(hr, scriptContext);
+            JavascriptExceptionOperators::OP_Throw(JavascriptNumber::New(hr, scriptContext), scriptContext);
         }
         return scriptContext->GetLibrary()->GetUndefined();
     }


### PR DESCRIPTION
Serialize the encoded workitem in inproc runs as well. 
Fix HRESULT of encode/decode of the work item 
in Function.invokeJit, throw if an error occurred instead of silently returning a number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4465)
<!-- Reviewable:end -->
