### PR TITLE
Defer parse treats yield as keyword

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -11705,6 +11705,10 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
             m_currentNodeFunc->sxFnc.SetStrictMode(!!this->m_fUseStrictMode);
 
             this->RestoreScopeInfo(scopeInfo);
+
+            m_currentNodeFunc->sxFnc.ClearFlags();
+            m_currentNodeFunc->sxFnc.SetIsGenerator(scopeInfo->IsGeneratorFunctionBody());
+            m_currentNodeFunc->sxFnc.SetIsAsync(scopeInfo->IsAsyncFunctionBody());
         }
     }
 

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -71,7 +71,12 @@ namespace Js
         scopeInfo->mustInstantiate = scope->GetMustInstantiate();
         scopeInfo->isCached = (scope->GetFunc()->GetBodyScope() == scope) && scope->GetFunc()->GetHasCachedScope();
         scopeInfo->hasLocalInClosure = scope->GetHasOwnLocalInClosure();
-        
+
+        if (scope->GetScopeType() == ScopeType_FunctionBody)
+        {
+            scopeInfo->isGeneratorFunctionBody = scope->GetFunc()->byteCodeFunction->GetFunctionInfo()->IsGenerator();
+            scopeInfo->isAsyncFunctionBody = scope->GetFunc()->byteCodeFunction->GetFunctionInfo()->IsAsync();
+        }
 
         TRACE_BYTECODE(_u("\nSave ScopeInfo: %s #symbols: %d %s\n"),
             scope->GetFunc()->name, count,

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -45,6 +45,8 @@ namespace Js {
         Field(BYTE) isCached : 1;              // indicates that local vars and functions are cached across invocations
         Field(BYTE) areNamesCached : 1;
         Field(BYTE) hasLocalInClosure : 1;
+        Field(BYTE) isGeneratorFunctionBody : 1;
+        Field(BYTE) isAsyncFunctionBody : 1;
 
         FieldNoBarrier(Scope *) scope;
         Field(::ScopeType) scopeType;
@@ -54,7 +56,7 @@ namespace Js {
 
     private:
         ScopeInfo(FunctionInfo * function, int symbolCount)
-            : functionInfo(function), /*funcExprScopeInfo(nullptr), paramScopeInfo(nullptr),*/ symbolCount(symbolCount), parent(nullptr), scope(nullptr), areNamesCached(false), hasLocalInClosure(false)/*, parentOnly(false)*/
+            : functionInfo(function), /*funcExprScopeInfo(nullptr), paramScopeInfo(nullptr),*/ symbolCount(symbolCount), parent(nullptr), scope(nullptr), areNamesCached(false), hasLocalInClosure(false), isGeneratorFunctionBody(false), isAsyncFunctionBody(false)/*, parentOnly(false)*/
         {
         }
 
@@ -257,6 +259,16 @@ namespace Js {
         bool GetHasOwnLocalInClosure() const
         {
             return hasLocalInClosure;
+        }
+
+        bool IsGeneratorFunctionBody() const
+        {
+            return this->isGeneratorFunctionBody;
+        }
+
+        bool IsAsyncFunctionBody() const
+        {
+            return this->isAsyncFunctionBody;
         }
 
         static void SaveEnclosingScopeInfo(ByteCodeGenerator* byteCodeGenerator, /*FuncInfo* parentFunc,*/ FuncInfo* func);

--- a/test/es6/DeferParseLambda.js
+++ b/test/es6/DeferParseLambda.js
@@ -110,6 +110,54 @@ var tests = [
             `);
         }
     },
+    {
+        name: "Global functions using 'yield' as identifier",
+        body: function () {
+            WScript.LoadScript(`
+                var a = async (yield) => { yield };
+                assert.isTrue(a() instanceof Promise, "Async lambda with yield as a formal parameter name");
+
+                function b(yield) {
+                    return yield;
+                }
+                assert.areEqual('b', b('b'), "Function with yield as a formal parameter name");
+
+                var c = async (yield) => yield;
+                assert.isTrue(c() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+                
+                async function d(yield) {
+                    return yield;
+                }
+                assert.isTrue(d() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+            `);
+        }
+    },
+    {
+        name: "Nested functions using 'yield' as identifier",
+        body: function () {
+            var a = async (yield) => { yield };
+            assert.isTrue(a() instanceof Promise, "Async lambda with yield as a formal parameter name");
+
+            function b(yield) {
+                return yield;
+            }
+            assert.areEqual('b', b('b'), "Function with yield as a formal parameter name");
+
+            var c = async (yield) => yield;
+            assert.isTrue(c() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+
+            async function d(yield) {
+                return yield;
+            }
+            assert.isTrue(d() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+            
+            var e = async (a = yield) => { yield };
+            assert.isTrue(e() instanceof Promise, "Async lambda with yield in a default argument");
+            
+            var f = async (a = yield) => yield;
+            assert.isTrue(f() instanceof Promise, "Async lambda with compact body and yield in a default argument");
+        }
+    },
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -831,6 +831,13 @@
   </test>
   <test>
     <default>
+      <files>generators-syntax.js</files>
+      <compile-flags>-ES6Generators -ES6Classes -ES6DefaultArgs -force:deferparse -args summary -endargs</compile-flags>
+      <tags>exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>generators-deferparse.js</files>
       <compile-flags>-force:deferparse -ES6Generators -ES6Classes -ES6DefaultArgs</compile-flags>
       <tags>exclude_arm</tags>


### PR DESCRIPTION
When we're defer parsing a function, we construct an enclosing function context to use as a parent function. That dummy parent function does not initialize the function flags, though, so they're random. When we're parsing a deferred lambda function, we look at those flags in the dummy parent function to see if it was a generator function to know if we should treat yield as an identifier or not. Because the flags are random, we sometimes throw a syntax error here thinking yield should be treated as a keyword. If we throw a syntax error upon defer-parse, we will hit an assert.

Fix by storing a bit of state in the ScopeInfo which indicates if the enclosing function is a generator or is an async function.

Fixes:
https://microsoft.visualstudio.com/web/wi.aspx?id=14502906
