### PR TITLE
OS#14568840: Remove 'this' binding for indirect eval

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1712,19 +1712,17 @@ ParseNodePtr Parser::CreateSpecialVarDeclIfNeeded(ParseNodePtr pnodeFnc, IdentPt
     return nullptr;
 }
 
-void Parser::CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGlobal)
+void Parser::CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc)
 {
     // Lambda function cannot have any special bindings.
     if (pnodeFnc->sxFnc.IsLambda())
     {
         return;
     }
-    Assert(!(isGlobal && (this->m_grfscr & fscrEval)));
-    Assert(!isGlobal || (this->m_grfscr & fscrEvalCode));
 
     bool isTopLevelEventHandler = (this->m_grfscr & fscrImplicitThis || this->m_grfscr & fscrImplicitParents) && !pnodeFnc->sxFnc.IsNested();
 
-    // Create a 'this' symbol for indirect eval, non-lambda functions with references to 'this', and all class constructors and top level event hanlders.
+    // Create a 'this' symbol for non-lambda functions with references to 'this', and all class constructors and top level event hanlders.
     ParseNodePtr varDeclNode = CreateSpecialVarDeclIfNeeded(pnodeFnc, wellKnownPropertyPids._this, pnodeFnc->sxFnc.IsClassConstructor() || isTopLevelEventHandler);
     if (varDeclNode)
     {
@@ -1734,12 +1732,6 @@ void Parser::CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGloba
         {
             varDeclNode->sxPid.sym->SetNeedDeclaration(true);
         }
-    }
-
-    // Global code cannot have 'new.target' or 'super' bindings.
-    if (isGlobal)
-    {
-        return;
     }
 
     // Create a 'new.target' symbol for any ordinary function with a reference and all class constructors.
@@ -5804,7 +5796,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
             UpdateArgumentsNode(pnodeFnc, argNode);
         }
 
-        CreateSpecialSymbolDeclarations(pnodeFnc, false);
+        CreateSpecialSymbolDeclarations(pnodeFnc);
 
         // Restore the lists of scopes that contain function expressions.
 
@@ -7126,7 +7118,7 @@ ParseNodePtr Parser::GenerateEmptyConstructor(bool extends)
 
     FinishParseBlock(pnodeInnerBlock);
 
-    CreateSpecialSymbolDeclarations(pnodeFnc, false);
+    CreateSpecialSymbolDeclarations(pnodeFnc);
 
     FinishParseBlock(pnodeBlock);
 
@@ -11446,7 +11438,7 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
                 UpdateArgumentsNode(pnodeFnc, argNode);
             }
 
-            CreateSpecialSymbolDeclarations(pnodeFnc, false);
+            CreateSpecialSymbolDeclarations(pnodeFnc);
 
             this->FinishParseBlock(pnodeBlock);
             if (pnodeFncExprBlock)
@@ -11851,12 +11843,6 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
 
     if (tkEOF != m_token.tk)
         Error(ERRsyntax);
-
-    // We only need to create special symbol bindings for 'this' for indirect eval
-    if ((this->m_grfscr & fscrEvalCode) && !(this->m_grfscr & fscrEval))
-    {
-        CreateSpecialSymbolDeclarations(pnodeProg, true);
-    }
 
     // Append an EndCode node.
     AddToNodeList(&pnodeProg->sxFnc.pnodeBody, &lastNodeRef,

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -768,7 +768,7 @@ private:
     void FinishParseFncExprScope(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncExprScope);
 
     bool IsSpecialName(IdentPtr pid);
-    void CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGlobal);
+    void CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc);
     ParseNodePtr ReferenceSpecialName(IdentPtr pid, charcount_t ichMin = 0, charcount_t ichLim = 0, bool createNode = false);
     ParseNodePtr CreateSpecialVarDeclIfNeeded(ParseNodePtr pnodeFnc, IdentPtr pid, bool forceCreate = false);
 

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -4917,13 +4917,13 @@ void ByteCodeGenerator::EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pno
     }
     else
     {
-    this->EmitPropLoad(lhsLocation, pnode->sxPid.sym, pnode->sxPid.pid, funcInfo, true);
+        this->EmitPropLoad(lhsLocation, pnode->sxPid.sym, pnode->sxPid.pid, funcInfo, true);
 
-    if ((!sym || sym->GetNeedDeclaration()) && chkUndecl)
-    {
-        this->Writer()->Reg1(Js::OpCode::ChkUndecl, lhsLocation);
+        if ((!sym || sym->GetNeedDeclaration()) && chkUndecl)
+        {
+            this->Writer()->Reg1(Js::OpCode::ChkUndecl, lhsLocation);
+        }
     }
-}
 }
 
 void ByteCodeGenerator::EmitPropStoreForSpecialSymbol(Js::RegSlot rhsLocation, Symbol *sym, IdentPtr pid, FuncInfo *funcInfo, bool init)

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -986,6 +986,19 @@ var tests = [
             assert.throws(() => WScript.LoadScript(`(class classExpr {}())`), TypeError, "Class expression called at global scope", "Class constructor cannot be called without the new keyword");
             assert.throws(() => WScript.LoadScript(`(() => (class classExpr {}()))()`), TypeError, "Class expression called in global lambda", "Class constructor cannot be called without the new keyword");
         }
+    },
+    {
+        name: "Indirect eval should not create a 'this' binding",
+        body: function() {
+            WScript.LoadScript(`
+                this.eval("(() => assert.areEqual('global', this.o, 'Lambda in indirect eval called off of this capturing this'))()");
+                this['eval']("(() => assert.areEqual('global', this.o, 'Lambda in indirect eval called from a property index capturing this'))()");
+                var _eval = 'eval';
+                this[_eval]("(() => assert.areEqual('global', this.o, 'Lambda in indirect eval called from a property index capturing this'))()");
+                _eval = eval;
+                _eval("(() => assert.areEqual('global', this.o, 'Lambda in indirect eval capturing this'))()");
+            `);
+        }
     }
 ]
 


### PR DESCRIPTION
Having a 'this' binding in the indirect eval leads to problems if there is a lambda capturing 'this' in the indirect eval. The lambda would try to load 'this' from a scope slot in the global scope of the indirect eval which asserts.

Seems we can simplify the above by just removing the 'this' binding from the indirect eval. Then we'll simply load 'this' like an ordinary lambda at global scope would.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14568840
