### PR TITLE
OS 13924587 : Shold export only top lever vars in module.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1873,7 +1873,7 @@ void Parser::BindPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint max
     Js::LocalFunctionId funcId = GetCurrentFunctionNode()->sxFnc.functionId;
     Assert(sym);
 
-    if (pid->GetIsModuleExport())
+    if (pid->GetIsModuleExport() && IsTopLevelModuleFunc())
     {
         sym->SetIsModuleExportStorage(true);
     }

--- a/test/es6/module-functionality.js
+++ b/test/es6/module-functionality.js
@@ -331,6 +331,25 @@ var tests = [
             testRunner.LoadModule(functionBody, 'samethread');
         }
     },
+    {
+        name: "OS13924587 - should export only top level vars",
+        body: function() {
+            let functionBody =
+                `
+                export {a as baz};
+                function foo(a) {
+                    function bar() {
+                        a;
+                    }
+                }
+                var a = 1;
+                foo(30);
+                assert.areEqual(1, a);
+                `;
+
+            testRunner.LoadModule(functionBody, 'samethread');
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
We were exporting all vars which has matching pid, we should be exporting the ones which are defined at top-level in the module.
