### PR TITLE
Increase timeout for moreProperties-enumeration

### DIFF
--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -174,6 +174,7 @@
       <files>moreProperties-enumeration.js</files>
       <baseline>moreProperties-enumeration.baseline</baseline>
       <tags>Slow</tags>
+      <timeout>600</timeout>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Reasons;
           1 ) WBSetBit is blocking
           2 ) WBVerifyBitIsSet loops take time
           3 ) (scheduler is not happy with 1)
           4 ) As a result, double/triple time on a shared CI machine (ie. https://github.com/CCRobot/TestResults/blob/20180112T050742DEBUG_FLG2_osx/TEST_STEP1_2.md )