### PR TITLE
Fix missed copyprop opportunity due to unhandled InitFld case

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3662,7 +3662,6 @@ GlobOpt::CopyProp(IR::Opnd *opnd, IR::Instr *instr, Value *val, IR::IndirOpnd *p
 
     ValueInfo *valueInfo = val->GetValueInfo();
 
-
     if (this->func->HasFinally())
     {
         // s0 = undefined was added on functions with early exit in try-finally functions, that can get copy-proped and case incorrect results
@@ -4847,6 +4846,8 @@ GlobOpt::ValueNumberDst(IR::Instr **pInstr, Value *src1Val, Value *src2Val)
     case Js::OpCode::StRootFld:
     case Js::OpCode::StFldStrict:
     case Js::OpCode::StRootFldStrict:
+    case Js::OpCode::InitFld:
+    case Js::OpCode::InitComputedProperty:
         if (DoFieldCopyProp())
         {
             if (src1Val == nullptr)

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -468,6 +468,7 @@ GlobOpt::ProcessFieldKills(IR::Instr *instr, BVSparse<JitArenaAllocator> *bv, bo
     {
     case Js::OpCode::StElemI_A:
     case Js::OpCode::StElemI_A_Strict:
+    case Js::OpCode::InitComputedProperty:
         Assert(dstOpnd != nullptr);
         KillLiveFields(this->lengthEquivBv, bv);
         KillLiveElems(dstOpnd->AsIndirOpnd(), bv, inGlobOpt, instr->m_func);
@@ -504,7 +505,7 @@ GlobOpt::ProcessFieldKills(IR::Instr *instr, BVSparse<JitArenaAllocator> *bv, bo
             this->KillAllObjectTypes(bv);
         }
         break;
-
+    case Js::OpCode::InitFld:
     case Js::OpCode::StFld:
     case Js::OpCode::StRootFld:
     case Js::OpCode::StFldStrict:

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -468,9 +468,12 @@ GlobOpt::ProcessFieldKills(IR::Instr *instr, BVSparse<JitArenaAllocator> *bv, bo
     {
     case Js::OpCode::StElemI_A:
     case Js::OpCode::StElemI_A_Strict:
-    case Js::OpCode::InitComputedProperty:
         Assert(dstOpnd != nullptr);
         KillLiveFields(this->lengthEquivBv, bv);
+        KillLiveElems(dstOpnd->AsIndirOpnd(), bv, inGlobOpt, instr->m_func);
+        break;
+
+    case Js::OpCode::InitComputedProperty:
         KillLiveElems(dstOpnd->AsIndirOpnd(), bv, inGlobOpt, instr->m_func);
         break;
 


### PR DESCRIPTION
```var num = 50;
function inlineCall(tnum) {
  return {x : tnum};  // InitFld
}
function foo (obj) {
  var tnum = num;
  var sum = 0;
  while (tnum >= 0) {
    var retObj = inlineCall(tnum);
    if (tnum > 10) {
      sum += retObj.x;  // missed copy prop opportunity
    }
    tnum--;
  }
  return sum;
}

var obj = {};
foo(obj);
foo(obj);
foo(obj)
```
We were not setting a property initialized from InitFld instruction on the liveFields bit vector,
this led to returning null valueInfo when we queried through GlobOptBlockData::FindPropertyValue,
because that function checks if the property is live first and then queries its valauenumber from the symToValue map.

This pattern comes up in forof on array iterators, the constructor returns an object literal and we miss copy proping "done" and "value" fields of the iterator object.
