### PR TITLE
xplat: do pal initialization check debug only

### DIFF
--- a/pal/src/map/virtual.cpp
+++ b/pal/src/map/virtual.cpp
@@ -1612,12 +1612,11 @@ VirtualAlloc_(
          IN DWORD flAllocationType, /* Type of allocation */
          IN DWORD flProtect)        /* Type of access protection */
 {
+#ifdef DEBUG
     static bool was_pal_initialized = PAL_Initialize_Check_Once();
+    _ASSERTE(was_pal_initialized);
+#endif
 
-    if (!was_pal_initialized) // do not assert. leave it as is.
-    {
-        abort();
-    }
     LPVOID  pRetVal       = NULL;
     CPalThread *pthrCurrent;
 

--- a/pal/src/memory/heap.cpp
+++ b/pal/src/memory/heap.cpp
@@ -169,12 +169,10 @@ GetProcessHeap(
 	       VOID)
 {
     HANDLE ret;
+#ifdef DEBUG
     static bool was_pal_initialized = PAL_Initialize_Check_Once();
-
-    if (!was_pal_initialized) // do not assert. leave it as is.
-    {
-        abort();
-    }
+    _ASSERTE(was_pal_initialized);
+#endif
 
     PERF_ENTRY(GetProcessHeap);
     ENTRY("GetProcessHeap()\n");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -310,12 +310,7 @@
     <default>
       <files>misc_bugs.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-    </default>
-  </test>
-  <test>
-    <default>
-      <files>misc_bugs.js</files>
-      <compile-flags>-args summary -endargs</compile-flags>
+      <tags>Slow</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
`___cxa_guard_**` is expensive. At the moment, library / dependency initialization order is no longer an issue on our pal dependency. Make the checks and safe pre initialization DEBUG only.