### PR TITLE
Fix clear of inlinee call info

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -93,20 +93,23 @@ namespace Js
     {
         void *continuation = nullptr;
         JavascriptExceptionObject *exception = nullptr;
-
+        void *tryCatchFrameAddr = nullptr;
         PROBE_STACK(scriptContext, Constants::MinStackDefault + spillSize + argsSize);
-        Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, frame);
-
-        try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
-            continuation = amd64_CallWithFakeFrame(tryAddr, frame, spillSize, argsSize);
-        }
-        catch (const Js::JavascriptException& err)
-        {
-            exception = err.GetAndClear();
-        }
+            Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, frame);
 
+            try
+            {
+                Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+                continuation = amd64_CallWithFakeFrame(tryAddr, frame, spillSize, argsSize);
+            }
+            catch (const Js::JavascriptException& err)
+            {
+                exception = err.GetAndClear();
+                tryCatchFrameAddr = scriptContext->GetThreadContext()->GetTryCatchFrameAddr();
+                Assert(frame == tryCatchFrameAddr);
+            }
+        }
         if (exception)
         {
             // We need to clear callinfo on inlinee virtual frames on an exception.
@@ -118,10 +121,9 @@ namespace Js
             // When we start inlining functions with try, we have to track the try addresses of the inlined functions as well.
 
 #if ENABLE_NATIVE_CODEGEN
-            Assert(scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr);
             if (exception->GetExceptionContext() && exception->GetExceptionContext()->ThrowingFunction())
             {
-                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */);
+                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, tryCatchFrameAddr);
             }
 #endif
 
@@ -180,7 +182,6 @@ namespace Js
                 // Re-throw!
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }
-            // MGTODO : We need to set the exception object, so that we can access in the interpreter, better way out ?
             scriptContext->GetThreadContext()->SetPendingFinallyException(exception);
             void *continuation = amd64_CallWithFakeFrame(finallyAddr, frame, spillSize, argsSize, exception);
             return continuation;
@@ -238,22 +239,27 @@ namespace Js
     {
         void *continuation = nullptr;
         JavascriptExceptionObject *exception = nullptr;
+        void * tryCatchFrameAddr = nullptr;
 
         PROBE_STACK(scriptContext, Constants::MinStackDefault + argsSize);
-        Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
+        {
+            Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
 
-        try
-        {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            try
+            {
+                Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
 #if defined(_M_ARM)
-            continuation = arm_CallEhFrame(tryAddr, framePtr, localsPtr, argsSize);
+                continuation = arm_CallEhFrame(tryAddr, framePtr, localsPtr, argsSize);
 #elif defined(_M_ARM64)
-            continuation = arm64_CallEhFrame(tryAddr, framePtr, localsPtr, argsSize);
+                continuation = arm64_CallEhFrame(tryAddr, framePtr, localsPtr, argsSize);
 #endif
-        }
-        catch (const Js::JavascriptException& err)
-        {
-            exception = err.GetAndClear();
+            }
+            catch (const Js::JavascriptException& err)
+            {
+                exception = err.GetAndClear();
+                tryCatchFrameAddr = scriptContext->GetThreadContext()->GetTryCatchFrameAddr();
+                Assert(framePtr == tryCatchFrameAddr);
+            }
         }
 
         if (exception)
@@ -267,10 +273,9 @@ namespace Js
             // When we start inlining functions with try, we have to track the try addresses of the inlined functions as well.
 
 #if ENABLE_NATIVE_CODEGEN
-            Assert(scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr);
             if (exception->GetExceptionContext() && exception->GetExceptionContext()->ThrowingFunction())
             {
-                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */);
+                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, tryCatchFrameAddr);
             }
 #endif
             exception = exception->CloneIfStaticExceptionObject(scriptContext);
@@ -404,73 +409,78 @@ namespace Js
     {
         void* continuationAddr = NULL;
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
+        void *tryCatchFrameAddr = nullptr;
 
         PROBE_STACK(scriptContext, Constants::MinStackDefault);
-        Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
-
-        try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
 
-            // Adjust the frame pointer and call into the try.
-            // If the try completes without raising an exception, it will pass back the continuation address.
-
-            // Bug in compiler optimizer: try-catch can be optimized away if the try block contains __asm calls into function
-            // that may throw. The current workaround is to add the following dummy throw to prevent this optimization.
-            if (!tryAddr)
+            try
             {
-                Js::Throw::InternalError();
-            }
+                Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+
+                // Adjust the frame pointer and call into the try.
+                // If the try completes without raising an exception, it will pass back the continuation address.
+
+                // Bug in compiler optimizer: try-catch can be optimized away if the try block contains __asm calls into function
+                // that may throw. The current workaround is to add the following dummy throw to prevent this optimization.
+                if (!tryAddr)
+                {
+                    Js::Throw::InternalError();
+                }
 #ifdef _M_IX86
-            void *savedEsp;
-            __asm
-            {
-                // Save and restore the callee-saved registers around the call.
-                // TODO: track register kills by region and generate per-region prologs and epilogs
-                push esi
-                push edi
-                push ebx
+                void *savedEsp;
+                __asm
+                {
+                    // Save and restore the callee-saved registers around the call.
+                    // TODO: track register kills by region and generate per-region prologs and epilogs
+                    push esi
+                    push edi
+                    push ebx
 
-                // 8-byte align frame to improve floating point perf of our JIT'd code.
-                // Save ESP
-                mov ecx, esp
-                mov savedEsp, ecx
-                and esp, -8
+                    // 8-byte align frame to improve floating point perf of our JIT'd code.
+                    // Save ESP
+                    mov ecx, esp
+                    mov savedEsp, ecx
+                    and esp, -8
 
-                // Set up the call target, save the current frame ptr, and adjust the frame to access
-                // locals in native code.
-                mov eax, tryAddr
+                    // Set up the call target, save the current frame ptr, and adjust the frame to access
+                    // locals in native code.
+                    mov eax, tryAddr
 #if 0 && defined(_CONTROL_FLOW_GUARD)
-                // verify that the call target is valid
-                mov  ebx, eax     ; save call target
-                mov  ecx, eax
-                call [__guard_check_icall_fptr]
-                mov  eax, ebx     ; restore call target
+                    // verify that the call target is valid
+                    mov  ebx, eax; save call target
+                    mov  ecx, eax
+                    call[__guard_check_icall_fptr]
+                    mov  eax, ebx; restore call target
 #endif
-                push ebp
-                mov ebp, framePtr
-                call eax
-                pop ebp
+                    push ebp
+                    mov ebp, framePtr
+                    call eax
+                    pop ebp
 
-                // The native code gives us the address where execution should continue on exit
-                // from the region.
-                mov continuationAddr, eax
+                    // The native code gives us the address where execution should continue on exit
+                    // from the region.
+                    mov continuationAddr, eax
 
-                // Restore ESP
-                mov ecx, savedEsp
-                mov esp, ecx
+                    // Restore ESP
+                    mov ecx, savedEsp
+                    mov esp, ecx
 
-                pop ebx
-                pop edi
-                pop esi
-            }
+                    pop ebx
+                    pop edi
+                    pop esi
+                }
 #else
-            AssertMsg(FALSE, "Unsupported native try-catch handler");
+                AssertMsg(FALSE, "Unsupported native try-catch handler");
 #endif
-        }
-        catch(const Js::JavascriptException& err)
-        {
-            pExceptionObject = err.GetAndClear();
+            }
+            catch (const Js::JavascriptException& err)
+            {
+                pExceptionObject = err.GetAndClear();
+                tryCatchFrameAddr = scriptContext->GetThreadContext()->GetTryCatchFrameAddr();
+                Assert(framePtr == tryCatchFrameAddr);
+            }
         }
 
         // Let's run user catch handler code only after the stack has been unwound.
@@ -485,10 +495,9 @@ namespace Js
             // When we start inlining functions with try, we have to track the try addresses of the inlined functions as well.
 
 #if ENABLE_NATIVE_CODEGEN
-            Assert(scriptContext->GetThreadContext()->GetTryCatchFrameAddr() != nullptr);
             if (pExceptionObject->GetExceptionContext() && pExceptionObject->GetExceptionContext()->ThrowingFunction())
             {
-                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */);
+                WalkStackForCleaningUpInlineeInfo(scriptContext, nullptr /* start stackwalk from the current frame */, tryCatchFrameAddr);
             }
 #endif
             pExceptionObject = pExceptionObject->CloneIfStaticExceptionObject(scriptContext);
@@ -938,13 +947,14 @@ namespace Js
     }
 #if ENABLE_NATIVE_CODEGEN
     // TODO: Add code address of throwing function on exception context, and use that for returnAddress instead of passing nullptr which starts stackwalk from the top
-    void JavascriptExceptionOperators::WalkStackForCleaningUpInlineeInfo(ScriptContext *scriptContext, PVOID returnAddress)
+    void JavascriptExceptionOperators::WalkStackForCleaningUpInlineeInfo(ScriptContext *scriptContext, PVOID returnAddress, PVOID tryCatchFrameAddr)
     {
+        Assert(tryCatchFrameAddr != nullptr);
         JavascriptStackWalker walker(scriptContext, /*useEERContext*/ true, returnAddress);
 
         // We have to walk the inlinee frames and clear callinfo count on them on an exception
         // At this point inlinedFrameWalker is closed, so we should build it again by calling InlinedFrameWalker::FromPhysicalFrame
-        walker.WalkAndClearInlineeFrameCallInfoOnException();
+        walker.WalkAndClearInlineeFrameCallInfoOnException(tryCatchFrameAddr);
     }
 #endif
     void

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -92,7 +92,7 @@ namespace Js
         static Var StackTraceAccessor(RecyclableObject* function, CallInfo callInfo, ...);
         static void WalkStackForExceptionContext(ScriptContext& scriptContext, JavascriptExceptionContext& exceptionContext, Var thrownObject, uint64 stackCrawlLimit, PVOID returnAddress, bool isThrownException = true, bool resetSatck = false);
 #if ENABLE_NATIVE_CODEGEN
-        static void WalkStackForCleaningUpInlineeInfo(ScriptContext *scriptContext, PVOID returnAddress);
+        static void WalkStackForCleaningUpInlineeInfo(ScriptContext *scriptContext, PVOID returnAddress, PVOID tryCatchFrameAddr);
 #endif
         static void AddStackTraceToObject(Var obj, JavascriptExceptionContext::StackTrace* stackTrace, ScriptContext& scriptContext, bool isThrownException = true, bool resetSatck = false);
         static uint64 StackCrawlLimitOnThrow(Var thrownObject, ScriptContext& scriptContext);

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -237,7 +237,7 @@ namespace Js
         void ClearCachedInternalFrameInfo();
         void SetCachedInternalFrameInfo(InternalFrameType frameType, JavascriptFunction* function, bool hasInlinedFramesOnStack, bool prevIntFrameIsFromBailout);
         InternalFrameInfo GetCachedInternalFrameInfo() const { return this->lastInternalFrameInfo; }
-        void WalkAndClearInlineeFrameCallInfoOnException();
+        void WalkAndClearInlineeFrameCallInfoOnException(void *tryCatchFrameAddr);
 #endif
         bool IsCurrentPhysicalFrameForLoopBody() const;
 


### PR DESCRIPTION
We currently walk the stack on an expection in the jit and clear inlinee call info till the enclosing trycatch. This is necessary so that we don't end up with inaccurate inlinee call info on bailout.

During clearing the inlinee call info, for all JavascriptFrames we clear inlinee call info till we match the top most try catch frame address that we store on the threadContext.

This is not sufficient. It may so happen that the OP_TryCatch c++ function is not called from a JavascriptFrame but from a jitted loop body, we will end up missing the loop break condition and clear additional inlinee call info than required.

This change expands the loop break condition  for all native frames.

Fixes OS#15202517