### PR TITLE
OS#14562349: Dynamic import is not handled for op-equiv expressions

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -6902,9 +6902,21 @@ void EmitLoad(
 
         // f(x) +=
     case knopCall:
-        funcInfo->AcquireLoc(lhs);
-        EmitReference(lhs, byteCodeGenerator, funcInfo);
-        EmitCall(lhs, byteCodeGenerator, funcInfo, /*fReturnValue=*/ false, /*fEvaluateComponents=*/ false);
+        if (lhs->sxCall.pnodeTarget->nop == knopImport)
+        {
+            ParseNodePtr args = lhs->sxCall.pnodeArgs;
+            Assert(CountArguments(args) == 2); // import() takes one argument
+            Emit(args, byteCodeGenerator, funcInfo, false);
+            funcInfo->ReleaseLoc(args);
+            funcInfo->AcquireLoc(lhs);
+            byteCodeGenerator->Writer()->Reg2(Js::OpCode::ImportCall, lhs->location, args->location);
+        }
+        else
+        {
+            funcInfo->AcquireLoc(lhs);
+            EmitReference(lhs, byteCodeGenerator, funcInfo);
+            EmitCall(lhs, byteCodeGenerator, funcInfo, /*fReturnValue=*/ false, /*fEvaluateComponents=*/ false);
+        }
         break;
 
     default:

--- a/test/es6/bug_OS14562349.js
+++ b/test/es6/bug_OS14562349.js
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Dynamic import can be used as part of an op-equiv expression",
+    body: function () {
+        var failed = false;
+        try {
+          function foo() { };
+          foo(import('ModuleSimpleExport.js')*=2);
+        } catch(e) { 
+          failed = true;
+        }
+        assert.isTrue(failed, "Failed as expected.")
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1522,6 +1522,13 @@
   </test>
   <test>
     <default>
+      <files>bug_OS14562349.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-ESDynamicImport -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>DeferParseLambda.js</files>
       <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
If we have a dynamic import on the left side of a `*=` expression, for example, we hit an assert that the dynamic import opcode is unhandled. We need to handle that case specially.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14562349
