### PR TITLE
Bug fixes for incremental value capture

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -1609,9 +1609,9 @@ BackwardPass::ProcessBailOutArgObj(BailOutInfo * bailOutInfo, BVSparse<JitArenaA
 {
     Assert(this->tag != Js::BackwardPhase);
 
-    if (this->globOpt->TrackArgumentsObject() && bailOutInfo->capturedValues.argObjSyms)
+    if (this->globOpt->TrackArgumentsObject() && bailOutInfo->capturedValues->argObjSyms)
     {
-        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues.argObjSyms)
+        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues->argObjSyms)
         {
             if (byteCodeUpwardExposedUsed->TestAndClear(symId))
             {
@@ -1646,7 +1646,7 @@ BackwardPass::ProcessBailOutConstants(BailOutInfo * bailOutInfo, BVSparse<JitAre
     NEXT_SLISTBASE_ENTRY;
 
     // Find other constants that we need to restore
-    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, value, &bailOutInfo->capturedValues.constantValues, iter)
+    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, value, &bailOutInfo->capturedValues->constantValues, iter)
     {
         if (byteCodeUpwardExposedUsed->TestAndClear(value.Key()->m_id) || bailoutReferencedArgSymsBv->TestAndClear(value.Key()->m_id))
         {
@@ -1682,7 +1682,7 @@ BackwardPass::ProcessBailOutCopyProps(BailOutInfo * bailOutInfo, BVSparse<JitAre
     BVSparse<JitArenaAllocator> * upwardExposedUses = block->upwardExposedUses;
 
     // Find other copy prop that we need to restore
-    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSyms, &bailOutInfo->capturedValues.copyPropSyms, iter)
+    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSyms, &bailOutInfo->capturedValues->copyPropSyms, iter)
     {
         // Copy prop syms should be vars
         Assert(!copyPropSyms.Key()->IsTypeSpec());

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -18,8 +18,12 @@ BailOutInfo::Clear(JitArenaAllocator * allocator)
 {
     // Currently, we don't have a case where we delete bailout info after we allocated the bailout record
     Assert(!bailOutRecord);
-    this->capturedValues.constantValues.Clear(allocator);
-    this->capturedValues.copyPropSyms.Clear(allocator);
+    if (this->capturedValues && this->capturedValues->DecrementRefCount() == 0)
+    {
+        this->capturedValues->constantValues.Clear(allocator);
+        this->capturedValues->copyPropSyms.Clear(allocator);
+        JitAdelete(allocator, this->capturedValues);
+    }
     this->usedCapturedValues.constantValues.Clear(allocator);
     this->usedCapturedValues.copyPropSyms.Clear(allocator);
     if (byteCodeUpwardExposedUsed)

--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -46,7 +46,8 @@ public:
 #if DBG
         wasCopied = false;
 #endif
-        this->capturedValues.argObjSyms = nullptr;
+        this->capturedValues = JitAnew(bailOutFunc->m_alloc, CapturedValues);
+        this->capturedValues->refCount = 1;
         this->usedCapturedValues.argObjSyms = nullptr;
     }
     void Clear(JitArenaAllocator * allocator);
@@ -82,7 +83,7 @@ public:
 #endif
     uint32 bailOutOffset;
     BailOutRecord * bailOutRecord;
-    CapturedValues capturedValues;                                      // Values we know about after forward pass
+    CapturedValues* capturedValues;                                      // Values we know about after forward pass
     CapturedValues usedCapturedValues;                                  // Values that need to be restored in the bail out
     BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed;            // Non-constant stack syms that needs to be restored in the bail out
     uint polymorphicCacheIndex;

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -4193,6 +4193,7 @@ BasicBlock::CleanUpValueMaps()
                     this->globOptData.liveInt32Syms->Clear(sym->m_id);
                     this->globOptData.liveLossyInt32Syms->Clear(sym->m_id);
                     this->globOptData.liveFloat64Syms->Clear(sym->m_id);
+                    this->globOptData.SetChangedSym(sym);
                 }
             }
             else
@@ -4291,6 +4292,8 @@ BasicBlock::CleanUpValueMaps()
     FOREACH_BITSET_IN_SPARSEBV(dead_id, &deadSymsBv)
     {
         thisTable->Clear(dead_id);
+        Sym* sym = this->func->m_symTable->Find(dead_id);
+        this->globOptData.SetChangedSym(sym);
     }
     NEXT_BITSET_IN_SPARSEBV;
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2761,7 +2761,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
         }
     }
 
-    if (!isHoisted && instr->HasBailOutInfo() && !this->IsLoopPrePass())
+    if (CurrentBlockData()->capturedValuesCandidate && !this->IsLoopPrePass())
     {
         this->CommitCapturedValuesCandidate();
     }
@@ -4570,11 +4570,7 @@ void
 GlobOpt::SetSymStoreDirect(ValueInfo * valueInfo, Sym * sym)
 {
     Sym * prevSymStore = valueInfo->GetSymStore();
-    if (prevSymStore && prevSymStore->IsStackSym() &&
-        prevSymStore->AsStackSym()->HasByteCodeRegSlot())
-    {
-        CurrentBlockData()->SetChangedSym(prevSymStore->m_id);
-    }
+    CurrentBlockData()->SetChangedSym(prevSymStore);
     valueInfo->SetSymStore(sym);
 }
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2763,29 +2763,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
 
     if (!isHoisted && instr->HasBailOutInfo() && !this->IsLoopPrePass())
     {
-        GlobOptBlockData * globOptData = CurrentBlockData();
-        globOptData->changedSyms->ClearAll();
-
-        if (!this->changedSymsAfterIncBailoutCandidate->IsEmpty())
-        {
-            //
-            // some symbols are changed after the values for current bailout have been
-            // captured (GlobOpt::CapturedValues), need to restore such symbols as changed
-            // for following incremental bailout construction, or we will miss capturing
-            // values for later bailout
-            //
-
-            // swap changedSyms and changedSymsAfterIncBailoutCandidate
-            // because both are from this->alloc
-            BVSparse<JitArenaAllocator> * tempBvSwap = globOptData->changedSyms;
-            globOptData->changedSyms = this->changedSymsAfterIncBailoutCandidate;
-            this->changedSymsAfterIncBailoutCandidate = tempBvSwap;
-        }
-
-        globOptData->capturedValues = globOptData->capturedValuesCandidate;
-
-        // null out capturedValuesCandicate to stop tracking symbols change for it
-        globOptData->capturedValuesCandidate = nullptr;
+        this->CommitCapturedValuesCandidate();
     }
 
     return instrNext;
@@ -15438,6 +15416,37 @@ GlobOptBlockData * GlobOpt::CurrentBlockData()
     return &this->currentBlock->globOptData;
 }
 
+void GlobOpt::CommitCapturedValuesCandidate()
+{
+    GlobOptBlockData * globOptData = CurrentBlockData();
+    globOptData->changedSyms->ClearAll();
+
+    if (!this->changedSymsAfterIncBailoutCandidate->IsEmpty())
+    {
+        //
+        // some symbols are changed after the values for current bailout have been
+        // captured (GlobOpt::CapturedValues), need to restore such symbols as changed
+        // for following incremental bailout construction, or we will miss capturing
+        // values for later bailout
+        //
+
+        // swap changedSyms and changedSymsAfterIncBailoutCandidate
+        // because both are from this->alloc
+        BVSparse<JitArenaAllocator> * tempBvSwap = globOptData->changedSyms;
+        globOptData->changedSyms = this->changedSymsAfterIncBailoutCandidate;
+        this->changedSymsAfterIncBailoutCandidate = tempBvSwap;
+    }
+
+    if (globOptData->capturedValues)
+    {
+        globOptData->capturedValues->DecrementRefCount();
+    }
+    globOptData->capturedValues = globOptData->capturedValuesCandidate;
+
+    // null out capturedValuesCandidate to stop tracking symbols change for it
+    globOptData->capturedValuesCandidate = nullptr;
+}
+
 bool
 GlobOpt::IsOperationThatLikelyKillsJsArraysWithNoMissingValues(IR::Instr *const instr)
 {
@@ -16750,7 +16759,7 @@ GlobOpt::OptHoistInvariant(
         EnsureBailTarget(loop);
 
         // Copy bailout info of loop top.
-        instr->ReplaceBailOutInfo(loop->bailOutInfo, this->currentBlock);
+        instr->ReplaceBailOutInfo(loop->bailOutInfo);
     }
 
     if(!dst)

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -701,6 +701,7 @@ public:
 
     GlobOptBlockData const * CurrentBlockData() const;
     GlobOptBlockData * CurrentBlockData();
+    void                    CommitCapturedValuesCandidate();
 
 private:
     bool                    IsOperationThatLikelyKillsJsArraysWithNoMissingValues(IR::Instr *const instr);

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -253,18 +253,23 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
 
     // attach capturedValues to bailOutInfo
 
-    bailOutInfo->capturedValues.constantValues.Clear(this->func->m_alloc);
-    bailOutConstValuesIter.SetNext(&bailOutInfo->capturedValues.constantValues);
-    bailOutInfo->capturedValues.constantValues = capturedValues.constantValues;
+    bailOutInfo->capturedValues->constantValues.Clear(this->func->m_alloc);
+    bailOutConstValuesIter.SetNext(&bailOutInfo->capturedValues->constantValues);
+    bailOutInfo->capturedValues->constantValues = capturedValues.constantValues;
 
-    bailOutInfo->capturedValues.copyPropSyms.Clear(this->func->m_alloc);
-    bailOutCopySymsIter.SetNext(&bailOutInfo->capturedValues.copyPropSyms);
-    bailOutInfo->capturedValues.copyPropSyms = capturedValues.copyPropSyms;
+    bailOutInfo->capturedValues->copyPropSyms.Clear(this->func->m_alloc);
+    bailOutCopySymsIter.SetNext(&bailOutInfo->capturedValues->copyPropSyms);
+    bailOutInfo->capturedValues->copyPropSyms = capturedValues.copyPropSyms;
     
     if (!PHASE_OFF(Js::IncrementalBailoutPhase, func))
     {
         // cache the pointer of current bailout as potential baseline for later bailout in this block
-        block->globOptData.capturedValuesCandidate = &bailOutInfo->capturedValues;
+        if (block->globOptData.capturedValuesCandidate)
+        {
+            block->globOptData.capturedValuesCandidate->DecrementRefCount();
+        }
+        block->globOptData.capturedValuesCandidate = bailOutInfo->capturedValues;
+        block->globOptData.capturedValuesCandidate->IncrementRefCount();
 
         // reset changed syms to track symbols change after the above captured values candidate
         this->changedSymsAfterIncBailoutCandidate->ClearAll();
@@ -283,12 +288,12 @@ GlobOpt::CaptureArguments(BasicBlock *block, BailOutInfo * bailOutInfo, JitArena
             continue;
         }
 
-        if (!bailOutInfo->capturedValues.argObjSyms)
+        if (!bailOutInfo->capturedValues->argObjSyms)
         {
-            bailOutInfo->capturedValues.argObjSyms = JitAnew(allocator, BVSparse<JitArenaAllocator>, allocator);
+            bailOutInfo->capturedValues->argObjSyms = JitAnew(allocator, BVSparse<JitArenaAllocator>, allocator);
         }
 
-        bailOutInfo->capturedValues.argObjSyms->Set(id);
+        bailOutInfo->capturedValues->argObjSyms->Set(id);
         // Add to BailOutInfo
     }
     NEXT_BITSET_IN_SPARSEBV

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -262,7 +262,7 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     bailOutInfo->capturedValues->copyPropSyms = capturedValues.copyPropSyms;
     
     // In pre-pass only bailout info created should be for the loop header, and that doesn't take into account the back edge.
-    // Don't use the captured values on that bailout for inremental capturing of values.
+    // Don't use the captured values on that bailout for incremental capturing of values.
     if (!PHASE_OFF(Js::IncrementalBailoutPhase, func) && !this->IsLoopPrePass())
     {
         // cache the pointer of current bailout as potential baseline for later bailout in this block

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -261,7 +261,9 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     bailOutCopySymsIter.SetNext(&bailOutInfo->capturedValues->copyPropSyms);
     bailOutInfo->capturedValues->copyPropSyms = capturedValues.copyPropSyms;
     
-    if (!PHASE_OFF(Js::IncrementalBailoutPhase, func))
+    // In pre-pass only bailout info created should be for the loop header, and that doesn't take into account the back edge.
+    // Don't use the captured values on that bailout for inremental capturing of values.
+    if (!PHASE_OFF(Js::IncrementalBailoutPhase, func) && !this->IsLoopPrePass())
     {
         // cache the pointer of current bailout as potential baseline for later bailout in this block
         if (block->globOptData.capturedValuesCandidate)

--- a/lib/Backend/GlobOptBlockData.cpp
+++ b/lib/Backend/GlobOptBlockData.cpp
@@ -1672,6 +1672,15 @@ GlobOptBlockData::SetChangedSym(SymID symId)
 }
 
 void
+GlobOptBlockData::SetChangedSym(Sym* sym)
+{
+    if (sym && sym->IsStackSym() && sym->AsStackSym()->HasByteCodeRegSlot())
+    {
+        SetChangedSym(sym->m_id);
+    }
+}
+
+void
 GlobOptBlockData::SetValue(Value *val, Sym * sym)
 {
     ValueInfo *valueInfo = val->GetValueInfo();
@@ -1688,10 +1697,7 @@ GlobOptBlockData::SetValue(Value *val, Sym * sym)
     else
     {
         this->SetValueToHashTable(this->symToValueMap, val, sym);
-        if (isStackSym && sym->AsStackSym()->HasByteCodeRegSlot())
-        {
-            this->SetChangedSym(sym->m_id);
-        }
+        this->SetChangedSym(sym);
     }
 }
 

--- a/lib/Backend/GlobOptBlockData.cpp
+++ b/lib/Backend/GlobOptBlockData.cpp
@@ -40,6 +40,10 @@ GlobOptBlockData::NullOutBlockData(GlobOpt* globOpt, Func* func)
 
     this->stackLiteralInitFldDataMap = nullptr;
 
+    if (this->capturedValues)
+    {
+        this->capturedValues->DecrementRefCount();
+    }
     this->capturedValues = nullptr;
     this->changedSyms = nullptr;
 

--- a/lib/Backend/GlobOptBlockData.h
+++ b/lib/Backend/GlobOptBlockData.h
@@ -344,6 +344,7 @@ public:
     // Changed Symbol Tracking
 public:
     void                    SetChangedSym(SymID symId);
+    void                    SetChangedSym(Sym* sym);
 private:
 
     // Other

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -1154,7 +1154,7 @@ Instr::UnlinkBailOutInfo()
 }
 
 void
-Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo, BasicBlock * block)
+Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo)
 {
     BailOutInfo *oldBailOutInfo = nullptr;
 
@@ -1186,13 +1186,8 @@ Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo, BasicBlock * block)
     if (oldBailOutInfo->bailOutInstr == this)
     {
         JitArenaAllocator * alloc = this->m_func->m_alloc;
-        // If the oldBailOutInfo's captured values were cached on the globopt-block-data, don't
-        // delete the old bailout info. It will eventually be freed when we're done jitting this function.
-        if (!(block && block->globOptData.capturedValuesCandidate == &oldBailOutInfo->capturedValues))
-        {
-            oldBailOutInfo->Clear(alloc);
-            JitAdelete(alloc, oldBailOutInfo);
-        }
+        oldBailOutInfo->Clear(alloc);
+        JitAdelete(alloc, oldBailOutInfo);
     }
 
     return;
@@ -3148,7 +3143,7 @@ Instr::ConvertToBailOutInstr(BailOutInfo * bailOutInfo, IR::BailOutKind kind, bo
         this->SetBailOutKind_NoAssert(kind);
 
         // Clear old (aux) info and set to the new bailOutInfo.
-        this->ReplaceBailOutInfo(bailOutInfo, nullptr);
+        this->ReplaceBailOutInfo(bailOutInfo);
         bailOutInfo->bailOutInstr = this;
         this->hasBailOutInfo = true;
 

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -36,7 +36,7 @@ struct CapturedValues
         constantValues.Reset();
         copyPropSyms.Reset();
         argObjSyms = nullptr;
-        refCount = 0;
+        Assert(refCount == 0);
     }
 
     uint DecrementRefCount()

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -26,15 +26,29 @@ struct CapturedValues
     SListBase<ConstantStackSymValue> constantValues;           // Captured constant values during glob opt
     SListBase<CopyPropSyms> copyPropSyms;                      // Captured copy prop values during glob opt
     BVSparse<JitArenaAllocator> * argObjSyms;                  // Captured arg object symbols during glob opt
+    uint refCount;
 
-
-    CapturedValues() : argObjSyms(nullptr) {}
+    CapturedValues() : argObjSyms(nullptr), refCount(0) {}
     ~CapturedValues()
     {
         // Reset SListBase to be exception safe. Captured values are from GlobOpt->func->alloc
         // in normal case the 2 SListBase are empty so no Clear needed, also no need to Clear in exception case
         constantValues.Reset();
         copyPropSyms.Reset();
+        argObjSyms = nullptr;
+        refCount = 0;
+    }
+
+    uint DecrementRefCount()
+    {
+        Assert(refCount != 0);
+        return --refCount;
+    }
+
+    void IncrementRefCount()
+    {
+        Assert(refCount > 0);
+        refCount++;
     }
 };
 
@@ -317,7 +331,7 @@ public:
 
     BailOutInfo *   GetBailOutInfo() const;
     BailOutInfo *   UnlinkBailOutInfo();
-    void            ReplaceBailOutInfo(BailOutInfo *newBailOutInfo, BasicBlock * block);
+    void            ReplaceBailOutInfo(BailOutInfo *newBailOutInfo);
     IR::Instr *     ShareBailOut();
     BailOutKind     GetBailOutKind() const;
     BailOutKind     GetBailOutKindNoBits() const;

--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -368,8 +368,8 @@ LinearScanMD::GenerateBailInForGeneratorYield(IR::Instr * resumeLabelInstr, Bail
     IR::Instr * instrInsertStackSym = instrAfter;
     IR::Instr * instrInsertRegSym = instrAfter;
 
-    Assert(bailOutInfo->capturedValues.constantValues.Empty());
-    Assert(bailOutInfo->capturedValues.copyPropSyms.Empty());
+    Assert(bailOutInfo->capturedValues->constantValues.Empty());
+    Assert(bailOutInfo->capturedValues->copyPropSyms.Empty());
     Assert(bailOutInfo->liveLosslessInt32Syms->IsEmpty());
     Assert(bailOutInfo->liveFloat64Syms->IsEmpty());
 
@@ -441,9 +441,9 @@ LinearScanMD::GenerateBailInForGeneratorYield(IR::Instr * resumeLabelInstr, Bail
     }
     NEXT_BITSET_IN_SPARSEBV;
 
-    if (bailOutInfo->capturedValues.argObjSyms)
+    if (bailOutInfo->capturedValues->argObjSyms)
     {
-        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues.argObjSyms)
+        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues->argObjSyms)
         {
             StackSym* stackSym = this->func->m_symTable->FindStackSym(symId);
             restoreSymFn(stackSym->GetByteCodeRegSlot(), stackSym);

--- a/lib/Backend/i386/LinearScanMD.cpp
+++ b/lib/Backend/i386/LinearScanMD.cpp
@@ -250,8 +250,8 @@ LinearScanMD::GenerateBailInForGeneratorYield(IR::Instr * resumeLabelInstr, Bail
     IR::Instr * instrInsertStackSym = instrAfter;
     IR::Instr * instrInsertRegSym = instrAfter;
 
-    Assert(bailOutInfo->capturedValues.constantValues.Empty());
-    Assert(bailOutInfo->capturedValues.copyPropSyms.Empty());
+    Assert(bailOutInfo->capturedValues->constantValues.Empty());
+    Assert(bailOutInfo->capturedValues->copyPropSyms.Empty());
 
     auto restoreSymFn = [this, &eaxRegOpnd, &ecxRegOpnd, &eaxRestoreInstr, &instrInsertStackSym, &instrInsertRegSym](SymID symId)
     {
@@ -327,9 +327,9 @@ LinearScanMD::GenerateBailInForGeneratorYield(IR::Instr * resumeLabelInstr, Bail
     }
     NEXT_BITSET_IN_SPARSEBV;
 
-    if (bailOutInfo->capturedValues.argObjSyms)
+    if (bailOutInfo->capturedValues->argObjSyms)
     {
-        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues.argObjSyms)
+        FOREACH_BITSET_IN_SPARSEBV(symId, bailOutInfo->capturedValues->argObjSyms)
         {
             restoreSymFn(symId);
         }

--- a/test/Optimizer/capturedValuesBugs.js
+++ b/test/Optimizer/capturedValuesBugs.js
@@ -68,4 +68,33 @@ assert.areEqual(test2(), -25677, "test2 should return -25677");
 assert.areEqual(test2(), -25677, "test2 should return -25677");
 assert.areEqual(test2(), -25677, "test2 should return -25677");
 
+function test3() {
+    var loopInvariant = 9;
+    function leaf() {
+    }
+    var obj0 = {};
+    var obj1 = {};
+    var func0 = function (argMath2) {
+      for (; argMath2; ) {
+        if (loopInvariant == 0) {
+          break;
+        }
+        loopInvariant -= 3;
+        var __loopSecondaryVar3_0 = loopInvariant;
+        while (ary.shift()) {
+          __loopSecondaryVar3_0 = 3;
+        }
+        leaf.call();
+      }
+    };
+    var func1 = function () {
+      var uniqobj4 = { prop1: func0(typeof Object.prototype.prop1) };
+    };
+    obj0.method0 = func1;
+    obj1.method1 = obj0.method0;
+    var ary = Array();
+    func0(obj1.method1());
+    func0(obj1.method1());
+}
+test3();
 print("passed");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1454,4 +1454,16 @@
       <files>capturedValuesBugs.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>test146.js</files>
+      <compile-flags>-off:bailonnoprofile</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>test147.js</files>
+      <compile-flags>-off:aggressiveinttypespec</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Optimizer/test146.js
+++ b/test/Optimizer/test146.js
@@ -1,0 +1,52 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    var obj1 = {};
+    var func0 = function (argMath0 = {
+      prop7: {
+        prop0: ary.pop() >> (typeof protoObj1.prop1 == 'undefined'),
+        prop1: typeof protoObj1.prop1 == 'undefined',
+        prop2: 314342286 >= 314342286 || obj0.prop0 == obj1.prop0,
+        prop3: obj0.length,
+        prop4: 138434197,
+        prop5: leaf.call(protoObj0),
+        prop6: (obj0.prop0 %= typeof ((2147483647 ^= leaf.call(obj0) ? protoObj0.length >> h : uic8[186 & 255]) ? typeof g == 'boolean' : (i32[132 & 255] * (typeof g == 'boolean') + {
+          prop2: 32061261727923600 instanceof (typeof Error == 'function' ? Error : Object),
+          prop1: ary[(-47093207 >= 0 ? -47093207 : 0) & 15],
+          prop0: new Object() instanceof (typeof EvalError == 'function' ? EvalError : Object)
+        } ? -1200911084.9 : leaf.call(obj1)) * (new leaf().prop1 - (ui32[-887632913.9 * (-152266440 + arrObj0.prop0) * (obj0.length - 314342286) + func0.caller & 255] - -710991759))) == 'undefined') ? ary.pop() : typeof protoObj0.prop1 != 'number' | 4294967297,
+        prop7: leaf.call(litObj1)
+      },
+      prop6: (obj0.prop0 %= typeof ((2147483647 ^= leaf.call(obj0) ? protoObj0.length >> h : uic8[186 & 255]) ? typeof g == 'boolean' : (i32[132 & 255] * (typeof g == 'boolean') + {
+        prop2: 32061261727923600 instanceof (typeof Error == 'function' ? Error : Object),
+        prop1: ary[(-47093207 >= 0 ? -47093207 : 0) & 15],
+        prop0: new Object() instanceof (typeof EvalError == 'function' ? EvalError : Object)
+      } ? -1200911084.9 : leaf.call(obj1)) * (new leaf().prop1 - (ui32[-887632913.9 * (-152266440 + arrObj0.prop0) * (obj0.length - 314342286) + func0.caller & 255] - -710991759))) == 'undefined') ? ary.pop() : typeof protoObj0.prop1 != 'number' | 4294967297,
+      prop5: g !== protoObj0.length || this.prop1 === arrObj0.prop1,
+      prop4: (2147483647 ^= leaf.call(obj0) ? protoObj0.length >> h : uic8[186 & 255]) ? typeof g == 'boolean' : (i32[132 & 255] * (typeof g == 'boolean') + {
+        prop2: 32061261727923600 instanceof (typeof Error == 'function' ? Error : Object),
+        prop1: ary[(-47093207 >= 0 ? -47093207 : 0) & 15],
+        prop0: new Object() instanceof (typeof EvalError == 'function' ? EvalError : Object)
+      } ? -1200911084.9 : leaf.call(obj1)) * (new leaf().prop1 - (ui32[-887632913.9 * (-152266440 + arrObj0.prop0) * (obj0.length - 314342286) + func0.caller & 255] - -710991759)),
+      prop3: obj1.prop1 = ary.push(i8[func0.caller & 255], func0.caller, -(typeof obj0.prop1 == 'object'), Math.acos(func0.caller), leaf.call(arrObj0) === leaf.call(obj0), 2147483647, ary.reverse() * (leaf.call(obj0) ? protoObj0.length >> h : uic8[186 & 255]) + -2147483648 || new Object() instanceof (typeof EvalError == 'function' ? EvalError : Object)),
+      prop2: new RangeError() instanceof (typeof RegExp == 'function' ? RegExp : Object),
+      prop1: new RangeError() instanceof (typeof RegExp == 'function' ? RegExp : Object),
+      prop0: arrObj0.prop1 > protoObj0.prop0 && obj0.length < obj1.prop1}) 
+    {
+    };
+    var id27 = 2147483647;
+    for (var i =0;i<1000;i++) {
+      if (obj1 >= 238436589.1) {
+        makeArrayLength(ary(id27));
+        while (+uic8[b != h & 255] - (id27 = obj1)) {
+        }
+      }
+      obj1.prop0;
+    }
+}
+
+test0();
+print("passed")

--- a/test/Optimizer/test147.js
+++ b/test/Optimizer/test147.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function leaf() {
+    return 100;
+}
+var func0 = function (argMath0 = new Array()) {
+    for (var i=0;i<100;i++) {
+        argMath0 %= leaf.call() ? ary.push(Object(), argMath0--) : prop1;
+        '#'.concat(ary.push(argMath0--));
+    }
+};
+var ary = Array();
+func0();
+func0();
+func0();
+print("passed")


### PR DESCRIPTION
1. Introducing ref-counting for `CapturedValues` to prevent use-after-free when we clear the bailout info of instruction (via removing the bailout or removing the instr itself) and some basic block's blockData was referring to the capturedValues on that bailout info. To facilitate this, made `BailOutInfo` have a pointer to `CapturedValues` instead of having it inline.

2a. Even if the current instr being processed by the globopt doesn't end up with a bailout when we are about to commit captured values (to the current block's blockData), we can do the commit as the state of copy prop syms and constant syms captured is still accurate. This may happen, for example, if an instr with a bailout got constant propagated, which removes the bailout. We capture the values before the constant-prop, and those should still be usable after the bailout gets removed.

2b. Can't use the values that were captured while processing a loop header's bailout for incremental value capturing since that bailout info doesn't take into account the back edge.

2c. `CleanUpValueMaps` should set the syms that it makes dead as changed.
  
  