### PR TITLE
OS#9030969 fix stack traces for inlined functions

### DIFF
--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -456,7 +456,7 @@ namespace Js
         }
 
         if (inlineeOffset != 0 &&
-            parentFunction->GetFunctionBody()->GetMatchingStatementMapFromNativeOffset(pCodeAddr, inlineeOffset, data, loopNum, *inlinee))
+            parentFunction->GetFunctionBody()->GetMatchingStatementMapFromNativeOffset(pCodeAddr, inlineeOffset - 1, data, loopNum, *inlinee))
         {
             offset = data.bytecodeBegin;
             return true;

--- a/test/StackTrace/InlineOffset.baseline
+++ b/test/StackTrace/InlineOffset.baseline
@@ -1,0 +1,5 @@
+TypeError: Assignment to read-only properties is not allowed in strict mode
+   at baz (InlineOffset.js:16:5)
+   at bar (InlineOffset.js:22:5)
+   at foo (InlineOffset.js:29:5)
+   at Global code (InlineOffset.js:37:5)

--- a/test/StackTrace/InlineOffset.js
+++ b/test/StackTrace/InlineOffset.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+'use strict';
+
+if (this.WScript && this.WScript.LoadScriptFile) {
+    this.WScript.LoadScriptFile("../UnitTestFramework/TrimStackTracePath.js");
+}
+
+var o = {};
+
+function baz()
+{
+    o.p &= undefined;
+}
+
+function bar()
+{
+    var a = 1;
+    baz();
+}
+
+function foo()
+{
+    var a = 1;
+    var b = 1;
+    bar();
+}
+
+try
+{
+    foo()
+    foo()
+    Object.defineProperty(o, 'p', {writable: false});
+    foo();
+}
+catch(ex)
+{
+    WScript.Echo(TrimStackTracePath(ex.stack));
+}

--- a/test/StackTrace/rlexe.xml
+++ b/test/StackTrace/rlexe.xml
@@ -141,4 +141,11 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <tags>StackTrace</tags>
+      <files>InlineOffset.js</files>
+      <baseline>InlineOffset.baseline</baseline>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
It is possible for inlinee functions to have statements at the address as the call site. In such cases the stack trace would pick up the statement number of the inlinee's statement instead of the statement associated with the inliner's call to the inlinee. The statement associated with the inliner's call always occurs before the address of the call, so this PR makes the stack walker look for the first statement before the inlinee start, and ensures that that statement gets recorded.
