### PR TITLE
Fix early SyntaxError when deleting special-named identifiers

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1663,6 +1663,14 @@ ParseNodePtr Parser::ParseBlock(ParseNodePtr pnodeLabel, LabelId* pLabelId)
     return pnodeBlock;
 }
 
+bool Parser::IsSpecialName(IdentPtr pid)
+{
+    return pid == wellKnownPropertyPids._this ||
+        pid == wellKnownPropertyPids._super ||
+        pid == wellKnownPropertyPids._superConstructor ||
+        pid == wellKnownPropertyPids._newTarget;
+}
+
 ParseNodePtr Parser::ReferenceSpecialName(IdentPtr pid, charcount_t ichMin, charcount_t ichLim, bool createNode)
 {
     PidRefStack* ref = this->PushPidRef(pid);
@@ -8837,8 +8845,8 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
             {
                 if (IsStrictMode())
                 {
-                    if ((buildAST && pnode->sxUni.pnode1->nop == knopName) ||
-                        (!buildAST && operandToken.tk == tkID))
+                    if ((buildAST && pnode->sxUni.pnode1->nop == knopName && !pnode->sxUni.pnode1->IsSpecialName()) ||
+                        (!buildAST && operandToken.tk == tkID && !this->IsSpecialName(operandToken.pid)))
                     {
                         Error(ERRInvalidDelete);
                     }

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -8845,7 +8845,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
             {
                 if (IsStrictMode())
                 {
-                    if ((buildAST && pnode->sxUni.pnode1->nop == knopName && !pnode->sxUni.pnode1->IsSpecialName()) ||
+                    if ((buildAST && pnode->sxUni.pnode1->IsUserIdentifier()) ||
                         (!buildAST && operandToken.tk == tkID && !this->IsSpecialName(operandToken.pid)))
                     {
                         Error(ERRInvalidDelete);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -767,6 +767,7 @@ private:
     void FinishParseBlock(ParseNode *pnodeBlock, bool needScanRCurly = true);
     void FinishParseFncExprScope(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncExprScope);
 
+    bool IsSpecialName(IdentPtr pid);
     void CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGlobal);
     ParseNodePtr ReferenceSpecialName(IdentPtr pid, charcount_t ichMin = 0, charcount_t ichLim = 0, bool createNode = false);
     ParseNodePtr CreateSpecialVarDeclIfNeeded(ParseNodePtr pnodeFnc, IdentPtr pid, bool forceCreate = false);

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -767,6 +767,11 @@ struct ParseNode
     bool IsSpecialName() { return isSpecialName; }
     void SetIsSpecialName() { isSpecialName = true; }
 
+    bool IsUserIdentifier() const
+    {
+        return this->nop == knopName && !this->isSpecialName;
+    }
+
     bool IsVarLetOrConst() const
     {
         return this->nop == knopVarDecl || this->nop == knopLetDecl || this->nop == knopConstDecl;

--- a/test/es6/bug_OS14880030.js
+++ b/test/es6/bug_OS14880030.js
@@ -6,54 +6,93 @@
 "use strict";
 var r = delete this;
 
-function test1() {
-    "use strict";
-    return delete this;
-}
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
-function test2() {
-    "use strict";
-    return delete new.target;
-}
-
-function test3() {
-    "use strict";
-    try {
-        eval('delete arguments;');
-    } catch(e) {
-        return true;
+var tests = [
+  {
+    name: "Delete this in strict global code",
+    body: function () {
+         assert.isTrue(r, "We should have returned true from the global delete this above");
     }
-    return false;
-}
-
-function test4() {
-    "use strict";
-    let a = 'a';
-    try {
-        eval('delete a;');
-    } catch(e) {
-        return true;
+  },
+  {
+    name: "Delete this in strict mode nested function",
+    body: function () {
+        function test() {
+            "use strict";
+            return delete this;
+        }
+        
+        assert.isTrue(test(), "Delete this in strict nested function does nothing but returns true");
     }
-    return false;
-}
-
-function test5() {
-    "use strict";
-    try {
-        eval(`
-            function test5_eval() {
-                "use strict";
-                let a = 'a';
-                delete a;
+  },
+  {
+    name: "Delete new.target in strict mode nested function",
+    body: function () {
+        function test() {
+            "use strict";
+            return delete new.target;
+        }
+        
+        assert.isTrue(test(), "Delete new.target in strict nested function does nothing but returns true");
+    }
+  },
+  {
+    name: "Delete arguments in strict mode nested function",
+    body: function () {
+        function test() {
+            "use strict";
+            try {
+                eval('delete arguments;');
+            } catch(e) {
+                return true;
             }
-            test5_eval();
-        `);
-    } catch(e) {
-        return true;
+            return false;
+        }
+        
+        assert.isTrue(test(), "Delete arguments in strict nested function should throw early SyntaxError");
     }
-    return false;
-}
+  },
+  {
+    name: "Delete user identifier in strict mode nested function",
+    body: function () {
+        function test() {
+            "use strict";
+            let a = 'a';
+            try {
+                eval('delete a;');
+            } catch(e) {
+                return true;
+            }
+            return false;
+        }
+        
+        assert.isTrue(test(), "Delete user identifier in strict nested function should throw early SyntaxError");
+    }
+  },
+  {
+    name: "Delete user identifier in strict eval in strict mode nested function",
+    body: function () {
+        function test() {
+            "use strict";
+            try {
+                eval(`
+                    function test5_eval() {
+                        "use strict";
+                        let a = 'a';
+                        delete a;
+                    }
+                    test5_eval();
+                `);
+            } catch(e) {
+                return true;
+            }
+            return false;
+        }
+        
+        assert.isTrue(test(), "Delete user identifier in strict nested function should throw early SyntaxError");
+    }
+  },
+];
 
-r = r && test1() && test2() && test3() && test4() && test5();
-
-console.log(r ? 'PASS' : 'FAIL');
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/bug_OS14880030.js
+++ b/test/es6/bug_OS14880030.js
@@ -6,16 +6,54 @@
 "use strict";
 var r = delete this;
 
-function foo() {
+function test1() {
     "use strict";
     return delete this;
 }
-r = r && foo();
 
-function bar() {
+function test2() {
     "use strict";
     return delete new.target;
 }
-r = r && bar();
+
+function test3() {
+    "use strict";
+    try {
+        eval('delete arguments;');
+    } catch(e) {
+        return true;
+    }
+    return false;
+}
+
+function test4() {
+    "use strict";
+    let a = 'a';
+    try {
+        eval('delete a;');
+    } catch(e) {
+        return true;
+    }
+    return false;
+}
+
+function test5() {
+    "use strict";
+    try {
+        eval(`
+            function test5_eval() {
+                "use strict";
+                let a = 'a';
+                delete a;
+            }
+            test5_eval();
+        `);
+    } catch(e) {
+        return true;
+    }
+    return false;
+}
+
+r = r && test1() && test2() && test3() && test4() && test5();
 
 console.log(r ? 'PASS' : 'FAIL');

--- a/test/es6/bug_OS14880030.js
+++ b/test/es6/bug_OS14880030.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+"use strict";
+var r = delete this;
+
+function foo() {
+    "use strict";
+    return delete this;
+}
+r = r && foo();
+
+function bar() {
+    "use strict";
+    return delete new.target;
+}
+r = r && bar();
+
+console.log(r ? 'PASS' : 'FAIL');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1509,13 +1509,14 @@
     <default>
       <files>bug_OS14880030.js</files>
       <tags>BugFix</tags>
+      <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>bug_OS14880030.js</files>
       <tags>BugFix</tags>
-      <compile-flags>-force:deferparse</compile-flags>
+      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1507,6 +1507,19 @@
   </test>
   <test>
     <default>
+      <files>bug_OS14880030.js</files>
+      <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>bug_OS14880030.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-force:deferparse</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>DeferParseLambda.js</files>
       <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
When we began binding special names as ordinary identifiers, we started throwing early SyntaxError on deleting these names. Instead, we should just be ignoring these operations.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/14880030
