### PR TITLE
Fixing the cross context behaviour in DebugEval

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionObject.h
+++ b/lib/Runtime/Language/JavascriptExceptionObject.h
@@ -17,6 +17,7 @@ namespace Js
         typedef Var (__stdcall *HostWrapperCreateFuncType)(Var var, ScriptContext * sourceScriptContext, ScriptContext * destScriptContext);
 
         JavascriptExceptionObject(Var object, ScriptContext * scriptContext, JavascriptExceptionContext* exceptionContextIn, bool isPendingExceptionObject = false) :
+            thrownObject(object),
             isPendingExceptionObject(isPendingExceptionObject),
             scriptContext(scriptContext), tag(true), 
 #ifdef ENABLE_SCRIPT_DEBUGGING
@@ -26,12 +27,6 @@ namespace Js
             hostWrapperCreateFunc(nullptr), isGeneratorReturnException(false),
             next(nullptr)
         {
-            if (object && RecyclableObject::Is(object) && CrossSite::NeedMarshalVar(object, scriptContext))
-            {
-                object = CrossSite::MarshalVar(scriptContext, object);
-            }
-            thrownObject = object;
-
             if (exceptionContextIn)
             {
                 exceptionContext = *exceptionContextIn;

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -556,7 +556,7 @@ namespace Js
     }
 
     Var GlobalObject::VEval(JavascriptLibrary* library, FrameDisplay* environment, ModuleID moduleID, bool strictMode, bool isIndirect,
-        Arguments& args, bool isLibraryCode, bool registerDocument, uint32 additionalGrfscr)
+        Arguments& args, bool isLibraryCode, bool registerDocument, uint32 additionalGrfscr, ScriptContext* debugEvalScriptContext)
     {
         Assert(library);
         ScriptContext* scriptContext = library->GetScriptContext();
@@ -596,7 +596,7 @@ namespace Js
 
         // PropertyString's buffer references to PropertyRecord's inline buffer, if both PropertyString and PropertyRecord are collected
         // we'll leave the PropertyRecord's interior buffer pointer in the EvalMap. So do not use evalmap if we are evaluating PropertyString
-        bool useEvalMap = !VirtualTableInfo<PropertyString>::HasVirtualTable(argString);
+        bool useEvalMap = !VirtualTableInfo<PropertyString>::HasVirtualTable(argString) && debugEvalScriptContext == nullptr; // Don't use the cache in case of debugEval
         bool found = useEvalMap && scriptContext->IsInEvalMap(key, isIndirect, &pfuncScript);
         if (!found || (!isIndirect && pfuncScript->GetEnvironment() != &NullFrameDisplay))
         {
@@ -609,6 +609,14 @@ namespace Js
 
             pfuncScript = library->GetGlobalObject()->EvalHelper(scriptContext, argString->GetSz(), argString->GetLength(), moduleID,
                 grfscr, Constants::EvalCode, doRegisterDocument, isIndirect, strictMode);
+
+            if (debugEvalScriptContext != nullptr && CrossSite::NeedMarshalVar(pfuncScript, debugEvalScriptContext))
+            {
+                // This is console scope scenario. DebugEval script context is on the top of the stack. But we are going
+                // to execute the user script from target script context. In order to fix the script context stack we
+                // need to marshall the function object.
+                pfuncScript = ScriptFunction::FromVar(CrossSite::MarshalVar(debugEvalScriptContext, pfuncScript));
+            }
 
             if (useEvalMap && !found)
             {

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -130,7 +130,7 @@ namespace Js
 
         static Var EntryEvalHelper(ScriptContext* scriptContext, RecyclableObject* function, Arguments& args);
         static Var VEval(JavascriptLibrary* library, FrameDisplay* environment, ModuleID moduleID, bool isStrictMode, bool isIndirect,
-            Arguments& args, bool isLibraryCode, bool registerDocument, uint32 additionalGrfscr);
+            Arguments& args, bool isLibraryCode, bool registerDocument, uint32 additionalGrfscr, ScriptContext* debugEvalScriptContext = nullptr);
 
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;


### PR DESCRIPTION
DebugEval method is invoked in debug eval script context. Then the string that user enters is executed in the target script context. The newly created function object belongs to target script context but the current top of the stack is pointing to the debug eval script context. We have to marshall the function object before invoking it to fix the stack.
