### PR TITLE
Add JSRT support for native callbacks with `new.target`

### DIFF
--- a/bin/ChakraCore/ChakraCore.def
+++ b/bin/ChakraCore/ChakraCore.def
@@ -58,3 +58,5 @@ JsReleaseSharedArrayBufferContentHandle
 
 JsLessThan
 JsLessThanOrEqual
+
+JsCreateEnhancedFunction

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -660,6 +660,215 @@ namespace JsRTApiTest
         JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternalFunctionTest);
     }
 
+    JsValueRef CALLBACK ExternaEnhancedFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    {
+        REQUIRE(callbackData != nullptr);
+        REQUIRE(*static_cast<int*>(callbackData) == 123);
+        REQUIRE(argumentCount == 2);
+
+        bool success = false;
+        JsValueRef _true;
+        REQUIRE(JsGetTrueValue(&_true) == JsNoError);
+        JsValueRef _false;
+        REQUIRE(JsGetFalseValue(&_false) == JsNoError);
+        JsValueRef _null;
+        REQUIRE(JsGetNullValue(&_null) == JsNoError);
+
+        REQUIRE(JsStrictEquals(_true, arguments[0], &success) == JsNoError);
+        REQUIRE(success);
+        REQUIRE(JsStrictEquals(_false, arguments[1], &success) == JsNoError);
+        REQUIRE(success);
+
+        REQUIRE(!info->isConstructCall);
+        REQUIRE(info->thisArg == arguments[0]);
+
+        REQUIRE(JsStrictEquals(_null, info->newTargetArg, &success) == JsNoError);
+        REQUIRE(success);
+
+        return _null;
+    }
+
+    JsValueRef CALLBACK ExternaEnhancedConstructorFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    {
+        REQUIRE(callbackData != nullptr);
+        REQUIRE(*static_cast<int*>(callbackData) == 456);
+        REQUIRE(argumentCount == 3);
+
+        bool success = false;
+        JsValueRef _true;
+        REQUIRE(JsGetTrueValue(&_true) == JsNoError);
+        JsValueRef _false;
+        REQUIRE(JsGetFalseValue(&_false) == JsNoError);
+        JsValueRef _null;
+        REQUIRE(JsGetNullValue(&_null) == JsNoError);
+
+        REQUIRE(info->thisArg == arguments[0]);
+        REQUIRE(JsStrictEquals(_true, arguments[1], &success) == JsNoError);
+        REQUIRE(success);
+        REQUIRE(JsStrictEquals(_false, arguments[2], &success) == JsNoError);
+        REQUIRE(success);
+
+        REQUIRE(info->isConstructCall);
+
+        JsValueType t;
+        REQUIRE(JsGetValueType(info->newTargetArg, &t) == JsNoError);
+        REQUIRE(t == JsFunction);
+        REQUIRE(JsGetValueType(info->thisArg, &t) == JsNoError);
+        REQUIRE(t == JsObject);
+
+        return info->thisArg;
+    }
+
+    void ExternaEnhancedFunctionTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        int sentinel = 123;
+        JsValueRef function = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
+        JsValueRef _true;
+        REQUIRE(JsGetTrueValue(&_true) == JsNoError);
+        JsValueRef _false;
+        REQUIRE(JsGetFalseValue(&_false) == JsNoError);
+        JsValueRef args[2] = { _true, _false };
+        JsValueRef _null;
+        REQUIRE(JsGetNullValue(&_null) == JsNoError);
+        JsValueRef result;
+        REQUIRE(JsCallFunction(function, args, 2, &result) == JsNoError);
+        bool success;
+        REQUIRE(JsStrictEquals(_null, result, &success) == JsNoError);
+        REQUIRE(success);
+
+        sentinel = 456;
+        function = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedConstructorFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
+        JsValueRef ctorArgs[3] = { _null, _true, _false };
+        REQUIRE(JsConstructObject(function, ctorArgs, 3, &result) == JsNoError);
+        JsValueType t;
+        REQUIRE(JsGetValueType(result, &t) == JsNoError);
+        REQUIRE(t == JsObject);
+    }
+
+    TEST_CASE("ApiTest_ExternaEnhancedFunctionTest", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternaEnhancedFunctionTest);
+    }
+
+    struct ExternaEnhancedBaseClassFunctionTestInfo
+    {
+        JsValueRef derived;
+        JsValueRef base;
+    };
+
+    JsValueRef CALLBACK ExternaEnhancedBaseClassFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    {
+        REQUIRE(callbackData != nullptr);
+
+        ExternaEnhancedBaseClassFunctionTestInfo* testinfo = (ExternaEnhancedBaseClassFunctionTestInfo*)callbackData;
+        JsValueType t;
+        REQUIRE(JsGetValueType(testinfo->derived, &t) == JsNoError);
+        REQUIRE(t == JsFunction);
+        REQUIRE(JsGetValueType(testinfo->base, &t) == JsNoError);
+        REQUIRE(t == JsFunction);
+        REQUIRE(argumentCount == 2);
+
+        JsPropertyIdRef propId;
+        bool success = false;
+        JsValueRef _true;
+        REQUIRE(JsGetTrueValue(&_true) == JsNoError);
+        JsValueRef _false;
+        REQUIRE(JsGetFalseValue(&_false) == JsNoError);
+
+        REQUIRE(info->thisArg == arguments[0]);
+        REQUIRE(JsStrictEquals(_true, arguments[1], &success) == JsNoError);
+        REQUIRE(success);
+
+        REQUIRE(info->isConstructCall);
+        REQUIRE(JsGetValueType(info->newTargetArg, &t) == JsNoError);
+        REQUIRE(t == JsFunction);
+        REQUIRE(JsGetValueType(info->thisArg, &t) == JsNoError);
+        REQUIRE(t == JsObject);
+
+        // new.target === Derived
+        REQUIRE(JsStrictEquals(info->newTargetArg, testinfo->derived, &success) == JsNoError);
+        REQUIRE(success);
+
+        // this.constructor === Derived
+        REQUIRE(JsGetPropertyIdFromName(_u("constructor"), &propId) == JsNoError);
+        JsValueRef thisCtor = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetProperty(info->thisArg, propId, &thisCtor) == JsNoError);
+        REQUIRE(JsStrictEquals(thisCtor, testinfo->derived, &success) == JsNoError);
+        REQUIRE(success);
+
+        // this.__proto__ === Derived.prototype
+        JsValueRef thisProto = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetPrototype(info->thisArg, &thisProto) == JsNoError);
+        JsValueRef derivedPrototype = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetPropertyIdFromName(_u("prototype"), &propId) == JsNoError);
+        REQUIRE(JsGetProperty(testinfo->derived, propId, &derivedPrototype) == JsNoError);
+        REQUIRE(JsStrictEquals(thisProto, derivedPrototype, &success) == JsNoError);
+        REQUIRE(success);
+
+        return info->thisArg;
+    }
+
+    void ExternalEnhancedBaseClassFunctionTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        ExternaEnhancedBaseClassFunctionTestInfo info;
+
+        JsValueRef name;
+        REQUIRE(JsCreateString("BaseClass", 10, &name) == JsNoError);
+        JsValueRef base = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedBaseClassFunctionTestCallback, name, &info, &base) == JsNoError);
+        info.base = base;
+
+        JsValueRef global = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetGlobalObject(&global) == JsNoError);
+        JsPropertyIdRef propId;
+        REQUIRE(JsGetPropertyIdFromName(_u("BaseClass"), &propId) == JsNoError);
+        REQUIRE(JsSetProperty(global, propId, base, false) == JsNoError);
+
+        bool success = false;
+        JsValueType t;
+        JsValueRef derived = JS_INVALID_REFERENCE;
+        REQUIRE(JsRunScript(
+            _u("class Derived extends BaseClass {") \
+            _u("  constructor() {") \
+            _u("    super(true);") \
+            _u("  }") \
+            _u("};"), JS_SOURCE_CONTEXT_NONE, _u(""), &derived) == JsNoError);
+
+        info.derived = derived;
+        REQUIRE(JsGetValueType(derived, &t) == JsNoError);
+        REQUIRE(t == JsFunction);
+
+        JsValueRef instance = JS_INVALID_REFERENCE;
+        REQUIRE(JsRunScript(
+            _u("new Derived();"), JS_SOURCE_CONTEXT_NONE, _u(""), &instance) == JsNoError);
+
+        REQUIRE(JsGetValueType(instance, &t) == JsNoError);
+        REQUIRE(t == JsObject);
+
+        // instance.constructor === Derived
+        REQUIRE(JsGetPropertyIdFromName(_u("constructor"), &propId) == JsNoError);
+        JsValueRef instanceCtor = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetProperty(instance, propId, &instanceCtor) == JsNoError);
+        REQUIRE(JsStrictEquals(instanceCtor, derived, &success) == JsNoError);
+        REQUIRE(success);
+
+        // instance.__proto__ === Derived.prototype
+        JsValueRef instanceProto = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetPrototype(instance, &instanceProto) == JsNoError);
+        JsValueRef derivedPrototype = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetPropertyIdFromName(_u("prototype"), &propId) == JsNoError);
+        REQUIRE(JsGetProperty(derived, propId, &derivedPrototype) == JsNoError);
+        REQUIRE(JsStrictEquals(instanceProto, derivedPrototype, &success) == JsNoError);
+        REQUIRE(success);
+    }
+
+    TEST_CASE("ApiTest_ExternalEnhancedBaseClassFunctionTest", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternalEnhancedBaseClassFunctionTest);
+    }
+
     void ExternalFunctionNameTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
         auto testConstructorName = [=](JsValueRef function, PCWCHAR expectedName, size_t expectedNameLength)

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -660,7 +660,7 @@ namespace JsRTApiTest
         JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternalFunctionTest);
     }
 
-    JsValueRef CALLBACK ExternaEnhancedFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    JsValueRef CALLBACK ExternalEnhancedFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
     {
         REQUIRE(callbackData != nullptr);
         REQUIRE(*static_cast<int*>(callbackData) == 123);
@@ -671,8 +671,7 @@ namespace JsRTApiTest
         REQUIRE(JsGetTrueValue(&_true) == JsNoError);
         JsValueRef _false;
         REQUIRE(JsGetFalseValue(&_false) == JsNoError);
-        JsValueRef _null;
-        REQUIRE(JsGetNullValue(&_null) == JsNoError);
+        
 
         REQUIRE(JsStrictEquals(_true, arguments[0], &success) == JsNoError);
         REQUIRE(success);
@@ -682,13 +681,17 @@ namespace JsRTApiTest
         REQUIRE(!info->isConstructCall);
         REQUIRE(info->thisArg == arguments[0]);
 
-        REQUIRE(JsStrictEquals(_null, info->newTargetArg, &success) == JsNoError);
+        JsValueRef undefined;
+        REQUIRE(JsGetUndefinedValue(&undefined) == JsNoError);
+        REQUIRE(JsStrictEquals(undefined, info->newTargetArg, &success) == JsNoError);
         REQUIRE(success);
 
+        JsValueRef _null;
+        REQUIRE(JsGetNullValue(&_null) == JsNoError);
         return _null;
     }
 
-    JsValueRef CALLBACK ExternaEnhancedConstructorFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    JsValueRef CALLBACK ExternalEnhancedConstructorFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
     {
         REQUIRE(callbackData != nullptr);
         REQUIRE(*static_cast<int*>(callbackData) == 456);
@@ -719,11 +722,11 @@ namespace JsRTApiTest
         return info->thisArg;
     }
 
-    void ExternaEnhancedFunctionTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    void ExternalEnhancedFunctionTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
         int sentinel = 123;
         JsValueRef function = JS_INVALID_REFERENCE;
-        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
+        REQUIRE(JsCreateEnhancedFunction(ExternalEnhancedFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
         JsValueRef _true;
         REQUIRE(JsGetTrueValue(&_true) == JsNoError);
         JsValueRef _false;
@@ -739,7 +742,7 @@ namespace JsRTApiTest
 
         sentinel = 456;
         function = JS_INVALID_REFERENCE;
-        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedConstructorFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
+        REQUIRE(JsCreateEnhancedFunction(ExternalEnhancedConstructorFunctionTestCallback, nullptr, &sentinel, &function) == JsNoError);
         JsValueRef ctorArgs[3] = { _null, _true, _false };
         REQUIRE(JsConstructObject(function, ctorArgs, 3, &result) == JsNoError);
         JsValueType t;
@@ -747,22 +750,22 @@ namespace JsRTApiTest
         REQUIRE(t == JsObject);
     }
 
-    TEST_CASE("ApiTest_ExternaEnhancedFunctionTest", "[ApiTest]")
+    TEST_CASE("ApiTest_ExternalEnhancedFunctionTest", "[ApiTest]")
     {
-        JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternaEnhancedFunctionTest);
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ExternalEnhancedFunctionTest);
     }
 
-    struct ExternaEnhancedBaseClassFunctionTestInfo
+    struct ExternalEnhancedBaseClassFunctionTestInfo
     {
         JsValueRef derived;
         JsValueRef base;
     };
 
-    JsValueRef CALLBACK ExternaEnhancedBaseClassFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
+    JsValueRef CALLBACK ExternalEnhancedBaseClassFunctionTestCallback(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *callbackData)
     {
         REQUIRE(callbackData != nullptr);
 
-        ExternaEnhancedBaseClassFunctionTestInfo* testinfo = (ExternaEnhancedBaseClassFunctionTestInfo*)callbackData;
+        ExternalEnhancedBaseClassFunctionTestInfo* testinfo = (ExternalEnhancedBaseClassFunctionTestInfo*)callbackData;
         JsValueType t;
         REQUIRE(JsGetValueType(testinfo->derived, &t) == JsNoError);
         REQUIRE(t == JsFunction);
@@ -812,12 +815,11 @@ namespace JsRTApiTest
 
     void ExternalEnhancedBaseClassFunctionTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
-        ExternaEnhancedBaseClassFunctionTestInfo info;
-
-        JsValueRef name;
+        ExternalEnhancedBaseClassFunctionTestInfo info = { nullptr, nullptr };
+        JsValueRef name = JS_INVALID_REFERENCE;
         REQUIRE(JsCreateString("BaseClass", 10, &name) == JsNoError);
         JsValueRef base = JS_INVALID_REFERENCE;
-        REQUIRE(JsCreateEnhancedFunction(ExternaEnhancedBaseClassFunctionTestCallback, name, &info, &base) == JsNoError);
+        REQUIRE(JsCreateEnhancedFunction(ExternalEnhancedBaseClassFunctionTestCallback, name, &info, &base) == JsNoError);
         info.base = base;
 
         JsValueRef global = JS_INVALID_REFERENCE;

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -8,7 +8,7 @@ struct JsAPIHooks
 {
     typedef JsErrorCode (WINAPI *JsrtCreateRuntimePtr)(JsRuntimeAttributes attributes, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
     typedef JsErrorCode (WINAPI *JsrtCreateContextPtr)(JsRuntimeHandle runtime, JsContextRef *newContext);
-    typedef JsErrorCode(WINAPI *JsrtSetObjectBeforeCollectCallbackPtr)(JsRef ref, void* callbackState, JsObjectBeforeCollectCallback objectBeforeCollectCallback);
+    typedef JsErrorCode (WINAPI *JsrtSetObjectBeforeCollectCallbackPtr)(JsRef ref, void* callbackState, JsObjectBeforeCollectCallback objectBeforeCollectCallback);
     typedef JsErrorCode (WINAPI *JsrtSetRuntimeMemoryLimitPtr)(JsRuntimeHandle runtime, size_t memoryLimit);
     typedef JsErrorCode (WINAPI *JsrtSetCurrentContextPtr)(JsContextRef context);
     typedef JsErrorCode (WINAPI *JsrtGetCurrentContextPtr)(JsContextRef* context);
@@ -16,6 +16,7 @@ struct JsAPIHooks
     typedef JsErrorCode (WINAPI *JsrtCreateObjectPtr)(JsValueRef *object);
     typedef JsErrorCode (WINAPI *JsrtCreateExternalObjectPtr)(void* data, JsFinalizeCallback callback, JsValueRef *object);
     typedef JsErrorCode (WINAPI *JsrtCreateFunctionPtr)(JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function);
+    typedef JsErrorCode (WINAPI *JsrtCreateEnhancedFunctionPtr)(JsEnhancedNativeFunction nativeFunction, JsValueRef metadata, void *callbackState, JsValueRef *function);
     typedef JsErrorCode (WINAPI *JsCreateNamedFunctionPtr)(JsValueRef name, JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function);
     typedef JsErrorCode (WINAPI *JsrtSetPropertyPtr)(JsValueRef object, JsPropertyIdRef property, JsValueRef value, bool useStrictRules);
     typedef JsErrorCode (WINAPI *JsrtGetGlobalObjectPtr)(JsValueRef *globalObject);
@@ -110,6 +111,7 @@ struct JsAPIHooks
     JsrtCreateObjectPtr pfJsrtCreateObject;
     JsrtCreateExternalObjectPtr pfJsrtCreateExternalObject;
     JsrtCreateFunctionPtr pfJsrtCreateFunction;
+    JsrtCreateEnhancedFunctionPtr pfJsrtCreateEnhancedFunction;
     JsCreateNamedFunctionPtr pfJsrtCreateNamedFunction;
     JsrtSetPropertyPtr pfJsrtSetProperty;
     JsrtGetGlobalObjectPtr pfJsrtGetGlobalObject;
@@ -318,6 +320,7 @@ public:
     static JsErrorCode WINAPI JsCreateObject(JsValueRef *object) { return HOOK_JS_API(CreateObject(object)); }
     static JsErrorCode WINAPI JsCreateExternalObject(void *data, JsFinalizeCallback callback, JsValueRef *object) { return HOOK_JS_API(CreateExternalObject(data, callback, object)); }
     static JsErrorCode WINAPI JsCreateFunction(JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function) { return HOOK_JS_API(CreateFunction(nativeFunction, callbackState, function)); }
+    static JsErrorCode WINAPI JsCreateEnhancedFunction(JsEnhancedNativeFunction nativeFunction, JsValueRef metadata, void *callbackState, JsValueRef *function) { return HOOK_JS_API(CreateEnhancedFunction(nativeFunction, metadata, callbackState, function)); }
     static JsErrorCode WINAPI JsCreateNamedFunction(JsValueRef name, JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function) { return HOOK_JS_API(CreateNamedFunction(name, nativeFunction, callbackState, function)); }
     static JsErrorCode WINAPI JsSetProperty(JsValueRef object, JsPropertyIdRef property, JsValueRef value, bool useStrictRules) { return HOOK_JS_API(SetProperty(object, property, value, useStrictRules)); }
     static JsErrorCode WINAPI JsGetGlobalObject(JsValueRef *globalObject) { return HOOK_JS_API(GetGlobalObject(globalObject)); }

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -107,12 +107,12 @@ typedef JsErrorCode(CHAKRA_CALLBACK * NotifyModuleReadyCallback)(_In_opt_ JsModu
 /// <summary>
 ///     A structure containing information about a native function callback.
 /// </summary>
-struct JsNativeFunctionInfo
+typedef struct JsNativeFunctionInfo
 {
     JsValueRef thisArg;
     JsValueRef newTargetArg;
     bool isConstructCall;
-};
+}JsNativeFunctionInfo;
 
 /// <summary>
 ///     A function callback.
@@ -136,7 +136,7 @@ typedef _Ret_maybenull_ JsValueRef(CHAKRA_CALLBACK * JsEnhancedNativeFunction)(_
 ///     Requires an active script context.
 /// </remarks>
 /// <param name="nativeFunction">The method to call when the function is invoked.</param>
-/// <param name="metadata">If this is a string, it is used as the name of the function.</param>
+/// <param name="metadata">If this is not <c>JS_INVALID_REFERENCE</c>, it is converted to a string and used as the name of the function.</param>
 /// <param name="callbackState">
 ///     User provided state that will be passed back to the callback.
 /// </param>

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -105,6 +105,53 @@ typedef JsErrorCode(CHAKRA_CALLBACK * FetchImportedModuleFromScriptCallBack)(_In
 typedef JsErrorCode(CHAKRA_CALLBACK * NotifyModuleReadyCallback)(_In_opt_ JsModuleRecord referencingModule, _In_opt_ JsValueRef exceptionVar);
 
 /// <summary>
+///     A structure containing information about a native function callback.
+/// </summary>
+struct JsNativeFunctionInfo
+{
+    JsValueRef thisArg;
+    JsValueRef newTargetArg;
+    bool isConstructCall;
+};
+
+/// <summary>
+///     A function callback.
+/// </summary>
+/// <param name="callee">
+///     A function object that represents the function being invoked.
+/// </param>
+/// <param name="arguments">The arguments to the call.</param>
+/// <param name="argumentCount">The number of arguments.</param>
+/// <param name="info">Additional information about this function call.</param>
+/// <param name="callbackState">
+///     The state passed to <c>JsCreateFunction</c>.
+/// </param>
+/// <returns>The result of the call, if any.</returns>
+typedef _Ret_maybenull_ JsValueRef(CHAKRA_CALLBACK * JsEnhancedNativeFunction)(_In_ JsValueRef callee, _In_ JsValueRef *arguments, _In_ unsigned short argumentCount, _In_ JsNativeFunctionInfo *info, _In_opt_ void *callbackState);
+
+/// <summary>
+///     Creates a new enhanced JavaScript function.
+/// </summary>
+/// <remarks>
+///     Requires an active script context.
+/// </remarks>
+/// <param name="nativeFunction">The method to call when the function is invoked.</param>
+/// <param name="metadata">If this is a string, it is used as the name of the function.</param>
+/// <param name="callbackState">
+///     User provided state that will be passed back to the callback.
+/// </param>
+/// <param name="function">The new function object.</param>
+/// <returns>
+///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+/// </returns>
+CHAKRA_API
+JsCreateEnhancedFunction(
+    _In_ JsEnhancedNativeFunction nativeFunction,
+    _In_opt_ JsValueRef metadata,
+    _In_opt_ void *callbackState,
+    _Out_ JsValueRef *function);
+
+/// <summary>
 ///     Initialize a ModuleRecord from host
 /// </summary>
 /// <remarks>

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -2791,16 +2791,65 @@ CHAKRA_API JsConstructObject(_In_ JsValueRef function, _In_reads_(cargs) JsValue
     });
 }
 
-CHAKRA_API JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+#ifndef _CHAKRACOREBUILD
+struct JsNativeFunctionInfo
 {
-    return ContextAPIWrapper<JSRT_MAYBE_TRUE>([&] (Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
-        PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTAllocateFunction, false, nullptr);
+    JsValueRef thisArg;
+    JsValueRef newTargetArg;
+    bool isConstructCall;
+};
 
+typedef _Ret_maybenull_ JsValueRef(CHAKRA_CALLBACK * JsEnhancedNativeFunction)(_In_ JsValueRef callee, _In_ JsValueRef *arguments, _In_ unsigned short argumentCount, _In_ JsNativeFunctionInfo *info, _In_opt_ void *callbackState);
+#endif
+
+struct JsNativeFunctionWrapperHolder
+{
+    void *callbackState;
+    JsNativeFunction nativeFunction;
+};
+
+JsValueRef CALLBACK JsNativeFunctionWrapper(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, JsNativeFunctionInfo *info, void *wrapperData)
+{
+    JsNativeFunctionWrapperHolder *wrapperHolder = static_cast<JsNativeFunctionWrapperHolder*>(wrapperData);
+    JsValueRef result = wrapperHolder->nativeFunction(callee, info->isConstructCall, arguments, argumentCount, wrapperHolder->callbackState);
+    return result;
+}
+
+template <bool wrapNativeFunction, class T>
+JsErrorCode JsCreateEnhancedFunctionHelper(_In_ T nativeFunction, _In_opt_ JsValueRef metadata, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+{
+    return ContextAPIWrapper<JSRT_MAYBE_TRUE>([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
+        PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTAllocateFunction, false, nullptr);
         PARAM_NOT_NULL(nativeFunction);
         PARAM_NOT_NULL(function);
         *function = nullptr;
 
-        Js::JavascriptExternalFunction *externalFunction = scriptContext->GetLibrary()->CreateStdCallExternalFunction((Js::StdCallJavascriptMethod)nativeFunction, 0, callbackState);
+        Js::StdCallJavascriptMethod method;
+
+        if (wrapNativeFunction)
+        {
+            JsNativeFunctionWrapperHolder *wrapperHolder = RecyclerNewStruct(scriptContext->GetRecycler(), JsNativeFunctionWrapperHolder);
+            wrapperHolder->callbackState = callbackState;
+            wrapperHolder->nativeFunction = (JsNativeFunction)nativeFunction;
+            callbackState = wrapperHolder;
+            method = (Js::StdCallJavascriptMethod)JsNativeFunctionWrapper;
+        }
+        else
+        {
+            method = (Js::StdCallJavascriptMethod)nativeFunction;
+        }
+
+        if (metadata != JS_INVALID_REFERENCE)
+        {
+            VALIDATE_INCOMING_REFERENCE(metadata, scriptContext);
+            metadata = Js::JavascriptConversion::ToString(metadata, scriptContext);
+        }
+        else
+        {
+            metadata = scriptContext->GetLibrary()->GetEmptyString();
+        }
+
+        Js::JavascriptExternalFunction *externalFunction = scriptContext->GetLibrary()->CreateStdCallExternalFunction(method, metadata, callbackState);
         *function = (JsValueRef)externalFunction;
 
         PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, function);
@@ -2809,32 +2858,19 @@ CHAKRA_API JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_opt_ void 
     });
 }
 
+CHAKRA_API JsCreateEnhancedFunction(_In_ JsEnhancedNativeFunction nativeFunction, _In_opt_ JsValueRef metadata, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+{
+    return JsCreateEnhancedFunctionHelper<false>(nativeFunction, metadata, callbackState, function);
+}
+
+CHAKRA_API JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+{
+    return JsCreateNamedFunction(JS_INVALID_REFERENCE, nativeFunction, callbackState, function);
+}
+
 CHAKRA_API JsCreateNamedFunction(_In_ JsValueRef name, _In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
 {
-    return ContextAPIWrapper<JSRT_MAYBE_TRUE>([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
-        PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTAllocateFunction, true, name);
-
-        VALIDATE_INCOMING_REFERENCE(name, scriptContext);
-        PARAM_NOT_NULL(nativeFunction);
-        PARAM_NOT_NULL(function);
-        *function = nullptr;
-
-        if (name != JS_INVALID_REFERENCE)
-        {
-            name = Js::JavascriptConversion::ToString(name, scriptContext);
-        }
-        else
-        {
-            name = scriptContext->GetLibrary()->GetEmptyString();
-        }
-
-        Js::JavascriptExternalFunction *externalFunction = scriptContext->GetLibrary()->CreateStdCallExternalFunction((Js::StdCallJavascriptMethod)nativeFunction, Js::JavascriptString::FromVar(name), callbackState);
-        *function = (JsValueRef)externalFunction;
-
-        PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(scriptContext, function);
-
-        return JsNoError;
-    });
+    return JsCreateEnhancedFunctionHelper<true>(nativeFunction, name, callbackState, function);
 }
 
 void SetErrorMessage(Js::ScriptContext *scriptContext, JsValueRef newError, JsValueRef message)

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6685,7 +6685,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
     BOOL JavascriptOperators::IsClassConstructor(Var instance)
     {
         JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
-        return function && (function->GetFunctionInfo()->IsClassConstructor() || !function->IsScriptFunction());
+        return function && (function->GetFunctionInfo()->IsClassConstructor() || (!function->IsScriptFunction() && !function->IsExternalFunction()));
     }
 
     BOOL JavascriptOperators::IsClassMethod(Var instance)

--- a/lib/Runtime/Library/JavascriptExternalFunction.cpp
+++ b/lib/Runtime/Library/JavascriptExternalFunction.cpp
@@ -274,10 +274,11 @@ namespace Js
         ScriptContext * scriptContext = externalFunction->type->GetScriptContext();
         AnalysisAssert(scriptContext);
         Var result = nullptr;
+        Assert(callInfo.Count > 0);
 
         StdCallJavascriptMethodInfo info = {
-            callInfo.Count > 0 ? args[0] : scriptContext->GetLibrary()->GetNull(),
-            args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetNull(),
+            args[0],
+            args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetUndefined(),
             args.IsNewCall()
         };
 
@@ -431,8 +432,8 @@ namespace Js
             TTD::NSLogEvents::EventLogEntry* callEvent = elog->RecordExternalCallEvent(externalFunction, scriptContext->GetThreadContext()->TTDRootNestingCount, args.Info.Count, args.Values, true);
 
             StdCallJavascriptMethodInfo info = {
-                callInfo.Count > 0 ? args[0] : scriptContext->GetLibrary()->GetNull(),
-                args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetNull(),
+                args[0],
+                args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetUndefined(),
                 args.IsNewCall()
             };
 

--- a/lib/Runtime/Library/JavascriptExternalFunction.cpp
+++ b/lib/Runtime/Library/JavascriptExternalFunction.cpp
@@ -273,7 +273,13 @@ namespace Js
 
         ScriptContext * scriptContext = externalFunction->type->GetScriptContext();
         AnalysisAssert(scriptContext);
-        Var result = NULL;
+        Var result = nullptr;
+
+        StdCallJavascriptMethodInfo info = {
+            callInfo.Count > 0 ? args[0] : scriptContext->GetLibrary()->GetNull(),
+            args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetNull(),
+            args.IsNewCall()
+        };
 
 #if ENABLE_TTD
         if(scriptContext->ShouldPerformRecordOrReplayAction())
@@ -284,14 +290,14 @@ namespace Js
         {
             BEGIN_LEAVE_SCRIPT(scriptContext)
             {
-                result = externalFunction->stdCallNativeMethod(function, ((callInfo.Flags & CallFlags_New) != 0), args.Values, args.Info.Count, externalFunction->callbackState);
+                result = externalFunction->stdCallNativeMethod(function, args.Values, args.Info.Count, &info, externalFunction->callbackState);
             }
             END_LEAVE_SCRIPT(scriptContext);
         }
 #else
         BEGIN_LEAVE_SCRIPT(scriptContext)
         {
-            result = externalFunction->stdCallNativeMethod(function, ((callInfo.Flags & CallFlags_New) != 0), args.Values, args.Info.Count, externalFunction->callbackState);
+            result = externalFunction->stdCallNativeMethod(function, args.Values, args.Info.Count, &info, externalFunction->callbackState);
         }
         END_LEAVE_SCRIPT(scriptContext);
 #endif
@@ -424,9 +430,15 @@ namespace Js
             TTD::TTDNestingDepthAutoAdjuster logPopper(scriptContext->GetThreadContext());
             TTD::NSLogEvents::EventLogEntry* callEvent = elog->RecordExternalCallEvent(externalFunction, scriptContext->GetThreadContext()->TTDRootNestingCount, args.Info.Count, args.Values, true);
 
+            StdCallJavascriptMethodInfo info = {
+                callInfo.Count > 0 ? args[0] : scriptContext->GetLibrary()->GetNull(),
+                args.HasNewTarget() ? args.GetNewTarget() : args.IsNewCall() ? function : scriptContext->GetLibrary()->GetNull(),
+                args.IsNewCall()
+            };
+
             BEGIN_LEAVE_SCRIPT(scriptContext)
             {
-                result = externalFunction->stdCallNativeMethod(function, ((callInfo.Flags & CallFlags_New) != 0), args.Values, args.Info.Count, externalFunction->callbackState);
+                result = externalFunction->stdCallNativeMethod(function, args.Values, args.Info.Count, &info, externalFunction->callbackState);
             }
             END_LEAVE_SCRIPT(scriptContext);
 
@@ -436,7 +448,7 @@ namespace Js
         return result;
     }
 
-    Var __stdcall JavascriptExternalFunction::TTDReplayDummyExternalMethod(Js::Var callee, bool isConstructCall, Var *args, USHORT cargs, void *callbackState)
+    Var __stdcall JavascriptExternalFunction::TTDReplayDummyExternalMethod(Var callee, Var *args, USHORT cargs, StdCallJavascriptMethodInfo *info, void *callbackState)
     {
         JavascriptExternalFunction* externalFunction = static_cast<JavascriptExternalFunction*>(callee);
 

--- a/lib/Runtime/Library/JavascriptExternalFunction.h
+++ b/lib/Runtime/Library/JavascriptExternalFunction.h
@@ -8,7 +8,14 @@ typedef HRESULT(__cdecl *InitializeMethod)(Js::Var instance);
 
 namespace Js
 {
-    typedef Var (__stdcall *StdCallJavascriptMethod)(Var callee, bool isConstructCall, Var *args, USHORT cargs, void *callbackState);
+    struct StdCallJavascriptMethodInfo
+    {
+        Var thisArg;
+        Var newTargetArg;
+        bool isConstructCall;
+    };
+
+    typedef Var (__stdcall *StdCallJavascriptMethod)(Var callee, Var *args, USHORT cargs, StdCallJavascriptMethodInfo *info, void *callbackState);
     typedef int JavascriptTypeId;
 
     class JavascriptExternalFunction : public RuntimeFunction
@@ -96,7 +103,7 @@ namespace Js
         static Var HandleRecordReplayExternalFunction_Thunk(Js::JavascriptFunction* function, CallInfo& callInfo, Arguments& args, ScriptContext* scriptContext);
         static Var HandleRecordReplayExternalFunction_StdThunk(Js::RecyclableObject* function, CallInfo& callInfo, Arguments& args, ScriptContext* scriptContext);
 
-        static Var __stdcall TTDReplayDummyExternalMethod(Js::Var callee, bool isConstructCall, Var *args, USHORT cargs, void *callbackState);
+        static Var __stdcall TTDReplayDummyExternalMethod(Var callee, Var *args, USHORT cargs, StdCallJavascriptMethodInfo *info, void *callbackState);
 #endif
 
         friend class JavascriptLibrary;

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1091,6 +1091,7 @@ namespace Js
         JavascriptExternalFunction* CreateExternalFunction(ExternalMethod entryPointer, Var nameId, Var signature, UINT64 flags, bool isLengthAvailable = false);
         JavascriptExternalFunction* CreateStdCallExternalFunction(StdCallJavascriptMethod entryPointer, PropertyId nameId, void *callbackState);
         JavascriptExternalFunction* CreateStdCallExternalFunction(StdCallJavascriptMethod entryPointer, Var name, void *callbackState);
+
         JavascriptPromiseAsyncSpawnExecutorFunction* CreatePromiseAsyncSpawnExecutorFunction(JavascriptMethod entryPoint, JavascriptGenerator* generator, Var target);
         JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* CreatePromiseAsyncSpawnStepArgumentExecutorFunction(JavascriptMethod entryPoint, JavascriptGenerator* generator, Var argument, Var resolve = nullptr, Var reject = nullptr, bool isReject = false);
         JavascriptPromiseCapabilitiesExecutorFunction* CreatePromiseCapabilitiesExecutorFunction(JavascriptMethod entryPoint, JavascriptPromiseCapability* capability);


### PR DESCRIPTION
Existing `JsNativeFunction` callbacks have no concept of `new.target` and, as a consequence, native functions cannot be used as the base class for a derived class constructor in Javascript. An API like `JsGetNewTarget` doesen't make a lot of sense so we propose here a new type of callback which will be called with `new.target` directly.

`JsCreateEnhancedFunction` acts similarly to the way `JsCreateFunction` did but takes a `JsEnhancedNativeFunction` callback instead. This callback is called passing a struct (`JsNativeFunctionInfo` containing `new.target`, `this`, and `isConstructCall`) as well as ordinary `callee`, `arguments`, and `argumentsCount`.

To simplify `JavascriptExternalFunction` and handling of native callback functions in ChakraCore, I refactored `JsCreateFunction` to use a `JsEnhancedNativeFunction` wrapper function which forwards to the `JsNativeFunction` callback.

Add native unit tests where an enhanced function (`JavascriptExternalFunction`) is used as the base class for a Javascript derived class.

Fixes: #3762 
