### PR TITLE
use LocalFree for freeing JIT failure message

### DIFF
--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -151,7 +151,7 @@ JITManager::CreateBinding(
             FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                            NULL, errorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
             Output::Print(_u("Last error was 0x%x (%s)"), errorNumber, messageBuffer);
-            free(messageBuffer);
+            LocalFree(messageBuffer);
 #endif
             // wait operation failed for an unknown reason.
             Assert(false);


### PR DESCRIPTION
Per [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms679351(v=vs.85).aspx)

>The caller should use the LocalFree function to free the buffer when it is no longer needed.