### PR TITLE
disable timing out test on osx

### DIFF
--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -978,7 +978,7 @@
       <compile-flags>-testtrace:asmjs -args 14000 -endargs -EnableFatalErrorOnOOM-</compile-flags>
       <!-- todo:: On unix platforms there is more stack available,
            so we need to find the right limit to test in order to not timeout -->
-      <tags>exclude_dynapogo</tags>
+      <tags>exclude_dynapogo,exclude_mac</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
It's a slow test in general and the OSX machines are very slow so this is timing out.