### PR TITLE
osx: use clock_gettime when it's available

### DIFF
--- a/lib/Runtime/PlatformAgnostic/Platform/Common/HiResTimer.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/HiResTimer.cpp
@@ -15,7 +15,7 @@ namespace DateTime
     // This method is expected to return UTC time (See MSDN GetSystemTime)
     inline static double GetSystemTimeREAL()
     {
-#ifndef __APPLE__
+#ifdef HAVE_WORKING_CLOCK_GETTIME
         struct timespec fast_time;
         // method below returns UTC time. So, nothing else is needed
         // we use clock_gettime first due to expectation of better accuracy


### PR DESCRIPTION
Recent OSX distros have clock_gettime support. Use it when it's available (~3 times faster to what we do to replace that)