### PR TITLE
disable test on jshost that uses wabt

### DIFF
--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -93,6 +93,7 @@
   <default>
     <files>divByConstants.js</files>
     <compile-flags>-wasm  </compile-flags>
+    <tags>exclude_jshost,exclude_win7</tags>
   </default>
 </test>
 <test>


### PR DESCRIPTION
jshost doesn't link against wabt, so we can't run tests that use wabt on jshost. wabt also doesn't build on old VS versions so we disable on legacy runs as well