### PR TITLE
Fix data coming from inlinee that can cause incompatible valuetypes in the inliner

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -16781,7 +16781,7 @@ GlobOpt::HoistInvariantValueInfo(
         newValueInfo = invariantValueInfoToHoist->Copy(alloc);
         this->SetSymStoreDirect(newValueInfo, symStore);
     }
-    ChangeValueInfo(targetBlock, valueToUpdate, newValueInfo, true);
+    ChangeValueInfo(targetBlock, valueToUpdate, newValueInfo);
 }
 
 // static

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -3318,7 +3318,6 @@ GlobOpt::UpdateObjPtrValueType(IR::Opnd * opnd, IR::Instr * instr)
 
     if (!AreValueInfosCompatible(objVal->GetValueInfo(), newValueInfo))
     {
-        Assert(instr->m_func != this->func);
         return;
     }
     if (newValueType != ValueType::Uninitialized)

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -3312,8 +3312,17 @@ GlobOpt::UpdateObjPtrValueType(IR::Opnd * opnd, IR::Instr * instr)
             break;
         }
     }
+
+    ValueInfo *const newValueInfo = objVal->GetValueInfo()->CopyWithGenericStructureKind(alloc);
+    newValueInfo->Type() = newValueType;
+
+    if (!AreValueInfosCompatible(objVal->GetValueInfo(), newValueInfo))
+    {
+        Assert(instr->m_func != this->func);
+        return;
+    }
     if (newValueType != ValueType::Uninitialized)
     {
-        ChangeValueType(currentBlock, objVal, newValueType, false, true);
+        ChangeValueInfo(currentBlock, objVal, newValueInfo);
     }
 }

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -4835,6 +4835,7 @@ Inline::MapFormals(Func *inlinee,
         }
 
         case Js::OpCode::ArgIn_A:
+        {
             formalOpnd = instr->UnlinkSrc1()->AsSymOpnd();
             argIndex = formalOpnd->m_sym->AsStackSym()->GetParamSlotNum() - 1;
             if (argIndex >= formalCount)
@@ -4907,7 +4908,9 @@ Inline::MapFormals(Func *inlinee,
                 instr->GetSrc1()->SetValueType(ValueType::Undefined);
                 instr->m_opcode = Js::OpCode::Ld_A;
             }
-            break;
+            instr->GetDst()->SetValueType(ValueType::Uninitialized);
+        }
+        break;
 
         case Js::OpCode::ArgOut_A_FromStackArgs:
             {


### PR DESCRIPTION
When we build IR for the inlinee, the profile data of the inlinee is used to initialize the valuetypes of profiled instructions. When we map actuals to formals during inlining, we are in effect copying the value from the inliner to the inlinee via a Ld_A, we end up inaccurate value type here because we retain the value type that came from the inlinee profile data. In this fix, we reset it to ValueType::Uninitialized so that eventually the right valuetype will flow in.

Additionally in UpdateObjPtrValueType we read objTypeSpecFieldInfo and accordingly convert to a definite object. But this info can be incompatible with the rest of the function, when this info originally came from an inlinee, in this case allow the valueInfo as per the flowgraph to propagate.

Fixes OS#15189393