### PR TITLE
Handle circular slot dependencies in Modules (fix #4482)

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -1144,6 +1144,11 @@ namespace Js
 
     uint SourceTextModuleRecord::GetLocalExportSlotIndexByExportName(PropertyId exportNameId)
     {
+        if(!this->WasDeclarationInitialized())//allow for circular imports that reference each other's functions
+        {
+            ModuleDeclarationInstantiation();
+        }
+        
         Assert(localSlotCount != 0);
         Assert(localExportSlots != nullptr);
         uint slotIndex = InvalidSlotIndex;
@@ -1160,6 +1165,11 @@ namespace Js
 
     uint SourceTextModuleRecord::GetLocalExportSlotIndexByLocalName(PropertyId localNameId)
     {
+        if(!this->WasDeclarationInitialized())//allow for circular imports that reference each other's functions
+        {
+            ModuleDeclarationInstantiation();
+        }
+        
         Assert(localSlotCount != 0 || localNameId == PropertyIds::star_);
         Assert(localExportSlots != nullptr);
         uint slotIndex = InvalidSlotIndex;

--- a/test/es6/module-4482-bug-dep1.js
+++ b/test/es6/module-4482-bug-dep1.js
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+import {Thing2} from "./module-4482-bug.js";
+
+export default function Thing1()
+{
+    Thing2();
+}

--- a/test/es6/module-4482-bug-dep2.js
+++ b/test/es6/module-4482-bug-dep2.js
@@ -1,0 +1,11 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+import {Thing1} from "./module-4482-bug.js";
+
+export default function Thing2()
+{
+}

--- a/test/es6/module-4482-bug.js
+++ b/test/es6/module-4482-bug.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+import Thing1 from './module-4482-bug-dep1.js';
+import Thing2 from './module-4482-bug-dep2.js';
+
+export { Thing1, Thing2 };
+
+export default function main()
+{
+    Thing1();
+    Thing2();
+}

--- a/test/es6/module-functionality.js
+++ b/test/es6/module-functionality.js
@@ -292,6 +292,14 @@ var tests = [
         }
     },
     {
+        name:"Inter-related circular dependencies",
+        body: function () {
+            let functionBody =
+                `import './module-4482-bug.js';`;
+            testModuleScript(functionBody);
+        }
+    },
+    {
         name: "Implicitly re-exporting an import binding (import { foo } from ''; export { foo };)",
         body: function () {
             let functionBody =


### PR DESCRIPTION
Fixes #4482 and adds the POC of that bug as a test case.

Notes:
1. #4482 is mis-titled - it was a coincidence that the debugger was attached when the error was first noticed
2. The issue is when there is a circular dependency in export slots between modules
3. Not sure if this is the best fix but I couldn't see any other practical way to do it