### PR TITLE
xplat: remove win64

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -788,7 +788,7 @@ Encoder::Encode()
         {
             __analysis_assume(m_instrNumber < instrCount);
             instr->DumpGlobOptInstrString();
-#ifdef _WIN64
+#ifdef TARGET_64
             Output::Print(_u("%12IX  "), m_offsetBuffer[m_instrNumber++] + (BYTE *)m_func->GetJITOutput()->GetCodeAddress());
 #else
             Output::Print(_u("%8IX  "), m_offsetBuffer[m_instrNumber++] + (BYTE *)m_func->GetJITOutput()->GetCodeAddress());

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -294,7 +294,7 @@
 #endif
 
 // ToDo (SaAgarwa): Disable VirtualTypedArray on ARM64 till we make sure it works correctly
-#if _WIN64 && !defined(_M_ARM64)
+#if defined(_WIN32) && defined(TARGET_64) && !defined(_M_ARM64)
 #define ENABLE_FAST_ARRAYBUFFER 1
 #endif
 #endif

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -332,11 +332,11 @@ typedef struct _SINGLE_LIST_ENTRY {
   struct _SINGLE_LIST_ENTRY *Next;
 } SINGLE_LIST_ENTRY, *PSINGLE_LIST_ENTRY;
 
-#if defined(_WIN64)
+#if defined(TARGET_64)
 
 //
 // The type SINGLE_LIST_ENTRY is not suitable for use with SLISTs.  For
-// WIN64, an entry on an SLIST is required to be 16-byte aligned, while a
+// TARGET_64, an entry on an SLIST is required to be 16-byte aligned, while a
 // SINGLE_LIST_ENTRY structure has only 8 byte alignment.
 //
 // Therefore, all SLIST code should use the SLIST_ENTRY type instead of the
@@ -352,11 +352,11 @@ typedef struct DECLSPEC_ALIGN(16) _SLIST_ENTRY {
 
 #pragma warning(pop)
 
-#else
+#else // defined(TARGET_64)
 
 typedef struct _SINGLE_LIST_ENTRY SLIST_ENTRY, *PSLIST_ENTRY;
 
-#endif // _WIN64
+#endif // defined(TARGET_64)
 
 #if defined(_AMD64_)
 

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -69,7 +69,7 @@ public:
 #ifdef STACK_ALIGN
     static DWORD const StackAlign = STACK_ALIGN;
 #else
-# if defined(_WIN64)
+# if defined(TARGET_64)
     static DWORD const StackAlign = 16;
 # elif defined(_M_ARM)
     static DWORD const StackAlign = 8;
@@ -84,7 +84,7 @@ public:
     UINT_PTR dllLoadAddress;
     UINT_PTR dllHighAddress;
 #endif
-    
+
 private:
     AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0), crtSize(0) { Initialize(); }
     void Initialize();

--- a/lib/Common/DataStructures/Comparer.h
+++ b/lib/Common/DataStructures/Comparer.h
@@ -65,7 +65,7 @@ struct DefaultComparer<size_t>
 
     inline static hash_t GetHashCode(size_t i)
     {
-#if _WIN64
+#ifdef TARGET_64
         // For 64 bits we want all 64 bits of the pointer to be represented in the hash code.
         uint32 hi = ((UINT_PTR) i >> 32);
         uint32 lo = (uint32) (i & 0xFFFFFFFF);

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -23,7 +23,7 @@ bool MarkContext::AddMarkedObject(void * objectAddress, size_t objectSize)
 
     MarkCandidate markCandidate;
 
-#if defined(_WIN64) && defined(_M_X64)
+#if defined(_WIN32) && defined(_M_X64)
     // Enabling store forwards. The intrinsic generates stores matching the load in size.
     // This enables skipping caches and forwarding the store data to the following load.
     *(__m128i *)&markCandidate = _mm_set_epi64x(objectSize, (__int64)objectAddress);
@@ -245,7 +245,7 @@ void MarkContext::ProcessMark()
             }
 #endif
         }
-        
+
         Assert(markStack.IsEmpty());
 
 #ifdef RECYCLER_VISITED_HOST

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -67,12 +67,12 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     VirtualQuery((LPCVOID)teb->StackLimit, &memInfo, sizeof(memInfo));
     Assert((char*)memInfo.AllocationBase == stackEnd);
     Assert(memInfo.AllocationProtect == PAGE_READWRITE);
-#endif
-#else
+#endif // DBG
+#else // defined(_WIN32) && defined(_M_X64) && !defined(_M_ARM64)
     ULONG_PTR stackBase = 0;
     ULONG_PTR stackEnd = 0;
     ::GetCurrentThreadStackLimits(&stackEnd, &stackBase);
-#endif
+#endif // defined(_WIN32) && defined(_M_X64) && !defined(_M_ARM64)
 
 #ifdef X64_WB_DIAG
     this->_stackbase = (char*)stackBase;

--- a/lib/Parser/errstr.cpp
+++ b/lib/Parser/errstr.cpp
@@ -94,7 +94,7 @@ static BOOL FGetStringFromLibrary(HMODULE hlib, int istring, __out_ecount(cchMax
 
 LError:
 
-#if !_WIN32 && !_WIN64
+#if !defined(_WIN32)
 
     //
     // Unlock/FreeResource non-essential on win32/64.
@@ -106,7 +106,7 @@ LError:
         FreeResource(hgl);
     }
 
-#endif
+#endif // !defined(_WIN32)
 #endif // ENABLE_GLOBALIZATION
     return fRet;
 }

--- a/lib/Parser/screrror.cpp
+++ b/lib/Parser/screrror.cpp
@@ -111,7 +111,7 @@ const MHR g_rgmhr[] =
     /*0x800401F5*/ MAPHR(CO_E_APPNOTFOUND, VBSERR_CantCreateObject),
     /*0x800401FE*/ MAPHR(CO_E_APPDIDNTREG, VBSERR_CantCreateObject),
 
-#if _WIN32 || _WIN64
+#if _WIN32
     // FACILITY_WIN32 errors
     /*0x80070005*/ MAPHR(E_ACCESSDENIED, VBSERR_PermissionDenied),
     /*0x8007000E*/ MAPHR(E_OUTOFMEMORY, VBSERR_OutOfMemory),
@@ -120,7 +120,7 @@ const MHR g_rgmhr[] =
 
     // FACILITY_WINDOWS
     /*0x80080005*/ MAPHR(CO_E_SERVER_EXEC_FAILURE, VBSERR_CantCreateObject),
-#endif // _WIN32 || _WIN64
+#endif // _WIN32
 };
 const int32 kcmhr = sizeof(g_rgmhr) / sizeof(g_rgmhr[0]);
 

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -166,7 +166,7 @@ namespace Js
         static int GetBufferOffset() { return offsetof(ArrayBuffer, buffer); }
 
         virtual void AddParent(ArrayBufferParent* parent) override;
-#if _WIN64
+#if defined(TARGET_64)
         //maximum 2G -1  for amd64
         static const uint32 MaxArrayBufferLength = 0x7FFFFFFF;
 #else

--- a/lib/Runtime/Library/SharedArrayBuffer.h
+++ b/lib/Runtime/Library/SharedArrayBuffer.h
@@ -42,7 +42,7 @@ namespace Js
 #if DBG
             , allowedAgents(nullptr)
 #endif
-        { 
+        {
         }
     };
 
@@ -89,7 +89,7 @@ namespace Js
         WaiterList *GetWaiterList(uint index);
         SharedContents *GetSharedContents() { return sharedContents; }
 
-#if _WIN64
+#if defined(TARGET_64)
         //maximum 2G -1  for amd64
         static const uint32 MaxSharedArrayBufferLength = 0x7FFFFFFF;
 #else


### PR DESCRIPTION
xplat was using some x86 codes / definitions for x64 due to win64 macro usage.
This PR fixes some of the slow test fails those we were experiencing recently on ccrobot.