### PR TITLE
PropertyRecord::Equals simplify and fix

### DIFF
--- a/lib/Runtime/Base/PropertyRecord.h
+++ b/lib/Runtime/Base/PropertyRecord.h
@@ -129,18 +129,7 @@ namespace Js
 
         bool Equals(JavascriptString * str) const
         {
-            PropertyString * propString = PropertyString::TryFromVar(str);
-            const PropertyRecord * propRecord = nullptr;
-            if (propString == nullptr)
-            {
-                LiteralStringWithPropertyStringPtr * lstr = LiteralStringWithPropertyStringPtr::TryFromVar(str);
-                propRecord = lstr->GetPropertyRecord();
-            }
-            else
-            {
-                propRecord = propString->GetPropertyRecord();
-            }
-
+            const PropertyRecord * propRecord = str->GetPropertyRecord();
 
             if (propRecord == nullptr)
             {

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -219,7 +219,8 @@
     <default>
       <files>wasmcctx.js</files>
       <compile-flags>-wasm -dbgbaseline:wasmcctx.js.dbg.baseline -InspectMaxStringLength:50</compile-flags>
-      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger</tags>
+      <!-- todo-xplat: Fix this! The test is flaky on XPLAT -->
+      <tags>exclude_jshost,exclude_win7,exclude_drt,exclude_snap,require_debugger,exclude_xplat</tags>
     </default>
   </test>
 <test>


### PR DESCRIPTION
Simplify the interface to latest and fix the case that `str` may not be LiteralStringWithPropertyStringPtr.

No perf regression / gain is expected since `LiteralStringWithPropertyStringPtr` case was using the default option of `dontLookupFromDictionary` == `false`