### PR TITLE
OS#14763260: Correctly update RegExp.$1 after RegExp.prototype.test matches and used a cached value

### DIFF
--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -128,6 +128,11 @@ namespace Js
                 captures[groupId] = emptyString;
             reset = false;
         }
+        else
+        {
+            // If we are not resetting the values, the last match cannot be invalidated.
+            Assert(!invalidatedLastMatch);
+        }
     }
 
     /*static*/

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -76,7 +76,7 @@ namespace Js
         {
             ScriptContext* scriptContext = this->GetScriptContext();
             const CharCount lastInputLen = lastInput->GetLength();
-            const wchar_t* lastInputStr = lastInput->GetString();
+            const char16* lastInputStr = lastInput->GetString();
             UnifiedRegex::RegexPattern* pattern = lastPattern;
 
             // When we perform a regex test operation it's possible the result of the operation will be loaded from a cache and the match will not be computed and updated in the ctor.

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -59,8 +59,8 @@ namespace Js
 
         Field(UnifiedRegex::RegexPattern*) lastPattern;
         Field(JavascriptString*) lastInput;
-        Field(bool) invalidatedLastMatch; // true if last match must be recalculated before use
         Field(UnifiedRegex::GroupInfo) lastMatch;
+        Field(bool) invalidatedLastMatch; // true if last match must be recalculated before use
         Field(bool) reset; // true if following fields must be recalculated from above before first use
         Field(Var) lastParen;
         Field(Var) lastIndex;

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -53,11 +53,13 @@ namespace Js
         bool GetPropertyBuiltIns(PropertyId propertyId, Var* value, BOOL* result);
         bool SetPropertyBuiltIns(PropertyId propertyId, Var value, BOOL* result);
         void SetLastMatch(UnifiedRegex::RegexPattern* lastPattern, JavascriptString* lastInput, UnifiedRegex::GroupInfo lastMatch);
+        void InvalidateLastMatch(UnifiedRegex::RegexPattern* lastPattern, JavascriptString* lastInput);
 
         void EnsureValues();
 
         Field(UnifiedRegex::RegexPattern*) lastPattern;
         Field(JavascriptString*) lastInput;
+        Field(bool) invalidatedLastMatch; // true if last match must be recalculated before use
         Field(UnifiedRegex::GroupInfo) lastMatch;
         Field(bool) reset; // true if following fields must be recalculated from above before first use
         Field(Var) lastParen;

--- a/lib/Runtime/Library/RegexHelper.h
+++ b/lib/Runtime/Library/RegexHelper.h
@@ -58,6 +58,8 @@ namespace Js
             , UnifiedRegex::GroupInfo lastSuccessfulMatch
             , bool useSplitPattern );
 
+        static void InvalidateLastMatchOnCtor(ScriptContext* scriptContext, JavascriptRegExp* regularExpression, JavascriptString* lastInput, bool useSplitPattern = false);
+
         static bool GetInitialOffset(bool isGlobal, bool isSticky, JavascriptRegExp* regularExpression, CharCount inputLength, CharCount& offset);
         static JavascriptArray* CreateMatchResult(void *const stackAllocationPointer, ScriptContext* scriptContext, bool isGlobal, int numGroups, JavascriptString* input);
         static void FinalizeMatchResult(ScriptContext* scriptContext, bool isGlobal, JavascriptArray* arr, UnifiedRegex::GroupInfo match);

--- a/test/Regex/bug_OS14763260.js
+++ b/test/Regex/bug_OS14763260.js
@@ -12,13 +12,34 @@ var tests = [
         const r1 = /(abc)/;
         const r2 = /(def)/;
         const s1 = "abc";
-        const s2 = "def";
+        const s2 = " def";
          
         r1.test(s1);
+        
+        assert.areEqual("abc", RegExp.input, "RegExp.input property caclculated correctly");
+        assert.areEqual("abc", RegExp['$_'], "RegExp.$_ property caclculated correctly");
+        assert.areEqual("abc", RegExp.lastMatch, "RegExp.lastMatch property caclculated correctly");
+        assert.areEqual("abc", RegExp['$&'], "RegExp.$& property caclculated correctly");
+        assert.areEqual("abc", RegExp.$1, "RegExp.$1 property caclculated correctly");
+        assert.areEqual(0, RegExp.index, "RegExp.index property caclculated correctly");
+        
         r2.test(s2);
+        
+        assert.areEqual(" def", RegExp.input, "RegExp.input property caclculated correctly");
+        assert.areEqual(" def", RegExp['$_'], "RegExp.$_ property caclculated correctly");
+        assert.areEqual("def", RegExp.lastMatch, "RegExp.lastMatch property caclculated correctly");
+        assert.areEqual("def", RegExp['$&'], "RegExp.$& property caclculated correctly");
+        assert.areEqual("def", RegExp.$1, "RegExp.$1 property caclculated correctly");
+        assert.areEqual(1, RegExp.index, "RegExp.index property caclculated correctly");
+        
         r1.test(s1);
 
-        assert.areEqual("abc", RegExp.$1, "Stale last match should be invalidated by second r1.test(s1)");
+        assert.areEqual("abc", RegExp.input, "Stale RegExp.input property should be invalidated by second r1.test(s1)");
+        assert.areEqual("abc", RegExp['$_'], "Stale RegExp.$_ property should be invalidated by second r1.test(s1)");
+        assert.areEqual("abc", RegExp.lastMatch, "Stale RegExp.lastMatch should be invalidated by second r1.test(s1)");
+        assert.areEqual("abc", RegExp['$&'], "Stale RegExp.$& property should be invalidated by second r1.test(s1)");
+        assert.areEqual("abc", RegExp.$1, "Stale RegExp.$1 should be invalidated by second r1.test(s1)");
+        assert.areEqual(0, RegExp.index, "Stale RegExp.index property should be invalidated by second r1.test(s1)");
     }
   },
 ];

--- a/test/Regex/bug_OS14763260.js
+++ b/test/Regex/bug_OS14763260.js
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Verify last match invalidated as expected",
+    body: function () {
+        const r1 = /(abc)/;
+        const r2 = /(def)/;
+        const s1 = "abc";
+        const s2 = "def";
+         
+        r1.test(s1);
+        r2.test(s2);
+        r1.test(s1);
+
+        assert.areEqual("abc", RegExp.$1, "Stale last match should be invalidated by second r1.test(s1)");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Regex/bug_OS14763260.js
+++ b/test/Regex/bug_OS14763260.js
@@ -16,21 +16,21 @@ var tests = [
          
         r1.test(s1);
         
-        assert.areEqual("abc", RegExp.input, "RegExp.input property caclculated correctly");
-        assert.areEqual("abc", RegExp['$_'], "RegExp.$_ property caclculated correctly");
-        assert.areEqual("abc", RegExp.lastMatch, "RegExp.lastMatch property caclculated correctly");
-        assert.areEqual("abc", RegExp['$&'], "RegExp.$& property caclculated correctly");
-        assert.areEqual("abc", RegExp.$1, "RegExp.$1 property caclculated correctly");
-        assert.areEqual(0, RegExp.index, "RegExp.index property caclculated correctly");
+        assert.areEqual("abc", RegExp.input, "RegExp.input property calculated correctly");
+        assert.areEqual("abc", RegExp['$_'], "RegExp.$_ property calculated correctly");
+        assert.areEqual("abc", RegExp.lastMatch, "RegExp.lastMatch property calculated correctly");
+        assert.areEqual("abc", RegExp['$&'], "RegExp.$& property calculated correctly");
+        assert.areEqual("abc", RegExp.$1, "RegExp.$1 property calculated correctly");
+        assert.areEqual(0, RegExp.index, "RegExp.index property calculated correctly");
         
         r2.test(s2);
         
-        assert.areEqual(" def", RegExp.input, "RegExp.input property caclculated correctly");
-        assert.areEqual(" def", RegExp['$_'], "RegExp.$_ property caclculated correctly");
-        assert.areEqual("def", RegExp.lastMatch, "RegExp.lastMatch property caclculated correctly");
-        assert.areEqual("def", RegExp['$&'], "RegExp.$& property caclculated correctly");
-        assert.areEqual("def", RegExp.$1, "RegExp.$1 property caclculated correctly");
-        assert.areEqual(1, RegExp.index, "RegExp.index property caclculated correctly");
+        assert.areEqual(" def", RegExp.input, "RegExp.input property calculated correctly");
+        assert.areEqual(" def", RegExp['$_'], "RegExp.$_ property calculated correctly");
+        assert.areEqual("def", RegExp.lastMatch, "RegExp.lastMatch property calculated correctly");
+        assert.areEqual("def", RegExp['$&'], "RegExp.$& property calculated correctly");
+        assert.areEqual("def", RegExp.$1, "RegExp.$1 property calculated correctly");
+        assert.areEqual(1, RegExp.index, "RegExp.index property calculated correctly");
         
         r1.test(s1);
 

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -206,4 +206,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS14763260.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Regression from https://github.com/Microsoft/ChakraCore/pull/3802 - if we hit the cache, we don't update the Regex constructor object with the last match and so retrieving properties about the match from the regex constructor object fails.

Fixed by adding an invalidation mechanism to the `JavascriptRegExpConstructor`. If we hit the cache, we'll mark the Regex constructor object last match properties as invalidated and we will then compute them on-demand the first time they're needed.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14763260
