### PR TITLE
Loosen Globopt assert when called from HoistInvariantValueInfo

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -17177,7 +17177,7 @@ GlobOpt::HoistInvariantValueInfo(
         newValueInfo = invariantValueInfoToHoist->Copy(alloc);
         this->SetSymStoreDirect(newValueInfo, symStore);
     }
-    ChangeValueInfo(targetBlock, valueToUpdate, newValueInfo);
+    ChangeValueInfo(targetBlock, valueToUpdate, newValueInfo, true);
 }
 
 // static


### PR DESCRIPTION
Fixes OS#15189393

Example:
```
  invariantSym = ..[]; // non object value type

  landingPad :

  loopTop :

     = LdElem[invariantSym + ...] // non-object value type in first pass, object value type in second pass
     = LdFld[invariantSym...] // object value type

  loopEnd
```
  invariantSym is invariant in this loop, for some reason if we fail to hoist the LdFld, then assert saying valueInfos are incompatible will fire, when we try to hoist the LdElem.
  Because optimization of LdFld will force combine the valuetype of invariantSym with Object, and in the second pass while optimizing LdElem in HoistInvariantValueInfo,
  we will call ChangeValueInfo and this assert will fire.
  This is because we are trying to change a non-object valuetype to an object valuetype.
  AreValueTypesCompatible function converts to definite valuetypes before checking if they are compatible.
  The check doesn't care if both of them are likely.

  Globopt calls ChangeValueInfo with allowIncompatiblyTypes set to false in most cases where we are transforming specific to generic/generic to specific like Typespecialization etc.
  It calls ChangeValueInfo with allowIncompatiblyTypes set to true, where we can expect incompatible types ex: UpdateObjPtrValueInfo.

  This fix calls ChangeValueInfo from HoistInvariantValueInfo with allowIncompatiblyTypes set to true.
