### PR TITLE
Support setting thread description

### DIFF
--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -535,7 +535,14 @@ namespace JsUtil
 
             this->parallelThreadData[i]->processor = this;
             // Make sure to create the thread suspended so the thread handle can be assigned before the thread starts running
-            this->parallelThreadData[i]->threadHandle = reinterpret_cast<HANDLE>(PlatformAgnostic::Thread::Create(0, &StaticThreadProc, this->parallelThreadData[i], PlatformAgnostic::Thread::ThreadInitCreateSuspended));
+            auto threadHandle = PlatformAgnostic::Thread::Create(0, &StaticThreadProc,
+                this->parallelThreadData[i], PlatformAgnostic::Thread::ThreadInitCreateSuspended, _u("Chakra Parallel Worker Thread"));
+
+            if (threadHandle != PlatformAgnostic::Thread::InvalidHandle)
+            {
+                this->parallelThreadData[i]->threadHandle = reinterpret_cast<HANDLE>(threadHandle);
+            }
+
             if (!this->parallelThreadData[i]->threadHandle)
             {
                 HeapDelete(parallelThreadData[i]);

--- a/lib/Common/Core/DelayLoadLibrary.cpp
+++ b/lib/Common/Core/DelayLoadLibrary.cpp
@@ -52,6 +52,35 @@ bool DelayLoadLibrary::IsAvailable()
 
 #if _WIN32
 
+static Kernel32Library Kernel32LibraryObject;
+Kernel32Library* Kernel32Library::Instance = &Kernel32LibraryObject;
+
+LPCTSTR Kernel32Library::GetLibraryName() const
+{
+    return _u("kernel32.dll");
+}
+
+HRESULT Kernel32Library::SetThreadDescription(
+    _In_ HANDLE hThread,
+    _In_ PCWSTR lpThreadDescription
+)
+{
+    if (m_hModule)
+    {
+        if (setThreadDescription == nullptr)
+        {
+            setThreadDescription = (PFnSetThreadDescription)GetFunction("SetThreadDescription");
+            if (setThreadDescription == nullptr)
+            {
+                return S_FALSE;
+            }
+        }
+        return setThreadDescription(hThread, lpThreadDescription);
+    }
+
+  return S_FALSE;
+}
+
 static NtdllLibrary NtdllLibraryObject;
 NtdllLibrary* NtdllLibrary::Instance = &NtdllLibraryObject;
 

--- a/lib/Common/Core/DelayLoadLibrary.h
+++ b/lib/Common/Core/DelayLoadLibrary.h
@@ -27,6 +27,35 @@ private:
 
 #if _WIN32
 
+// This needs to be delay loaded because SetThreadDescription is available only
+// on Win10 1607+
+class Kernel32Library : protected DelayLoadLibrary
+{
+private:
+    typedef HRESULT (WINAPI *PFnSetThreadDescription)(
+      _In_ HANDLE hThread,
+      _In_ PCWSTR lpThreadDescription
+    );
+
+    PFnSetThreadDescription setThreadDescription;
+
+  public:
+    static Kernel32Library* Instance;
+
+    Kernel32Library() : DelayLoadLibrary(),
+      setThreadDescription(NULL)
+    {
+        this->EnsureFromSystemDirOnly();
+    }
+
+    LPCTSTR GetLibraryName() const;
+
+    HRESULT WINAPI SetThreadDescription(
+        _In_ HANDLE hThread,
+        _In_ PCWSTR lpThreadDescription
+        );
+};
+
 // This needs to be delay loaded because it is available on
 // Win8 only
 class NtdllLibrary : protected DelayLoadLibrary

--- a/lib/Common/PlatformAgnostic/Thread.h
+++ b/lib/Common/PlatformAgnostic/Thread.h
@@ -18,9 +18,12 @@ class Thread
 
     typedef uintptr_t ThreadHandle;
 
+    static const uintptr_t InvalidHandle = (uintptr_t)-1;
+
     static ThreadHandle Create(unsigned int stack_size,
                                unsigned int ( *start_address )( void * ),
                                void* arg_list,
-                               ThreadInitFlag init_flag);
+                               ThreadInitFlag init_flag,
+                               const char16* description);
 };
 } // namespace PlatformAgnostic

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -5,7 +5,7 @@ set(PL_SOURCE_FILES
   Common/HiResTimer.cpp
   Common/DateTime.cpp
   Linux/NumbersUtility.cpp
-  Linux/Thread.cpp
+  Common/Thread.cpp
   Common/Trace.cpp
   Common/SystemInfo.Common.cpp
   )

--- a/lib/Runtime/PlatformAgnostic/Platform/Common/Thread.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/Thread.cpp
@@ -13,7 +13,8 @@ namespace PlatformAgnostic
     Thread::ThreadHandle Thread::Create(unsigned stack_size,
                                         unsigned ( *start_address )( void * ),
                                         void* arg_list,
-                                        ThreadInitFlag init_flag)
+                                        ThreadInitFlag init_flag,
+                                        const char16* /*name*/)
     {
         unsigned int flag = 0;
 

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/Thread.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/Thread.cpp
@@ -12,7 +12,8 @@ namespace PlatformAgnostic
     Thread::ThreadHandle Thread::Create(unsigned stack_size,
                                         unsigned ( __stdcall *start_address )( void * ),
                                         void* arg_list,
-                                        ThreadInitFlag init_flag)
+                                        ThreadInitFlag init_flag,
+                                        const char16* description)
     {
         unsigned int flag = 0;
 
@@ -31,6 +32,18 @@ namespace PlatformAgnostic
             Assert(false);
         }
 
-        return _beginthreadex(nullptr, stack_size, start_address, arg_list, flag, nullptr);
+        uintptr_t handle = _beginthreadex(nullptr, stack_size, start_address, arg_list, flag, nullptr);
+
+        if (handle == 0)
+        {
+            return InvalidHandle;
+        }
+
+        if (description != nullptr)
+        {
+            Kernel32Library::Instance->SetThreadDescription((HANDLE) handle, description);
+        }
+
+        return handle;
     }
 } // namespace PlatformAgnostic


### PR DESCRIPTION
This change adds setting a description for a thread On OSes that support such a feature.
This is useful when using a debugger or viewing CPU profiles.
