### PR TITLE
Add a Reentrancy check in CallFunction on x86.

### DIFF
--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -131,7 +131,8 @@ inline int _count_args(const T1&, const T2&, const T3&, const T4&, Js::CallInfo 
 #define JS_REENTRANCY_LOCK(reentrancyLock, threadContext) \
     JsReentLock reentrancyLock(threadContext);
 #else
-
+#define JS_REENTRANCY_CHECK(threadContext, ...) \
+    __VA_ARGS__;
 #define CALL_ENTRYPOINT(threadContext, entryPoint, function, callInfo, ...) \
     CALL_ENTRYPOINT_NOASSERT(entryPoint, function, callInfo, ##__VA_ARGS__);
 #define JS_REENTRANT(reentrancyLock, ...) \

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1225,6 +1225,8 @@ void __cdecl _alloca_probe_16()
             PROBE_STACK_CALL(scriptContext, function, argsSize);
         }
 
+        JS_REENTRANCY_CHECK(scriptContext->GetThreadContext());
+
         void *data;
         void *savedEsp;
         __asm {


### PR DESCRIPTION
For some reason CallFunction on x86 was the only version missing a reentrancy check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4502)
<!-- Reviewable:end -->
