### PR TITLE
ARM64: fix in-proc jit memory leak

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -8852,7 +8852,7 @@ namespace Js
                 }
 #endif
                 XDataAllocator::Unregister(this->xdataInfo);
-#if defined(_M_ARM32_OR_ARM64)
+#if defined(_M_ARM)
                 if (JITManager::GetJITManager()->IsOOPJITEnabled())
 #endif
                 {


### PR DESCRIPTION
arm32 has special handling for xdata, but arm64 handles it the same way as amd64. see: https://github.com/Microsoft/ChakraCore/blob/c60cf515ac902af1c0c3d3d4e160c40d09b4659e/lib/Backend/NativeCodeGenerator.cpp#L1119
