### PR TITLE
Speed up property accesses using Symbols

### DIFF
--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -320,6 +320,7 @@ private:
     void            GenerateIsEnabledFloatArraySetElementFastPathCheck(IR::LabelInstr * isDisabledLabel, IR::Instr * const insertBeforeInstr);
     void            GenerateTypeIdCheck(Js::TypeId typeId, IR::RegOpnd * opnd, IR::LabelInstr * labelFail, IR::Instr * insertBeforeInstr, bool generateObjectCheck = true);
     void            GenerateStringTest(IR::RegOpnd *srcReg, IR::Instr *instrInsert, IR::LabelInstr * failLabel, IR::LabelInstr * succeedLabel = nullptr, bool generateObjectCheck = true);
+    void            GenerateSymbolTest(IR::RegOpnd *srcReg, IR::Instr *instrInsert, IR::LabelInstr * failLabel, IR::LabelInstr * succeedLabel = nullptr, bool generateObjectCheck = true);
     IR::RegOpnd *   GenerateUntagVar(IR::RegOpnd * opnd, IR::LabelInstr * labelFail, IR::Instr * insertBeforeInstr, bool generateTagCheck = true);
     void            GenerateNotZeroTest( IR::Opnd * opndSrc, IR::LabelInstr * labelZero, IR::Instr * instrInsert);
     IR::Opnd *      CreateOpndForSlotAccess(IR::Opnd * opnd);
@@ -421,6 +422,8 @@ private:
         bool * indirOpndOverflowed = nullptr);
 
     IR::IndirOpnd * GenerateFastElemIStringIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
+    IR::IndirOpnd * GenerateFastElemISymbolIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
+    IR::IndirOpnd * GenerateFastElemISymbolOrStringIndexCommon(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, const uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper);
     bool            GenerateFastLdElemI(IR::Instr *& ldElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastStElemI(IR::Instr *& StElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastLdLen(IR::Instr *ldLen, bool *instrIsInHelperBlockRef);

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -113,6 +113,12 @@ ServerScriptContext::GetStringTypeStaticAddr() const
 }
 
 intptr_t
+ServerScriptContext::GetSymbolTypeStaticAddr() const
+{
+    return m_contextData.symbolTypeStaticAddr;
+}
+
+intptr_t
 ServerScriptContext::GetObjectTypeAddr() const
 {
     return m_contextData.objectTypeAddr;

--- a/lib/Backend/ServerScriptContext.h
+++ b/lib/Backend/ServerScriptContext.h
@@ -29,6 +29,7 @@ public:
     virtual intptr_t GetNegativeZeroAddr() const override;
     virtual intptr_t GetNumberTypeStaticAddr() const override;
     virtual intptr_t GetStringTypeStaticAddr() const override;
+    virtual intptr_t GetSymbolTypeStaticAddr() const override;
     virtual intptr_t GetObjectTypeAddr() const override;
     virtual intptr_t GetObjectHeaderInlinedTypeAddr() const override;
     virtual intptr_t GetRegexTypeAddr() const override;

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -213,6 +213,7 @@ enum LibraryValue {
     ValueNegativeZero,
     ValueNumberTypeStatic,
     ValueStringTypeStatic,
+    ValueSymbolTypeStatic,
     ValueObjectType,
     ValueObjectHeaderInlinedType,
     ValueRegexType,

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -302,7 +302,7 @@ PHASE(All)
         PHASE(InlineCache)
         PHASE(PolymorphicInlineCache)
         PHASE(MissingPropertyCache)
-        PHASE(PropertyStringCache)
+        PHASE(PropertyCache) // Trace caching of property lookups using PropertyString and JavascriptSymbol
         PHASE(CloneCacheInCollision)
         PHASE(ConstructorCache)
         PHASE(InlineCandidate)
@@ -467,9 +467,9 @@ PHASE(All)
 #define DEFAULT_CONFIG_RecursiveInlineDepthMax      (8)      // Maximum inline depth for recursive calls
 #define DEFAULT_CONFIG_RecursiveInlineDepthMin      (2)      // Minimum inline depth for recursive call
 #define DEFAULT_CONFIG_InlineInLoopBodyScaleDownFactor    (4)
-#define DEFAULT_CONFIG_StringCacheMissPenalty (10)
-#define DEFAULT_CONFIG_StringCacheMissThreshold (-100)
-#define DEFAULT_CONFIG_StringCacheMissReset (-5000)
+#define DEFAULT_CONFIG_PropertyCacheMissPenalty (10)
+#define DEFAULT_CONFIG_PropertyCacheMissThreshold (-100)
+#define DEFAULT_CONFIG_PropertyCacheMissReset (-5000)
 
 #define DEFAULT_CONFIG_CloneInlinedPolymorphicCaches (true)
 #define DEFAULT_CONFIG_HighPrecisionDate    (false)
@@ -949,9 +949,9 @@ FLAGNR(Boolean, ConsoleExitPause      , "Pause on exit when a console window is 
 #endif
 FLAGNR(Number,  ConstructorInlineThreshold      , "Maximum size in bytecodes of a constructor inline candidate with monomorphic field access", DEFAULT_CONFIG_ConstructorInlineThreshold)
 FLAGNR(Number,  ConstructorCallsRequiredToFinalizeCachedType, "Number of calls to a constructor required before the type cached in the constructor cache is finalized", DEFAULT_CONFIG_ConstructorCallsRequiredToFinalizeCachedType)
-FLAGNR(Number,  StringCacheMissPenalty, "Number of string cache hits per miss needed to be worth using cache", DEFAULT_CONFIG_StringCacheMissPenalty)
-FLAGNR(Number,  StringCacheMissThreshold, "Point at which we disable string property cache", DEFAULT_CONFIG_StringCacheMissThreshold)
-FLAGNR(Number,  StringCacheMissReset, "Point at which we try to start using string cache after giving up", DEFAULT_CONFIG_StringCacheMissReset)
+FLAGNR(Number,  PropertyCacheMissPenalty, "Number of string or symbol cache hits per miss needed to be worth using cache", DEFAULT_CONFIG_PropertyCacheMissPenalty)
+FLAGNR(Number,  PropertyCacheMissThreshold, "Point at which we disable string or symbol property cache", DEFAULT_CONFIG_PropertyCacheMissThreshold)
+FLAGNR(Number,  PropertyCacheMissReset, "Point at which we try to start using string or symbol cache after giving up", DEFAULT_CONFIG_PropertyCacheMissReset)
 #ifdef SECURITY_TESTING
 FLAGNR(Boolean, CrashOnException      , "Removes the top-level exception handler, allowing jc.exe to crash on an unhandled exception.  No effect on IE. (default: false)", false)
 #endif

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -347,6 +347,7 @@ typedef struct ScriptContextDataIDL
     CHAKRA_PTR negativeZeroAddr;
     CHAKRA_PTR numberTypeStaticAddr;
     CHAKRA_PTR stringTypeStaticAddr;
+    CHAKRA_PTR symbolTypeStaticAddr;
     CHAKRA_PTR objectTypeAddr;
     CHAKRA_PTR objectHeaderInlinedTypeAddr;
     CHAKRA_PTR regexTypeAddr;

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -13,7 +13,6 @@
 #include "Common/ByteSwap.h"
 #include "Library/DataView.h"
 #include "Library/JavascriptExceptionMetadata.h"
-#include "Library/JavascriptSymbol.h"
 #include "Library/JavascriptPromise.h"
 #include "Base/ThreadContextTlsEntry.h"
 #include "Codex/Utf8Helper.h"
@@ -3315,7 +3314,7 @@ CHAKRA_API JsGetSymbolFromPropertyId(_In_ JsPropertyIdRef propertyId, _Out_ JsVa
             return JsErrorPropertyNotSymbol;
         }
 
-        *symbol = scriptContext->GetLibrary()->CreateSymbol(propertyRecord);
+        *symbol = scriptContext->GetSymbol(propertyRecord);
         return JsNoError;
     });
 }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -929,6 +929,12 @@ private:
 
         void InternalClose();
 
+        template <typename TProperty> void InvalidatePropertyCache(PropertyId propertyId, Type* type);
+        void InvalidatePropertyRecordUsageCache(PropertyRecordUsageCache* propertyRecordUsageCache, Type *type);
+        template <typename TProperty> TProperty* TryGetProperty(PropertyId propertyId);
+        template <typename TProperty> TProperty* GetProperty(PropertyId propertyId, const PropertyRecord* propertyRecord);
+        template <typename TProperty> TProperty* CreateAndCacheSymbolOrPropertyString(const PropertyRecord* propertyRecord);
+
     public:
 
 #ifdef LEAK_REPORT
@@ -1322,9 +1328,11 @@ private:
         void SetDisposeDisposeByFaultInjectionEventHandler(EventHandler eventHandler);
 #endif
         EnumeratedObjectCache* GetEnumeratedObjectCache() { return &(this->Cache()->enumObjCache); }
-        PropertyString* TryGetPropertyString(PropertyId propertyId);
         PropertyString* GetPropertyString(PropertyId propertyId);
-        void InvalidatePropertyStringCache(PropertyId propertyId, Type* type);
+        PropertyString* GetPropertyString(const PropertyRecord* propertyRecord);
+        JavascriptSymbol* GetSymbol(PropertyId propertyId);
+        JavascriptSymbol* GetSymbol(const PropertyRecord* propertyRecord);
+        void InvalidatePropertyStringAndSymbolCaches(PropertyId propertyId, Type* type);
         JavascriptString* GetIntegerString(Var aValue);
         JavascriptString* GetIntegerString(int value);
         JavascriptString* GetIntegerString(uint value);
@@ -1723,6 +1731,7 @@ private:
         virtual intptr_t GetNegativeZeroAddr() const override;
         virtual intptr_t GetNumberTypeStaticAddr() const override;
         virtual intptr_t GetStringTypeStaticAddr() const override;
+        virtual intptr_t GetSymbolTypeStaticAddr() const override;
         virtual intptr_t GetObjectTypeAddr() const override;
         virtual intptr_t GetObjectHeaderInlinedTypeAddr() const override;
         virtual intptr_t GetRegexTypeAddr() const override;

--- a/lib/Runtime/Base/ScriptContextInfo.h
+++ b/lib/Runtime/Base/ScriptContextInfo.h
@@ -17,6 +17,7 @@ public:
     virtual intptr_t GetNegativeZeroAddr() const = 0;
     virtual intptr_t GetNumberTypeStaticAddr() const = 0;
     virtual intptr_t GetStringTypeStaticAddr() const = 0;
+    virtual intptr_t GetSymbolTypeStaticAddr() const = 0;
     virtual intptr_t GetObjectTypeAddr() const = 0;
     virtual intptr_t GetObjectHeaderInlinedTypeAddr() const = 0;
     virtual intptr_t GetRegexTypeAddr() const = 0;

--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -434,7 +434,7 @@ namespace Js
             // Don't resize a polymorphic inline cache from full JIT because it currently doesn't rejit to use the new
             // polymorphic inline cache. Once resized, bailouts would populate only the new set of caches and full JIT would
             // continue to use to old set of caches.
-            Assert(!info->AllowResizingPolymorphicInlineCache() || info->GetFunctionBody() || info->GetPropertyString());
+            Assert(!info->AllowResizingPolymorphicInlineCache() || info->GetFunctionBody() || info->GetPropertyRecordUsageCache());
             if(((includeTypePropertyCache && !createTypePropertyCache) || info->AllowResizingPolymorphicInlineCache()) &&
                 polymorphicInlineCache->HasDifferentType<IsAccessor>(isProto, type, typeWithoutProperty))
             {
@@ -450,7 +450,7 @@ namespace Js
                     else
                     {
                         Assert(!info->GetFunctionBody());
-                        polymorphicInlineCache = info->GetPropertyString()->CreateBiggerPolymorphicInlineCache(IsRead);
+                        polymorphicInlineCache = info->GetPropertyRecordUsageCache()->CreateBiggerPolymorphicInlineCache(IsRead);
                     }
                 }
                 if(includeTypePropertyCache)

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -1116,10 +1116,6 @@ namespace Js
             GetSize()
         );
     }
-    ScriptContext* FunctionBodyPolymorphicInlineCache::GetScriptContext() const
-    {
-        return this->functionBody->GetScriptContext();
-    }
 
     void ScriptContextPolymorphicInlineCache::PrintStats(InlineCacheData *data) const
     {
@@ -1135,12 +1131,17 @@ namespace Js
             GetSize()
         );
     }
+#endif
+
+    ScriptContext* FunctionBodyPolymorphicInlineCache::GetScriptContext() const
+    {
+        return this->functionBody->GetScriptContext();
+    }
 
     ScriptContext* ScriptContextPolymorphicInlineCache::GetScriptContext() const
     {
         return this->javascriptLibrary->scriptContext;
     }
-#endif
 
     void IsInstInlineCache::Set(Type * instanceType, JavascriptFunction * function, JavascriptBoolean * result)
     {

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -499,8 +499,8 @@ namespace Js
 
 #ifdef INLINE_CACHE_STATS
         virtual void PrintStats(InlineCacheData *data) const = 0;
-        virtual ScriptContext* GetScriptContext() const = 0;
 #endif
+        virtual ScriptContext* GetScriptContext() const = 0;
 
         static uint32 GetOffsetOfSize() { return offsetof(Js::PolymorphicInlineCache, size); }
         static uint32 GetOffsetOfInlineCaches() { return offsetof(Js::PolymorphicInlineCache, inlineCaches); }
@@ -565,8 +565,8 @@ namespace Js
 
 #ifdef INLINE_CACHE_STATS
         virtual void PrintStats(InlineCacheData *data) const override;
-        virtual ScriptContext* GetScriptContext() const override;
 #endif
+        virtual ScriptContext* GetScriptContext() const override;
 
         virtual void Finalize(bool isShutdown) override;
     };
@@ -588,8 +588,8 @@ namespace Js
 
 #ifdef INLINE_CACHE_STATS
         virtual void PrintStats(InlineCacheData *data) const override;
-        virtual ScriptContext* GetScriptContext() const override;
 #endif
+        virtual ScriptContext* GetScriptContext() const override;
 
         virtual void Finalize(bool isShutdown) override;
     };

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -381,7 +381,7 @@ CommonNumber:
             {
                 JavascriptSymbolObject* symbolObject = JavascriptSymbolObject::UnsafeFromVar(aValue);
 
-                return requestContext->GetLibrary()->CreateSymbol(symbolObject->GetValue());
+                return CrossSite::MarshalVar(requestContext, symbolObject->Unwrap(), symbolObject->GetScriptContext());
             }
 
         case TypeIds_Date:

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -687,6 +687,8 @@ namespace Js
         template <typename T>
         static BOOL OP_GetElementI_ArrayFastPath(T * arr, int indexInt, Var * result, ScriptContext * scriptContext);
 
+        static Var JavascriptOperators::GetElementIWithCache(Var instance, RecyclableObject* index, PropertyRecordUsageCache* propertyRecordUsageCache, ScriptContext* scriptContext);
+
         static ImplicitCallFlags  CacheAndClearImplicitBit(ScriptContext* scriptContext);
 
         static ImplicitCallFlags CheckAndUpdateFunctionBodyWithImplicitFlag(FunctionBody* functionBody);

--- a/lib/Runtime/Language/RuntimeLanguagePch.h
+++ b/lib/Runtime/Language/RuntimeLanguagePch.h
@@ -34,7 +34,6 @@
 #include "Types/TypePropertyCache.h"
 #include "Library/JavascriptVariantDate.h"
 #include "Library/JavascriptProxy.h"
-#include "Library/JavascriptSymbol.h"
 #include "Library/JavascriptSymbolObject.h"
 #include "Library/JavascriptGenerator.h"
 #include "Library/StackScriptFunction.h"

--- a/lib/Runtime/Library/CMakeLists.txt
+++ b/lib/Runtime/Library/CMakeLists.txt
@@ -110,6 +110,7 @@ set(CRLIB_SOURCE_CODES
     ModuleRoot.cpp
     ObjectPrototypeObject.cpp
     ProfileString.cpp
+    PropertyRecordUsageCache.cpp
     PropertyString.cpp
     RegexHelper.cpp
     RootObjectBase.cpp

--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JSONStringBuilder.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JSONStringifier.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LazyJSONString.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)PropertyRecordUsageCache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\DetachedStateBase.h" />
@@ -179,6 +180,7 @@
     <ClInclude Include="..\RuntimeCommon.h" />
     <ClInclude Include="..\SerializableFunctionFields.h" />
     <ClInclude Include="AtomicsObject.h" />
+    <ClInclude Include="PropertyRecordUsageCache.h" />
     <ClInclude Include="CustomExternalIterator.h" />
     <ClInclude Include="JsBuiltInEngineInterfaceExtensionObject.h" />
     <ClInclude Include="JsBuiltIn\JsBuiltIn.js.bc.32b.h" />

--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj.filters
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj.filters
@@ -124,6 +124,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JsBuiltInEngineInterfaceExtensionObject.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LazyJSONString.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JSONStringifier.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JSONStringBuilder.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)PropertyRecordUsageCache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\InternalPropertyList.h" />
@@ -270,6 +272,7 @@
     <ClInclude Include="JsBuiltIn\JsBuiltIn.js.bc.64b.h" />
     <ClInclude Include="JsBuiltIn\JsBuiltIn.js.nojit.bc.32b.h" />
     <ClInclude Include="JsBuiltIn\JsBuiltIn.js.nojit.bc.64b.h" />
+    <ClInclude Include="PropertyRecordUsageCache.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ConcatString.inl" />

--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -271,7 +271,7 @@ JSONStringifier::ToJSON(_In_ JavascriptString* key, _In_ RecyclableObject* value
     Var toJSON = nullptr;
     PolymorphicInlineCache* cache = this->scriptContext->Cache()->toJSONCache;
     PropertyValueInfo info;
-    PropertyValueInfo::SetCacheInfo(&info, nullptr, cache, false);
+    PropertyValueInfo::SetCacheInfo(&info, cache, false);
     if (!CacheOperators::TryGetProperty<
         true,   // CheckLocal
         true,   // CheckProto

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -397,6 +397,7 @@ namespace Js
         Field(DynamicObject*) missingPropertyHolder;
         Field(StaticType*) throwErrorObjectType;
         Field(PropertyStringCacheMap*) propertyStringMap;
+        Field(SymbolCacheMap*) symbolMap;
         Field(ConstructorCache*) builtInConstructorCache;
 
         Field(DynamicObject*) chakraLibraryObject;
@@ -579,6 +580,7 @@ namespace Js
             inProfileMode(false),
             inDispatchProfileMode(false),
             propertyStringMap(nullptr),
+            symbolMap(nullptr),
             parseIntFunctionObject(nullptr),
             evalFunctionObject(nullptr),
             parseFloatFunctionObject(nullptr),
@@ -1231,7 +1233,11 @@ namespace Js
 #endif
 
         PropertyStringCacheMap* EnsurePropertyStringMap();
-        PropertyStringCacheMap* GetPropertyStringMap() { return this->propertyStringMap; }
+        SymbolCacheMap* EnsureSymbolMap();
+
+        template <typename TProperty> WeakPropertyIdMap<TProperty>* GetPropertyMap();
+        template <> PropertyStringCacheMap* GetPropertyMap<PropertyString>() { return this->propertyStringMap; }
+        template <> SymbolCacheMap* GetPropertyMap<JavascriptSymbol>() { return this->symbolMap; }
 
         void TypeAndPrototypesAreEnsuredToHaveOnlyWritableDataProperties(Type *const type);
         void NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -362,7 +362,7 @@ namespace Js
         PropertyValueInfo info;
         // We don't allow cache resizing, at least for the moment: it's more work, and since there's only one
         // cache per script context, we can afford to create each cache with the maximum size.
-        PropertyValueInfo::SetCacheInfo(&info, nullptr, cache, false);
+        PropertyValueInfo::SetCacheInfo(&info, cache, false);
         Var value;
         if (CacheOperators::TryGetProperty<
             true,                                       // CheckLocal
@@ -1189,7 +1189,7 @@ namespace Js
 
                     if (propertyRecord->IsSymbol())
                     {
-                        symbol = scriptContext->GetLibrary()->CreateSymbol(propertyRecord);
+                        symbol = scriptContext->GetSymbol(propertyRecord);
                         // no need to marshal symbol because it is created from scriptContext
                         newArrForSymbols->DirectSetItemAt(symbolIndex++, symbol);
                         continue;
@@ -1997,7 +1997,7 @@ namespace Js
                 // Also, if the object's type has not changed, we need to ensure that
                 // the cached property string for this property, if any, does not
                 // specify this object's type.
-                scriptContext->InvalidatePropertyStringCache(propId, obj->GetType());
+                scriptContext->InvalidatePropertyStringAndSymbolCaches(propId, obj->GetType());
             }
         }
 

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1969,11 +1969,11 @@ namespace Js
         Var name;
         if (propertyRecord->IsSymbol())
         {
-            name = requestContext->GetLibrary()->CreateSymbol(propertyRecord);
+            name = requestContext->GetSymbol(propertyRecord);
         }
         else
         {
-            name = requestContext->GetLibrary()->CreatePropertyString(propertyRecord);
+            name = requestContext->GetPropertyString(propertyRecord);
         }
         return name;
     }

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -6,6 +6,11 @@
 
 namespace Js
 {
+    PropertyRecordUsageCache * JavascriptSymbol::GetPropertyRecordUsageCache()
+    {
+        return &this->propertyRecordUsageCache;
+    }
+
     bool JavascriptSymbol::Is(Var aValue)
     {
         return JavascriptOperators::GetTypeId(aValue) == TypeIds_Symbol;
@@ -74,7 +79,8 @@ namespace Js
         }
         else if (JavascriptSymbolObject::Is(args[0]))
         {
-            return scriptContext->GetLibrary()->CreateSymbol(JavascriptSymbolObject::FromVar(args[0])->GetValue());
+            JavascriptSymbolObject* obj = JavascriptSymbolObject::FromVar(args[0]);
+            return CrossSite::MarshalVar(scriptContext, obj->Unwrap(), obj->GetScriptContext());
         }
         else
         {
@@ -149,7 +155,7 @@ namespace Js
 
         Assert(propertyRecord != nullptr);
 
-        return library->CreateSymbol(propertyRecord);
+        return scriptContext->GetSymbol(propertyRecord);
     }
 
     // Symbol.keyFor as described in ES 2015
@@ -206,7 +212,8 @@ namespace Js
         }
         else if (JavascriptSymbolObject::Is(args[0]))
         {
-            return scriptContext->GetLibrary()->CreateSymbol(JavascriptSymbolObject::FromVar(args[0])->GetValue());
+            JavascriptSymbolObject* obj = JavascriptSymbolObject::FromVar(args[0]);
+            return CrossSite::MarshalVar(scriptContext, obj->Unwrap(), obj->GetScriptContext());
         }
         else
         {
@@ -218,7 +225,7 @@ namespace Js
     {
         // PropertyRecords are per-ThreadContext so we can just create a new primitive wrapper
         // around the PropertyRecord stored in this symbol via the other context library.
-        return requestContext->GetLibrary()->CreateSymbol(this->GetValue());
+        return requestContext->GetSymbol(this->GetValue());
     }
 
     Var JavascriptSymbol::TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, int32 errorCode, PCWSTR varName)

--- a/lib/Runtime/Library/JavascriptSymbol.h
+++ b/lib/Runtime/Library/JavascriptSymbol.h
@@ -9,17 +9,24 @@ namespace Js
     class JavascriptSymbol sealed : public RecyclableObject
     {
     private:
-        Field(const PropertyRecord*) value;
+        Field(PropertyRecordUsageCache) propertyRecordUsageCache;
 
         DEFINE_VTABLE_CTOR(JavascriptSymbol, RecyclableObject);
+
     public:
-        JavascriptSymbol(const PropertyRecord* val, StaticType* type) : RecyclableObject(type), value(val)
+        JavascriptSymbol(const PropertyRecord* val, StaticType* type) :
+            RecyclableObject(type),
+            propertyRecordUsageCache(type, val)
         {
             Assert(type->GetTypeId() == TypeIds_Symbol);
         }
 
-        const PropertyRecord* GetValue() { return value; }
+        const PropertyRecord* GetValue() { return propertyRecordUsageCache.GetPropertyRecord(); }
+        PropertyRecordUsageCache * GetPropertyRecordUsageCache();
 
+        static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(JavascriptSymbol, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfLdElemInlineCache(); }
+        static uint32 GetOffsetOfStElemInlineCache() { return offsetof(JavascriptSymbol, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfStElemInlineCache(); }
+        static uint32 GetOffsetOfHitRate() { return offsetof(JavascriptSymbol, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfHitRate(); }
         static bool Is(Var aValue);
         static JavascriptSymbol* FromVar(Var aValue);
         static JavascriptSymbol* UnsafeFromVar(Var aValue);

--- a/lib/Runtime/Library/JavascriptSymbolObject.cpp
+++ b/lib/Runtime/Library/JavascriptSymbolObject.cpp
@@ -31,6 +31,11 @@ namespace Js
         return static_cast<JavascriptSymbolObject *>(aValue);
     }
 
+    Var JavascriptSymbolObject::Unwrap() const
+    {
+        return value;
+    }
+
     BOOL JavascriptSymbolObject::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
     {
         if (this->GetValue())

--- a/lib/Runtime/Library/JavascriptSymbolObject.h
+++ b/lib/Runtime/Library/JavascriptSymbolObject.h
@@ -29,6 +29,8 @@ namespace Js
             return value->GetValue();
         }
 
+        Var Unwrap() const;
+
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
 

--- a/lib/Runtime/Library/PropertyRecordUsageCache.cpp
+++ b/lib/Runtime/Library/PropertyRecordUsageCache.cpp
@@ -1,0 +1,134 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include "RuntimeLibraryPch.h"
+
+namespace Js
+{
+    PropertyRecordUsageCache::PropertyRecordUsageCache() :
+        propertyRecord(nullptr),
+        ldElemInlineCache(nullptr),
+        stElemInlineCache(nullptr),
+        hitRate(0)
+    {
+        // Required due to DEFINE_VTABLE_CTOR on parent, but useless
+    }
+
+    PropertyRecordUsageCache::PropertyRecordUsageCache(StaticType* type, const PropertyRecord* propertyRecord) :
+        propertyRecord(propertyRecord),
+        ldElemInlineCache(nullptr),
+        stElemInlineCache(nullptr),
+        hitRate(0)
+    {
+        // TODO: in future, might be worth putting these inline to avoid extra allocations. PIC copy API needs to be updated to support this though
+        this->ldElemInlineCache = ScriptContextPolymorphicInlineCache::New(MinPropertyStringInlineCacheSize, type->GetLibrary());
+        this->stElemInlineCache = ScriptContextPolymorphicInlineCache::New(MinPropertyStringInlineCacheSize, type->GetLibrary());
+    }
+
+    PolymorphicInlineCache* PropertyRecordUsageCache::GetLdElemInlineCache() const
+    {
+        return this->ldElemInlineCache;
+    }
+
+    PolymorphicInlineCache* PropertyRecordUsageCache::GetStElemInlineCache() const
+    {
+        return this->stElemInlineCache;
+    }
+
+    bool PropertyRecordUsageCache::ShouldUseCache() const
+    {
+        return this->hitRate > (int)CONFIG_FLAG(PropertyCacheMissThreshold);
+    }
+
+    bool PropertyRecordUsageCache::TrySetPropertyFromCache(
+        _In_ RecyclableObject *const object,
+        _In_ Var propertyValue,
+        _In_ ScriptContext *const requestContext,
+        const PropertyOperationFlags propertyOperationFlags,
+        _Inout_ PropertyValueInfo *const propertyValueInfo,
+        RecyclableObject *const owner /* Object that this usage cache is part of */)
+    {
+        if (ShouldUseCache())
+        {
+            PropertyValueInfo::SetCacheInfo(propertyValueInfo, owner, this, GetStElemInlineCache(), true /* allowResizing */);
+            bool found = CacheOperators::TrySetProperty<
+                true,   // CheckLocal
+                true,   // CheckLocalTypeWithoutProperty
+                true,   // CheckAccessor
+                true,   // CheckPolymorphicInlineCache
+                true,   // CheckTypePropertyCache
+                false,  // IsInlineCacheAvailable
+                true,   // IsPolymorphicInlineCacheAvailable
+                false>  // ReturnOperationInfo
+                    (object,
+                    false, // isRoot
+                    this->propertyRecord->GetPropertyId(),
+                    propertyValue,
+                    requestContext,
+                    propertyOperationFlags,
+                    nullptr, // operationInfo
+                    propertyValueInfo);
+
+            if (found)
+            {
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+                if (PHASE_TRACE1(PropertyCachePhase))
+                {
+                    Output::Print(_u("PropertyCache: SetElem cache hit for '%s': type %p\n"), GetString(), object->GetType());
+                }
+#endif
+                RegisterCacheHit();
+                return true;
+            }
+        }
+        RegisterCacheMiss();
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        if (PHASE_TRACE1(PropertyCachePhase))
+        {
+            Output::Print(_u("PropertyCache: SetElem cache miss for '%s': type %p, index %d\n"),
+                GetString(),
+                object->GetType(),
+                GetStElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
+            DumpCache(false);
+        }
+#endif
+        return false;
+    }
+
+    void PropertyRecordUsageCache::RegisterCacheMiss()
+    {
+        this->hitRate -= (int)CONFIG_FLAG(PropertyCacheMissPenalty);
+        if (this->hitRate < (int)CONFIG_FLAG(PropertyCacheMissReset))
+        {
+            this->hitRate = 0;
+        }
+    }
+
+    PolymorphicInlineCache * PropertyRecordUsageCache::CreateBiggerPolymorphicInlineCache(bool isLdElem)
+    {
+        PolymorphicInlineCache * polymorphicInlineCache = isLdElem ? GetLdElemInlineCache() : GetStElemInlineCache();
+        ScriptContext * scriptContext = polymorphicInlineCache->GetScriptContext();
+        Assert(polymorphicInlineCache && polymorphicInlineCache->CanAllocateBigger());
+        uint16 polymorphicInlineCacheSize = polymorphicInlineCache->GetSize();
+        uint16 newPolymorphicInlineCacheSize = PolymorphicInlineCache::GetNextSize(polymorphicInlineCacheSize);
+        Assert(newPolymorphicInlineCacheSize > polymorphicInlineCacheSize);
+        PolymorphicInlineCache * newPolymorphicInlineCache = ScriptContextPolymorphicInlineCache::New(newPolymorphicInlineCacheSize, scriptContext->GetLibrary());
+        polymorphicInlineCache->CopyTo(this->propertyRecord->GetPropertyId(), scriptContext, newPolymorphicInlineCache);
+        if (isLdElem)
+        {
+            this->ldElemInlineCache = newPolymorphicInlineCache;
+        }
+        else
+        {
+            this->stElemInlineCache = newPolymorphicInlineCache;
+        }
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        if (PHASE_VERBOSE_TRACE1(Js::PolymorphicInlineCachePhase) || PHASE_TRACE1(PropertyCachePhase))
+        {
+            Output::Print(_u("PropertyRecordUsageCache '%s' : Bigger PIC, oldSize = %d, newSize = %d\n"), GetString(), polymorphicInlineCacheSize, newPolymorphicInlineCacheSize);
+        }
+#endif
+        return newPolymorphicInlineCache;
+    }
+}

--- a/lib/Runtime/Library/PropertyRecordUsageCache.h
+++ b/lib/Runtime/Library/PropertyRecordUsageCache.h
@@ -1,0 +1,137 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+namespace Js
+{
+    // Keeps track of inline caches for loads and stores on the contained PropertyRecord.
+    // Used in PropertyString and JavascriptSymbol.
+    class PropertyRecordUsageCache sealed
+    {
+    private:
+        Field(const PropertyRecord*) propertyRecord;
+        Field(PolymorphicInlineCache*) ldElemInlineCache;
+        Field(PolymorphicInlineCache*) stElemInlineCache;
+        Field(int) hitRate;
+
+    public:
+        PropertyRecordUsageCache();
+        PropertyRecordUsageCache(StaticType* type, const PropertyRecord* propertyRecord);
+
+        const PropertyRecord* GetPropertyRecord() const { return propertyRecord; }
+
+        PolymorphicInlineCache* GetLdElemInlineCache() const;
+        PolymorphicInlineCache* GetStElemInlineCache() const;
+        PolymorphicInlineCache* CreateBiggerPolymorphicInlineCache(bool isLdElem);
+        void RegisterCacheMiss();
+        int GetHitRate() const { return this->hitRate; };
+        void RegisterCacheHit() { ++this->hitRate; };
+        bool ShouldUseCache() const;
+
+        static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyRecordUsageCache, ldElemInlineCache); }
+        static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyRecordUsageCache, stElemInlineCache); }
+        static uint32 GetOffsetOfHitRate() { return offsetof(PropertyRecordUsageCache, hitRate); }
+
+        bool TrySetPropertyFromCache(
+            _In_ RecyclableObject *const object,
+            _In_ Var propertyValue,
+            _In_ ScriptContext *const requestContext,
+            const PropertyOperationFlags propertyOperationFlags,
+            _Inout_ PropertyValueInfo *const propertyValueInfo,
+            RecyclableObject *const owner /* Object that this usage cache is part of */);
+
+
+        template <bool OwnPropertyOnly>
+        bool TryGetPropertyFromCache(
+            Var const instance,
+            RecyclableObject *const object,
+            Var *const propertyValue,
+            ScriptContext *const requestContext,
+            PropertyValueInfo *const propertyValueInfo,
+            RecyclableObject *const owner /* Object that this usage cache is part of */);
+
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+
+        const char16* GetString()
+        {
+            return propertyRecord->GetBuffer();
+        }
+
+    private:
+        void DumpCache(bool ldElemCache)
+        {
+            PolymorphicInlineCache * cache = ldElemCache ? GetLdElemInlineCache() : GetStElemInlineCache();
+            Output::Print(_u("PropertyCache HitRate: %i; types: "), this->hitRate);
+            for (uint i = 0; i < cache->GetSize(); ++i)
+            {
+                Output::Print(_u("%p,"), cache->GetInlineCaches()[i].GetType());
+            }
+            Output::Print(_u("\n"));
+        }
+#endif
+    };
+
+    template <bool OwnPropertyOnly> inline
+    bool PropertyRecordUsageCache::TryGetPropertyFromCache(
+        Var const instance,
+        RecyclableObject *const object,
+        Var *const propertyValue,
+        ScriptContext *const requestContext,
+        PropertyValueInfo *const propertyValueInfo,
+        RecyclableObject *const owner /* Object that this usage cache is part of */)
+    {
+        if (ShouldUseCache())
+        {
+            PropertyValueInfo::SetCacheInfo(propertyValueInfo, owner, this, GetLdElemInlineCache(), true /* allowResizing */);
+
+            // Some caches will look at prototype, so GetOwnProperty lookups must not check these
+            bool found = CacheOperators::TryGetProperty<
+                true,               // CheckLocal
+                !OwnPropertyOnly,   // CheckProto
+                !OwnPropertyOnly,   // CheckAccessor
+                !OwnPropertyOnly,   // CheckMissing
+                true,               // CheckPolymorphicInlineCache
+                !OwnPropertyOnly,   // CheckTypePropertyCache
+                false,              // IsInlineCacheAvailable
+                true,               // IsPolymorphicInlineCacheAvailable
+                false>              // ReturnOperationInfo
+                    (instance,
+                    false, // isRoot
+                    object,
+                    this->propertyRecord->GetPropertyId(),
+                    propertyValue,
+                    requestContext,
+                    nullptr, // operationInfo
+                    propertyValueInfo);
+
+            if (found)
+            {
+                RegisterCacheHit();
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+                if (PHASE_TRACE1(PropertyCachePhase))
+                {
+                    Output::Print(_u("PropertyCache: GetElem cache hit for '%s': type %p\n"),
+                        GetString(),
+                        object->GetType());
+                }
+#endif
+                return true;
+            }
+        }
+
+        RegisterCacheMiss();
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        if (PHASE_TRACE1(PropertyCachePhase))
+        {
+            Output::Print(_u("PropertyCache: GetElem cache miss for '%s': type %p, index %d\n"),
+                GetString(),
+                object->GetType(),
+                GetLdElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
+            DumpCache(true);
+        }
+#endif
+        return false;
+    }
+}

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -11,30 +11,28 @@ namespace Js
 
     PropertyString::PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord) :
         JavascriptString(type, propertyRecord->GetLength(), propertyRecord->GetBuffer()),
-        propertyRecord(propertyRecord),
-        ldElemInlineCache(nullptr),
-        stElemInlineCache(nullptr),
-        hitRate(0)
+        propertyRecordUsageCache(type, propertyRecord)
     {
     }
 
     PropertyString* PropertyString::New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler)
     {
-        PropertyString * propertyString = RecyclerNewZ(recycler, PropertyString, type, propertyRecord);
-        // TODO: in future, might be worth putting these inline to avoid extra allocations. PIC copy API needs to be updated to support this though
-        propertyString->ldElemInlineCache = ScriptContextPolymorphicInlineCache::New(MinPropertyStringInlineCacheSize, type->GetLibrary());
-        propertyString->stElemInlineCache = ScriptContextPolymorphicInlineCache::New(MinPropertyStringInlineCacheSize, type->GetLibrary());
-        return propertyString;
+        return RecyclerNewZ(recycler, PropertyString, type, propertyRecord);
     }
 
     PolymorphicInlineCache * PropertyString::GetLdElemInlineCache() const
     {
-        return this->ldElemInlineCache;
+        return this->propertyRecordUsageCache.GetLdElemInlineCache();
     }
 
     PolymorphicInlineCache * PropertyString::GetStElemInlineCache() const
     {
-        return this->stElemInlineCache;
+        return this->propertyRecordUsageCache.GetStElemInlineCache();
+    }
+
+    PropertyRecordUsageCache * PropertyString::GetPropertyRecordUsageCache()
+    {
+        return &this->propertyRecordUsageCache;
     }
 
     /* static */
@@ -49,15 +47,17 @@ namespace Js
         return RecyclableObject::Is(var) && PropertyString::Is(RecyclableObject::UnsafeFromVar(var));
     }
 
+    PropertyString* PropertyString::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'PropertyString'");
+
+        return static_cast<PropertyString *>(aValue);
+    }
+
     void const * PropertyString::GetOriginalStringReference()
     {
         // Property record is the allocation containing the string buffer
-        return this->propertyRecord;
-    }
-
-    bool PropertyString::ShouldUseCache() const
-    {
-        return this->hitRate > (int)CONFIG_FLAG(StringCacheMissThreshold);
+        return this->propertyRecordUsageCache.GetPropertyRecord();
     }
 
     bool PropertyString::TrySetPropertyFromCache(
@@ -67,90 +67,11 @@ namespace Js
         const PropertyOperationFlags propertyOperationFlags,
         _Inout_ PropertyValueInfo *const propertyValueInfo)
     {
-        if (ShouldUseCache())
-        {
-            PropertyValueInfo::SetCacheInfo(propertyValueInfo, this, GetStElemInlineCache(), true /* allowResizing */);
-            bool found = CacheOperators::TrySetProperty<
-                true,   // CheckLocal
-                true,   // CheckLocalTypeWithoutProperty
-                true,   // CheckAccessor
-                true,   // CheckPolymorphicInlineCache
-                true,   // CheckTypePropertyCache
-                false,  // IsInlineCacheAvailable
-                true,   // IsPolymorphicInlineCacheAvailable
-                false>  // ReturnOperationInfo
-                   (object,
-                    false, // isRoot
-                    this->propertyRecord->GetPropertyId(),
-                    propertyValue,
-                    requestContext,
-                    propertyOperationFlags,
-                    nullptr, // operationInfo
-                    propertyValueInfo);
-
-            if(found)
-            {
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                if (PHASE_TRACE1(PropertyStringCachePhase))
-                {
-                    Output::Print(_u("PropertyCache: SetElem cache hit for '%s': type %p\n"), GetString(), object->GetType());
-                }
-#endif
-                RegisterCacheHit();
-                return true;
-            }
-        }
-        RegisterCacheMiss();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-        if (PHASE_TRACE1(PropertyStringCachePhase))
-        {
-            Output::Print(_u("PropertyCache: SetElem cache miss for '%s': type %p, index %d\n"),
-                GetString(),
-                object->GetType(),
-                GetStElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
-            DumpCache(false);
-        }
-#endif
-        return false;
-    }
-
-    void PropertyString::RegisterCacheMiss()
-    {
-        this->hitRate -= (int)CONFIG_FLAG(StringCacheMissPenalty);
-        if (this->hitRate < (int)CONFIG_FLAG(StringCacheMissReset))
-        {
-            this->hitRate = 0;
-        }
+        return this->propertyRecordUsageCache.TrySetPropertyFromCache(object, propertyValue, requestContext, propertyOperationFlags, propertyValueInfo, this);
     }
 
     RecyclableObject * PropertyString::CloneToScriptContext(ScriptContext* requestContext)
     {
-        return requestContext->GetLibrary()->CreatePropertyString(this->propertyRecord);
-    }
-
-    PolymorphicInlineCache * PropertyString::CreateBiggerPolymorphicInlineCache(bool isLdElem)
-    {
-        PolymorphicInlineCache * polymorphicInlineCache = isLdElem ? GetLdElemInlineCache() : GetStElemInlineCache();
-        Assert(polymorphicInlineCache && polymorphicInlineCache->CanAllocateBigger());
-        uint16 polymorphicInlineCacheSize = polymorphicInlineCache->GetSize();
-        uint16 newPolymorphicInlineCacheSize = PolymorphicInlineCache::GetNextSize(polymorphicInlineCacheSize);
-        Assert(newPolymorphicInlineCacheSize > polymorphicInlineCacheSize);
-        PolymorphicInlineCache * newPolymorphicInlineCache = ScriptContextPolymorphicInlineCache::New(newPolymorphicInlineCacheSize, GetLibrary());
-        polymorphicInlineCache->CopyTo(this->propertyRecord->GetPropertyId(), GetScriptContext(), newPolymorphicInlineCache);
-        if (isLdElem)
-        {
-            this->ldElemInlineCache = newPolymorphicInlineCache;
-        }
-        else
-        {
-            this->stElemInlineCache = newPolymorphicInlineCache;
-        }
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-        if (PHASE_VERBOSE_TRACE1(Js::PolymorphicInlineCachePhase) || PHASE_TRACE1(PropertyStringCachePhase))
-        {
-            Output::Print(_u("PropertyString '%s' : Bigger PIC, oldSize = %d, newSize = %d\n"), GetString(), polymorphicInlineCacheSize, newPolymorphicInlineCacheSize);
-        }
-#endif
-        return newPolymorphicInlineCache;
+        return requestContext->GetPropertyString(this->propertyRecordUsageCache.GetPropertyRecord());
     }
 }

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -9,10 +9,7 @@ namespace Js
 class PropertyString : public JavascriptString
 {
 protected:
-    Field(int) hitRate;
-    Field(PolymorphicInlineCache*) ldElemInlineCache;
-    Field(PolymorphicInlineCache*) stElemInlineCache;
-    Field(const Js::PropertyRecord*) propertyRecord;
+    Field(PropertyRecordUsageCache) propertyRecordUsageCache;
 
     DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
 
@@ -20,16 +17,12 @@ protected:
 public:
     virtual Js::PropertyRecord const * GetPropertyRecord(bool dontLookupFromDictionary = false) override
     {
-        return this->propertyRecord;
+        return this->propertyRecordUsageCache.GetPropertyRecord();
     }
 
     PolymorphicInlineCache * GetLdElemInlineCache() const;
     PolymorphicInlineCache * GetStElemInlineCache() const;
-    PolymorphicInlineCache * CreateBiggerPolymorphicInlineCache(bool isLdElem);
-    void RegisterCacheMiss();
-    int GetHitRate() const { return this->hitRate; };
-    void RegisterCacheHit() { ++this->hitRate; };
-    bool ShouldUseCache() const;
+    PropertyRecordUsageCache * GetPropertyRecordUsageCache();
 
     bool TrySetPropertyFromCache(
         _In_ RecyclableObject *const object,
@@ -52,29 +45,18 @@ public:
     virtual void const * GetOriginalStringReference() override;
     virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
-    static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyString, ldElemInlineCache); }
-    static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyString, stElemInlineCache); }
-    static uint32 GetOffsetOfHitRate() { return offsetof(PropertyString, hitRate); }
+    static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyString, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfLdElemInlineCache(); }
+    static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyString, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfStElemInlineCache(); }
+    static uint32 GetOffsetOfHitRate() { return offsetof(PropertyString, propertyRecordUsageCache) + PropertyRecordUsageCache::GetOffsetOfHitRate(); }
     static bool Is(Var var);
     static bool Is(RecyclableObject * var);
 
     template <typename T> static PropertyString* TryFromVar(T var);
+    static PropertyString* UnsafeFromVar(Var aValue);
 
-#if ENABLE_DEBUG_CONFIG_OPTIONS
-    void DumpCache(bool ldElemCache)
-    {
-        PolymorphicInlineCache * cache = ldElemCache ? GetLdElemInlineCache() : GetStElemInlineCache();
-        Output::Print(_u("PropertyCache HitRate: %i; types: "), this->hitRate);
-        for (uint i = 0; i < cache->GetSize(); ++i)
-        {
-            Output::Print(_u("%p,"), cache->GetInlineCaches()[i].GetType());
-        }
-        Output::Print(_u("\n"));
-    }
-#endif
 #if ENABLE_TTD
     //Get the associated property id for this string if there is on (e.g. it is a propertystring otherwise return Js::PropertyIds::_none)
-    virtual Js::PropertyId TryGetAssociatedPropertyId() const override { return this->propertyRecord->GetPropertyId(); }
+    virtual Js::PropertyId TryGetAssociatedPropertyId() const override { return this->propertyRecordUsageCache.GetPropertyRecord()->GetPropertyId(); }
 #endif
 public:
     virtual VTableValue DummyVirtualFunctionToHinderLinkerICF()
@@ -103,55 +85,7 @@ bool PropertyString::TryGetPropertyFromCache(
     ScriptContext *const requestContext,
     PropertyValueInfo *const propertyValueInfo)
 {
-    if (ShouldUseCache())
-    {
-        PropertyValueInfo::SetCacheInfo(propertyValueInfo, this, GetLdElemInlineCache(), true /* allowResizing */);
-
-        // Some caches will look at prototype, so GetOwnProperty lookups must not check these
-        bool found = CacheOperators::TryGetProperty<
-            true,               // CheckLocal
-            !OwnPropertyOnly,   // CheckProto
-            !OwnPropertyOnly,   // CheckAccessor
-            !OwnPropertyOnly,   // CheckMissing
-            true,               // CheckPolymorphicInlineCache
-            !OwnPropertyOnly,   // CheckTypePropertyCache
-            false,              // IsInlineCacheAvailable
-            true,               // IsPolymorphicInlineCacheAvailable
-            false>              // ReturnOperationInfo
-            (instance,
-                false, // isRoot
-                object,
-                this->propertyRecord->GetPropertyId(),
-                propertyValue,
-                requestContext,
-                nullptr, // operationInfo
-                propertyValueInfo);
-
-        if (found)
-        {
-            RegisterCacheHit();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-            if (PHASE_TRACE1(PropertyStringCachePhase))
-            {
-                Output::Print(_u("PropertyCache: GetElem cache hit for '%s': type %p\n"), GetString(), object->GetType());
-            }
-#endif
-            return true;
-        }
-    }
-
-    RegisterCacheMiss();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    if (PHASE_TRACE1(PropertyStringCachePhase))
-    {
-        Output::Print(_u("PropertyCache: GetElem cache miss for '%s': type %p, index %d\n"),
-            GetString(),
-            object->GetType(),
-            GetLdElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
-        DumpCache(true);
-    }
-#endif
-    return false;
+    return this->propertyRecordUsageCache.TryGetPropertyFromCache<OwnPropertyOnly>(instance, object, propertyValue, requestContext, propertyValueInfo, this);
 }
 
 } // namespace Js

--- a/lib/Runtime/Library/RuntimeLibraryPch.h
+++ b/lib/Runtime/Library/RuntimeLibraryPch.h
@@ -39,7 +39,6 @@
 
 #include "Library/JavascriptVariantDate.h"
 #include "Library/JavascriptPromise.h"
-#include "Library/JavascriptSymbol.h"
 #include "Library/JavascriptSymbolObject.h"
 #include "Library/JavascriptProxy.h"
 #include "Library/JavascriptReflect.h"

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -143,6 +143,7 @@ namespace Js
     class StringCopyInfoStack;
     class ObjectPrototypeObject;
     class PropertyString;
+    class PropertyRecordUsageCache;
     class ArgumentsObject;
     class HeapArgumentsObject;
     class ActivationObject;
@@ -306,7 +307,9 @@ namespace Js
     class AsmJSByteCodeGenerator;
     enum AsmJSMathBuiltinFunction: int;
     //////////////////////////////////////////////////////////////////////////
-    typedef JsUtil::WeakReferenceDictionary<PropertyId, PropertyString, PrimeSizePolicy> PropertyStringCacheMap;
+    template <typename T> using WeakPropertyIdMap = JsUtil::WeakReferenceDictionary<PropertyId, T, PrimeSizePolicy>;
+    typedef WeakPropertyIdMap<PropertyString> PropertyStringCacheMap;
+    typedef WeakPropertyIdMap<JavascriptSymbol> SymbolCacheMap;
 
     extern const FrameDisplay NullFrameDisplay;
     extern const FrameDisplay StrictNullFrameDisplay;
@@ -513,6 +516,7 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Library/LiteralString.h"
 #include "Library/ConcatString.h"
 #include "Library/CompoundString.h"
+#include "Library/PropertyRecordUsageCache.h"
 #include "Library/PropertyString.h"
 #include "Library/SingleCharString.h"
 
@@ -520,6 +524,7 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Library/SparseArraySegment.h"
 #include "Library/JavascriptError.h"
 #include "Library/JavascriptArray.h"
+#include "Library/JavascriptSymbol.h"
 
 #include "Library/AtomicsObject.h"
 #include "DetachedStateBase.h"

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -255,12 +255,12 @@ namespace Js
             }
         } while (Js::IsInternalPropertyId(propertyId));
 
-        if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
+        if (info.GetPropertyRecordUsageCache() != nullptr && info.GetPropertyRecordUsageCache()->ShouldUseCache() && propertyString == info.GetProperty())
         {
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
             if ((!(this->flags & EnumeratorFlags::EphemeralReference)) && info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
             {
-                PropertyValueInfo::SetCacheInfo(&info, info.GetPropertyString(), info.GetPropertyString()->GetStElemInlineCache(), info.AllowResizingPolymorphicInlineCache());
+                PropertyValueInfo::SetCacheInfo(&info, info.GetPropertyRecordUsageCache()->GetStElemInlineCache(), info.AllowResizingPolymorphicInlineCache());
                 CacheOperators::CachePropertyWrite(this->object, false, this->object->GetType(), propertyId, &info, scriptContext);
             }
         }

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeTypePch.h"
-#include "Library/JavascriptSymbol.h"
 
 namespace Js
 {

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeTypePch.h"
-#include "Library/JavascriptSymbol.h"
 #include "Library/JavascriptSymbolObject.h"
 
 DEFINE_VALIDATE_HAS_VTABLE_CTOR(Js::RecyclableObject);
@@ -24,15 +23,30 @@ namespace Js
 
     void PropertyValueInfo::SetCacheInfo(
         _Out_ PropertyValueInfo* info,
-        _In_opt_ PropertyString *const propertyString,
+        _In_opt_ RecyclableObject * prop,
+        _In_opt_ PropertyRecordUsageCache *const propertyRecordUsageCache,
         _In_ PolymorphicInlineCache *const polymorphicInlineCache,
         bool allowResizing)
+    {
+        Assert(info);
+
+        // Make sure the given prop and usage cache match
+        Assert(
+            prop == nullptr && propertyRecordUsageCache == nullptr ||
+            JavascriptSymbol::Is(prop) && JavascriptSymbol::UnsafeFromVar(prop)->GetPropertyRecordUsageCache() == propertyRecordUsageCache ||
+            PropertyString::Is(prop) && PropertyString::UnsafeFromVar(prop)->GetPropertyRecordUsageCache() == propertyRecordUsageCache);
+
+        info->prop = prop;
+        info->propertyRecordUsageCache = propertyRecordUsageCache;
+        SetCacheInfo(info, polymorphicInlineCache, allowResizing);
+    }
+
+    void PropertyValueInfo::SetCacheInfo(_Out_ PropertyValueInfo* info, _In_ PolymorphicInlineCache *const polymorphicInlineCache, bool allowResizing)
     {
         Assert(info);
         Assert(polymorphicInlineCache);
 
         info->functionBody = nullptr;
-        info->propertyString = propertyString;
         info->inlineCache = nullptr;
         info->polymorphicInlineCache = polymorphicInlineCache;
         info->inlineCacheIndex = Js::Constants::NoInlineCacheIndex;
@@ -84,7 +98,8 @@ namespace Js
             info->functionBody = nullptr;
             info->inlineCache = nullptr;
             info->polymorphicInlineCache = nullptr;
-            info->propertyString = nullptr;
+            info->prop = nullptr;
+            info->propertyRecordUsageCache = nullptr;
             info->inlineCacheIndex = Constants::NoInlineCacheIndex;
             info->allowResizingPolymorphicInlineCache = true;
         }


### PR DESCRIPTION
This change puts a polymorphic inline cache on JavascriptSymbol so that it can act like PropertyString and cache information about loads and stores that use it. It also adds a cache mapping property IDs to JavascriptSymbol weak refs in ScriptContext, similar to the existing cache for PropertyStrings, and modifies existing code to not create new JavascriptSymbol instances unless necessary. When lowering a load or store with a likely symbol, we can emit code that is very similar to the fast path for strings.