### PR TITLE
Check for reentrant argument evaluation in copyWithin. Fixes OS:15157669

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9110,7 +9110,7 @@ Case0:
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, _u("[TypedArray].prototype.copyWithin"));
             }
 
-            Assert(length == typedArrayBase->GetLength());
+            AssertOrFailFast(length == typedArrayBase->GetLength());
 
             uint32 bytesPerElement = typedArrayBase->GetBytesPerElement();
             byte *buffer = typedArrayBase->GetByteBuffer();
@@ -9118,8 +9118,9 @@ Case0:
             size_t toByteIndex = static_cast<size_t>(toVal) * bytesPerElement;
             size_t byteCount = static_cast<size_t>(count) * bytesPerElement;
 
-            Assert(fromByteIndex + byteCount <= typedArrayBase->GetByteLength());
-            Assert(toByteIndex + byteCount <= typedArrayBase->GetByteLength());
+            Assert(typedArrayBase->GetByteLength() >= byteCount);
+            Assert(fromByteIndex <= typedArrayBase->GetByteLength() - byteCount);
+            Assert(toByteIndex <= typedArrayBase->GetByteLength() - byteCount);
 
             memmove(&buffer[toByteIndex], &buffer[fromByteIndex], byteCount);
 

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9103,6 +9103,13 @@ Case0:
         if (isTypedArrayEntryPoint)
         {
             Assert(typedArrayBase);
+
+            // Re-validate the typed array, which could have become detached due to reentrant script.
+            if (typedArrayBase->IsDetachedBuffer())
+            {
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, _u("[TypedArray].prototype.copyWithin"));
+            }
+
             Assert(length == typedArrayBase->GetLength());
 
             uint32 bytesPerElement = typedArrayBase->GetBytesPerElement();

--- a/test/es6/ES6TypedArrayExtensions.js
+++ b/test/es6/ES6TypedArrayExtensions.js
@@ -905,6 +905,18 @@ var tests = [
             assert.throws(function() { copyWithinFn.call('string'); }, TypeError, "Calling %TypedArrayPrototype%.copyWithin with non-object this throws TypeError", "'this' is not a typed array object");
             assert.throws(function() { copyWithinFn.call(getRegularArray()); }, TypeError, "Calling %TypedArrayPrototype%.copyWithin with non-TypedArray object this throws TypeError", "'this' is not a typed array object");
             assert.throws(function() { copyWithinFn.call(getObjectArray()); }, TypeError, "Calling %TypedArrayPrototype%.copyWithin with non-TypedArray object this throws TypeError", "'this' is not a typed array object");
+
+            {
+                let buffer = new ArrayBuffer(0x1000);
+                let u32 = new Uint32Array(buffer);
+                let t = {
+                    valueOf: function() {
+                        ArrayBuffer.detach(buffer);
+                        return 3;
+                    }
+                };
+                assert.throws(function() { u32.copyWithin(3,0,t); }, TypeError, "Detaching the typed array buffer during reentrant code causes copyWithin to throw", "[TypedArray].prototype.copyWithin: The ArrayBuffer is detached.");
+            }
         }
     },
     {
@@ -1073,7 +1085,7 @@ var tests = [
                 counter++;
                 return elem;
             };
-            
+
             // Validating how many times the map function is called.
             [[-1, 0], [2, 2], [100, 8], [2**31, 8]].forEach(function ([len, expectedCounter]) {
                 var v = new Int8Array(8);
@@ -1092,7 +1104,7 @@ var tests = [
                 counter++;
                 return elem;
             };
-            
+
             // Validating how many times the find function is called.
             [[-1, 0], [2, 2], [100, 100]].forEach(function ([len, expectedCounter]) {
                 var v = new Int8Array(8);


### PR DESCRIPTION
My [previous change](https://github.com/Microsoft/ChakraCore/pull/4345) introduced an issue where valueOf could be used to detach the array buffer and memmove arbitrary memory, just like in [another bug from last year](https://www.zerodayinitiative.com/blog/2017/12/22/a-matching-pair-of-use-after-free-bugs-in-chakra-asmjs). This change protects against such misuse.