### PR TITLE
Modules: Fix indirect circular children

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -842,11 +842,6 @@ namespace Js
                     Assert(childModuleRecord->WasParsed());
                     childModuleRecord->ModuleDeclarationInstantiation();
                 });
-
-                childrenModuleSet->EachValue([=](SourceTextModuleRecord* childModuleRecord)
-                {
-                    childModuleRecord->GenerateRootFunction();
-                });
             }
 
             ENTER_SCRIPT_IF(scriptContext, true, false, false, !scriptContext->GetThreadContext()->IsScriptActive(),
@@ -903,6 +898,13 @@ namespace Js
             scriptContext->GetDebugContext()->RegisterFunction(this->rootFunction->GetFunctionBody(), nullptr);
         }
 #endif
+        if (childrenModuleSet != nullptr)
+        {
+            childrenModuleSet->EachValue([=](SourceTextModuleRecord* childModuleRecord)
+            {
+                childModuleRecord->GenerateRootFunction();
+            });
+        }
     }
 
     Var SourceTextModuleRecord::ModuleEvaluation()

--- a/test/es6/module_4482_dep1.js
+++ b/test/es6/module_4482_dep1.js
@@ -13,11 +13,14 @@
 //v) Thing2 would not yet exist = segfault
 
 
-import Thing1 from './module_4482_dep2.js';
-import Thing2 from './module_4482_dep3.js';
+import Thing1 from 'module_4482_dep2.js';
+import Thing2 from 'module_4482_dep3.js';
 
 export { Thing1, Thing2 };
 
 export default
 function main()
-{}
+{
+	Thing1();
+	Thing2();
+}

--- a/test/es6/module_4482_dep2.js
+++ b/test/es6/module_4482_dep2.js
@@ -4,10 +4,10 @@
 //-------------------------------------------------------------------------------------------------------
 
 //thing1.js
-import { Thing2 } from './module_4482_dep1.js';
+import { Thing2 } from 'module_4482_dep1.js';
 
 export default
-function Thing1()
+function main()
 {
     Thing2();
 }

--- a/test/es6/module_4482_dep3.js
+++ b/test/es6/module_4482_dep3.js
@@ -4,7 +4,10 @@
 //-------------------------------------------------------------------------------------------------------
 
 
-import { Thing1 } from './module_4482_dep1.js';
+import { Thing1 } from 'module_4482_dep1.js';
 
 export default
-function Thing2(){}
+function main()
+{
+	Thing1();
+}


### PR DESCRIPTION
This re-fixes https://github.com/Microsoft/ChakraCore/issues/4482

Notes:
1. Test case was previously dependent on load order. Load order was changed which made the issue appear to be fixed (and test pass) when it wasn't actually fixed. - Test case revised to trigger issue irrespective of load order.
2. Have to complete all ModuleDeclarationInstantiation before we generate any root functions to ensure this issue can never occur.

Conscious the test case may need moving to fit with #4582 