### PR TITLE
Remove useless setParent call and related condition.

### DIFF
--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -27,10 +27,6 @@ JsInitializeModuleRecord(
         if (normalizedSpecifier != JS_INVALID_REFERENCE)
         {
             childModuleRecord->SetSpecifier(normalizedSpecifier);
-            if (Js::SourceTextModuleRecord::Is(referencingModule) && Js::JavascriptString::Is(normalizedSpecifier))
-            {
-                childModuleRecord->SetParent(Js::SourceTextModuleRecord::FromHost(referencingModule), Js::JavascriptString::FromVar(normalizedSpecifier)->GetSz());
-            }
         }
         return JsNoError;
     });


### PR DESCRIPTION
Follow up to issue: https://github.com/Microsoft/ChakraCore/issues/3638

The issue was already fixed by removing the unnecessary assert:
https://github.com/Microsoft/ChakraCore/pull/4548

But - it highlighted another small issue. The setParent call in JsrtCore is useless - it results in several operations all of which have no useful end result.

(No test case included as this doesn't fix a bug it just removes useless code)