### PR TITLE
OS 15681335: Fix inspection of Promise state in debugger

### DIFF
--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -3896,6 +3896,7 @@ namespace Js
                 break;
             case JavascriptPromise::PromiseStatusCode_Unresolved:
                 pResolvedObject->obj = scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("pending"));
+                break;
             case JavascriptPromise::PromiseStatusCode_HasResolution:
                 pResolvedObject->obj = scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("resolved"));
                 break;

--- a/test/DebuggerCommon/promiseDisplay.js.dbg.baseline
+++ b/test/DebuggerCommon/promiseDisplay.js.dbg.baseline
@@ -11,7 +11,7 @@
         },
         "someOtherProp": "string before",
         "[Promise]": {
-          "[status]": "string resolved",
+          "[status]": "string pending",
           "[value]": "string undefined"
         }
       }


### PR DESCRIPTION
RecyclablePromiseObjectWalker::Get had a missing break when inspecting the
state of a promise, causing an unresolved promise to show up as resolved in
F12. Fixed the logic here.
