### PR TITLE
OS#13976524: Force scanner to create pid for string constant trailing defer-parsed compact-body lambda

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7153,7 +7153,13 @@ void Parser::ParseExpressionLambdaBody(ParseNodePtr pnodeLambda)
 
     IdentToken token;
     charcount_t lastRParen = 0;
+
+    // We need to disable deferred parse mode in the scanner because the lambda body doesn't end with a right paren.
+    // The scanner needs to create a pid in the case of a string constant token immediately following the lambda body expression.
+    // Otherwise, we'll save null for the string constant pid which will AV during ByteCode generation.
+    BYTE fScanDeferredFlagsSave = m_pscan->SetDeferredParse(FALSE);
     ParseNodePtr result = ParseExpr<buildAST>(koplAsg, nullptr, TRUE, FALSE, nullptr, nullptr, nullptr, &token, false, nullptr, &lastRParen);
+    m_pscan->SetDeferredParseFlags(fScanDeferredFlagsSave);
 
     this->MarkEscapingRef(result, &token);
 

--- a/test/es6/bug_OS13976524.js
+++ b/test/es6/bug_OS13976524.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Lambda with a string constant on the following line shouldn't AV",
+    body: function () {
+jtmchw => z
+'123'
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1407,6 +1407,13 @@
   </test>
   <test>
     <default>
+      <files>bug_OS13976524.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>DeferParseLambda.js</files>
       <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
Lambda with compact-body which is defer-parsed and which is trailed immediately by a string constant can cause the string constant to miss having a pid created. When we try to load the string constant table in `ByteCodeGenerator`, we'll hit an AV with this pid being nullptr.

Fix by forcing the scanner to create a pid for this string constant - only for the single case of a string constant token immediately following the single-expression lambda body which is defer-parsed.

Test case looks like this:
```
jtmchw => z
'123'
```

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=13976524
