### PR TITLE
Some small improvements on IO error message formatting

### DIFF
--- a/bin/NativeTests/FileLoadHelpers.cpp
+++ b/bin/NativeTests/FileLoadHelpers.cpp
@@ -28,7 +28,7 @@ HRESULT FileLoadHelpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, 
             char16 wszBuff[512];
             fprintf(stderr, "Error in opening file '%s' ", filename);
             wszBuff[0] = 0;
-            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                 nullptr,
                 lastError,
                 0,

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -213,7 +213,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UIN
             char16 wszBuff[MAX_URI_LENGTH];
             fprintf(stderr, "Error in opening file '%s' ", filename);
             wszBuff[0] = 0;
-            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                 nullptr,
                 lastError,
                 0,
@@ -417,7 +417,7 @@ HRESULT Helpers::LoadBinaryFile(LPCSTR filename, LPCSTR& contents, UINT& lengthB
             DWORD lastError = GetLastError();
             char16 wszBuff[MAX_URI_LENGTH];
             wszBuff[0] = 0;
-            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                 nullptr,
                 lastError,
                 0,
@@ -475,8 +475,9 @@ void Helpers::TTReportLastIOErrorAsNeeded(BOOL ok, const char* msg)
 #ifdef _WIN32
         DWORD lastError = GetLastError();
         LPTSTR pTemp = NULL;
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY, NULL, lastError, 0, (LPTSTR)&pTemp, 0, NULL);
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, lastError, 0, (LPTSTR)&pTemp, 0, NULL);
         fwprintf(stderr, _u("Error is: %s\n"), pTemp);
+        LocalFree(pTemp);
 #else
         fprintf(stderr, "Error is: %i %s\n", errno, strerror(errno));
 #endif
@@ -515,7 +516,7 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
     if(success != 0)
     {
         //we may fail because someone else created the directory -- that is ok
-        Helpers::TTReportLastIOErrorAsNeeded(errno != ENOENT, "Failed to create directory");
+        Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
 
     char realAsciiDir2[MAX_TTD_ASCII_PATH_EXT_LENGTH];
@@ -543,7 +544,7 @@ void Helpers::CreateTTDDirectoryAsNeeded(size_t* uriLength, char* uri, const cha
     if(success != 0)
     {
         //we may fail because someone else created the directory -- that is ok
-        Helpers::TTReportLastIOErrorAsNeeded(errno != ENOENT, "Failed to create directory");
+        Helpers::TTReportLastIOErrorAsNeeded(errno == EEXIST, "Failed to create directory");
     }
 }
 


### PR DESCRIPTION
1. Adds FORMAT_MESSAGE_IGNORE_INSERTS flag when we call FormatMessage(), so that if some IO error messages contain insert sequences, it won't crash the program due to null dereference.

2. If FormatMessage() is called with FORMAT_MESSAGE_ALLOCATE_BUFFER, we need to free the buffer. It doesn't really matter because the process exits immediately after printing the error, but it adds noise to analysis tools.

3. To check if TTDHostMKDir() succeeds, I think it's better to check if errno == EEXIST, because errno can have values other than EEXIST and ENOENT, such as EACCES (access denied).