### PR TITLE
string-test: fix localCompare test

### DIFF
--- a/test/Strings/compare.baseline
+++ b/test/Strings/compare.baseline
@@ -1,4 +1,0 @@
-Basic string compare.
-compare ( 'abcd1234' , 'abcd1234' ) = 0
-compare ( 'abcd1234' , '1234567a' ) = 1
-compare ( 'abcd1234' , undef ) = -1

--- a/test/Strings/compare.js
+++ b/test/Strings/compare.js
@@ -3,11 +3,16 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-WScript.Echo("Basic string compare.");
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js", "self");
+
 var str1 = "abcd1234"
 var str2 = "1234567a"
+var str3 = "abcd12345"
 var str1a = "abcd1234"
 
-WScript.Echo("compare ( '" + str1 + "' , '" + str1a + "' ) = " + str1.localeCompare(str1a));
-WScript.Echo("compare ( '" + str1 + "' , '" + str2 + "' ) = " + str1.localeCompare(str2));
-WScript.Echo("compare ( '" + str1 + "' , undef ) = " + str1.localeCompare());
+assert.isTrue(str1.localeCompare(str1a) == 0);
+assert.isTrue(str1.localeCompare(str2) > 0);
+assert.isTrue(str1.localeCompare(str3) < 0);
+assert.isTrue(str1.localeCompare() < 0);
+
+console.log("pass")

--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -105,7 +105,6 @@
   <test>
     <default>
       <files>compare.js</files>
-      <baseline>compare.baseline</baseline>
     </default>
   </test>
   <test>


### PR DESCRIPTION
spec asks for `<`, `=`, or `>` while our baseline was expecting a particular output.