### PR TITLE
Module : memory leak fix when the syntax error happens.

### DIFF
--- a/bin/ch/MessageQueue.h
+++ b/bin/ch/MessageQueue.h
@@ -102,6 +102,16 @@ public:
         }
     }
 
+    template <typename PredicateFn>
+    void RemoveAll(PredicateFn fn)
+    {
+        while (head != nullptr)
+        {
+            fn(head->data);
+            Remove(head);
+        }
+    }
+
     bool IsEmpty()
     {
         return head == nullptr;
@@ -229,10 +239,9 @@ public:
 
     void RemoveAll()
     {
-        m_queue.Remove([](const ListEntry& entry) { 
+        m_queue.RemoveAll([](const ListEntry& entry) { 
             MessageBase* msg = entry.message;
             delete msg;
-            return true;
         });
     }
 

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -1666,7 +1666,10 @@ JsErrorCode WScriptJsrt::NotifyModuleReadyCallback(_In_opt_ JsModuleRecord refer
             wprintf(_u("NotifyModuleReadyCallback(exception) %S\n"), fileName.GetString());
         }
 
-        PrintException(*fileName, JsErrorScriptException);
+        // No need to print - just consume the exception
+        JsValueRef exception;
+        ChakraRTInterface::JsGetAndClearException(&exception);
+        exception; // unused
     }
     else
     {

--- a/lib/Runtime/Library/JavascriptError.cpp
+++ b/lib/Runtime/Library/JavascriptError.cpp
@@ -831,6 +831,7 @@ namespace Js
         if (cse->ei.bstrDescription)
         {
             value = JavascriptString::NewCopySz(cse->ei.bstrDescription, scriptContext);
+            JavascriptOperators::OP_SetProperty(error, PropertyIds::description, value, scriptContext);
             JavascriptOperators::OP_SetProperty(error, PropertyIds::message, value, scriptContext);
         }
 

--- a/test/es6/module-bugfixes.js
+++ b/test/es6/module-bugfixes.js
@@ -42,6 +42,18 @@ var tests = [
             testRunner.LoadModule(functionBody, 'samethread');
         }
     },
+    {
+        name: "Memory leak test on syntax error",
+        body: function() {
+            try {
+                WScript.LoadModule('');
+                WScript.LoadModule('1');
+                WScript.LoadModule('const a = () -> {};');
+            } catch(e) {
+                // no-op
+            }
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
We were no removing modulerecord from MessageQueue when the exception happens - fixed that.
We were printing the exception in the notifymoduleready callback, which is not needed.
Populating the description field in the case of error, so that correct error will be propagated in the event of exception (sometime we use message field, other times description).
