### PR TITLE
OS#14323330: Fix typeof incorrectly doing property load for special-named identifiers

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10284,9 +10284,13 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         }
         case knopName:
         {
-            funcInfo->AcquireLoc(pnode);
-            byteCodeGenerator->EmitPropTypeof(pnode->location, pnodeOpnd->sxPid.sym, pnodeOpnd->sxPid.pid, funcInfo);
-            break;
+            if (pnodeOpnd->IsUserIdentifier())
+            {
+                funcInfo->AcquireLoc(pnode);
+                byteCodeGenerator->EmitPropTypeof(pnode->location, pnodeOpnd->sxPid.sym, pnodeOpnd->sxPid.pid, funcInfo);
+                break;
+            }
+            // Special names should fallthrough to default case
         }
 
         default:

--- a/test/Bugs/bug14323330.js
+++ b/test/Bugs/bug14323330.js
@@ -1,0 +1,49 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var r = typeof this;
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "typeof global this is 'object'",
+    body: function () {
+        assert.areEqual('object', r, "'typeof this' is 'object' for the global this");
+    }
+  },
+  {
+    name: "typeof nested function this",
+    body: function () {
+        function foo() {
+            return typeof this;
+        }
+        assert.areEqual('object', foo(), "'typeof this' is 'object' for nested function this called with default 'this' binding");
+        assert.areEqual('function', foo.call(foo), "'typeof this' should be 'function' when 'this' binding is overriden");
+        
+        function bar() {
+            "use strict";
+            return typeof this;
+        }
+        assert.areEqual('undefined', bar(), "'typeof this' is 'undefined' for nested strict function this called with default 'this' binding");
+        assert.areEqual('function', bar.call(bar), "'typeof this' should be 'function' when 'this' binding is overriden");
+    }
+  },
+  {
+    name: "typeof nested function new.target",
+    body: function () {
+        var out = 'wrong';
+        function foo() {
+            out = typeof new.target;
+        }
+        foo();
+        assert.areEqual('undefined', out, "'typeof new.target' is 'undefined' for normal function call");
+        new foo();
+        assert.areEqual('function', out, "'typeof new.target' is 'function' for function called as constructor");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -419,4 +419,11 @@
       <compile-flags>-off:inlineConstructors</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug14323330.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When we emit a typeof node, we always try to emit a special property load if the property is a name. This won't work for special-named identifiers.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14323330
