### PR TITLE
OS#14115684: Cached scope is not invalidated when eval code leaks a function from the cached scope

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5489,7 +5489,7 @@ CommonNumber:
 
         if (firstFuncSlot != Constants::NoProperty)
         {
-            if (firstVarSlot == Constants::NoProperty)
+            if (firstVarSlot == Constants::NoProperty || firstVarSlot < firstFuncSlot)
             {
                 lastFuncSlot = propIds->count - 1;
             }

--- a/test/Bugs/bug_OS14326981.js
+++ b/test/Bugs/bug_OS14326981.js
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Verify cached scope is invalidated",
+    body: function () {
+        function foo() {
+            var x = 100;
+            //create a stack allocated func 
+            function bar() {
+                return x;
+            }
+            eval("count = bar;");
+        }
+        var count = {};
+        foo();
+        assert.areEqual(100, count(), "Function leaked from cached scope should cause cached scope to be invalidated");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -437,4 +437,11 @@
       <files>bug15490382.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS14326981.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We detect property loads from an ActivationObject for which the property is a function stored in the cached scope. If we load one of those functions, we must mark the parent function as having a function escape and invalidate the cached scope. Right now we aren't doing this correctly due to a math error. We keep track of the indices of both the first and last functions in the activation object slots but the last slot index is always less than the first slot index. Because of this, when we load a property from the activation object it can never invalidate the cached scope even if it is an escaping function.

Fix seems to be to correct the math to compute the slot indices in `JavascriptOperators::OP_InitCachedScope`.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14115684