### PR TITLE
WASM: Bytecode reset assert

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -4911,6 +4911,7 @@ namespace Js
 
         this->SetAuxiliaryData(nullptr);
         this->SetAuxiliaryContextData(nullptr);
+        AssertMsg(!this->byteCodeBlock || !this->IsWasmFunction(), "We should never reset the bytecode block for Wasm");
         this->byteCodeBlock = nullptr;
         this->SetLoopHeaderArray(nullptr);
         this->SetConstTable(nullptr);
@@ -6395,6 +6396,7 @@ namespace Js
         hasCachedScopePropIds = false;
         this->SetConstantCount(0);
         this->SetConstTable(nullptr);
+        AssertMsg(!this->byteCodeBlock || !this->IsWasmFunction(), "We should never reset the bytecode block for Wasm");
         this->byteCodeBlock = nullptr;
 
         // Also, remove the function body from the source info to prevent any further processing 
@@ -7382,6 +7384,7 @@ namespace Js
         // Manually clear these values to break any circular references
         // that might prevent the script context from being disposed        
         this->auxPtrs = nullptr;
+        AssertMsg(isScriptContextClosing || !m_hasActiveReference || !this->byteCodeBlock || !this->IsWasmFunction(), "We should never reset the bytecode block for Wasm when still referenced");
         this->byteCodeBlock = nullptr;
         this->entryPoints = nullptr;
         this->inlineCaches = nullptr;


### PR DESCRIPTION
Add asserts to catch cases where we would reset the bytecode block to nullptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4523)
<!-- Reviewable:end -->
