### PR TITLE
Allow getter functions to be inlined across source files

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7514,15 +7514,7 @@ namespace Js
 
     bool FunctionBody::CheckCalleeContextForInlining(FunctionProxy* calleeFunctionProxy)
     {
-        if (this->GetScriptContext() == calleeFunctionProxy->GetScriptContext())
-        {
-            if (this->GetHostSourceContext() == calleeFunctionProxy->GetHostSourceContext() &&
-                this->GetSecondaryHostSourceContext() == calleeFunctionProxy->GetSecondaryHostSourceContext())
-            {
-                return true;
-            }
-        }
-        return false;
+        return this->GetScriptContext() == calleeFunctionProxy->GetScriptContext();
     }
 
 #if ENABLE_NATIVE_CODEGEN

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -773,7 +773,7 @@ namespace Js
         Assert(functionBody);
         const auto callSiteCount = functionBody->GetProfiledCallSiteCount();
         Assert(callSiteId < callSiteCount);
-        Assert(functionBody->IsJsBuiltInCode() || HasCallSiteInfo(functionBody));
+        Assert(functionBody->IsJsBuiltInCode() || functionBody->IsPublicLibraryCode() || HasCallSiteInfo(functionBody));
         Assert(functionBodyArray);
         Assert(functionBodyArrayLength == DynamicProfileInfo::maxPolymorphicInliningSize);
 
@@ -864,7 +864,7 @@ namespace Js
         Assert(functionBody);
         const auto callSiteCount = functionBody->GetProfiledCallSiteCount();
         Assert(callSiteId < callSiteCount);
-        Assert(functionBody->IsJsBuiltInCode() || HasCallSiteInfo(functionBody));
+        Assert(functionBody->IsJsBuiltInCode() || functionBody->IsPublicLibraryCode() || HasCallSiteInfo(functionBody));
 
         *isConstructorCall = callSiteInfo[callSiteId].isConstructorCall;
         if (callSiteInfo[callSiteId].dontInline)
@@ -941,7 +941,7 @@ namespace Js
         Assert(functionBody);
         const auto callSiteCount = functionBody->GetProfiledCallSiteCount();
         Assert(callSiteId < callSiteCount);
-        Assert(functionBody->IsJsBuiltInCode() || HasCallSiteInfo(functionBody));
+        Assert(functionBody->IsJsBuiltInCode() || functionBody->IsPublicLibraryCode() || HasCallSiteInfo(functionBody));
 
         return callSiteInfo[callSiteId].ldFldInlineCacheId;
     }

--- a/test/bailout/inline_get_bailout.js
+++ b/test/bailout/inline_get_bailout.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+if (this.WScript && this.WScript.LoadScriptFile) {
+  WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+  WScript.LoadScriptFile("inline_get_bailout_helper.js");
+}
+
+let tests = [{
+  name: "after inlining a getter function from another source file, we should bail out if the input data changes",
+  body: function () {
+    const bar = new Bar();
+
+    function getWithGetter() {
+      return bar.data;
+    }
+
+    let sum = 0;
+    sum += getWithGetter();
+    sum += getWithGetter();
+
+    Object.defineProperty(bar, "data", { value: 3 });
+
+    sum += getWithGetter();
+
+    assert.areEqual(13, sum);
+  }
+}];
+
+testRunner.run(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/bailout/inline_get_bailout_helper.js
+++ b/test/bailout/inline_get_bailout_helper.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function Bar() {
+  this.foo = 5;
+}
+
+Object.defineProperty(Bar.prototype, "data", {
+  get: function () {
+      return this.foo;
+  },
+  set: function (v) {
+      this.foo = v;
+  },
+  configurable: true
+});

--- a/test/bailout/rlexe.xml
+++ b/test/bailout/rlexe.xml
@@ -249,6 +249,12 @@
   </test>
   <test>
     <default>
+      <files>inline_get_bailout.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>spill.js</files>
     </default>
   </test>


### PR DESCRIPTION
This change allows a cross-script getter call both to be flagged as an inline candidate from `DynamicProfileInfo::RecordLdFldCallSiteInfo` and to be selected for inlining in `NativeCodeGenerator::GatherCodeGenData`.

It also updates a few places to treat public library code like JS built-in code, since public library code uses `noContextSourceContextInfo` and therefore doesn't contain call-site info. This came up in some tests that were calling public library code such as the getter for `Collator.compare`, which was then attempting to recursively inline.