### PR TITLE
xplat-intl: default to non intl compare for localeCompare

### DIFF
--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -106,7 +106,6 @@
     <default>
       <files>compare.js</files>
       <baseline>compare.baseline</baseline>
-      <compile-flags>-Intl-</compile-flags>
     </default>
   </test>
   <test>
@@ -248,7 +247,7 @@
       <tags>exclude_win7</tags>
     </default>
   </test>
-  <!--  This test is disabled as this is going to throw out of memory. Since this test takes time to reach the memory boundary, 
+  <!--  This test is disabled as this is going to throw out of memory. Since this test takes time to reach the memory boundary,
         it does not seem to be a good test to keep it enabled with -EnableFatalErrorOnOOM-
   <test>
     <default>


### PR DESCRIPTION
Fixes #4623 

Also enabling a test case that only tests the interface.