### PR TITLE
Fix #4368: In unicode-mode RegExp, explicitly disallow invalid escapes.

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -1751,6 +1751,11 @@ namespace UnifiedRegex
                 // Take to be identity escape if ill-formed as per Annex B
                 break;
             default:
+                if (this->unicodeFlagPresent)
+                {
+                    // As per #sec-forbidden-extensions, if unicode flag is present, we must disallow any other escape.
+                    Js::JavascriptError::ThrowSyntaxError(scriptContext, JSERR_RegExpInvalidEscape);
+                }
                 // As per Annex B, allow anything other than newlines and above. Embedded 0 is ok
                 break;
             }

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -370,6 +370,7 @@ RT_ERROR_MSG(JSERR_OutOfBoundString, 5670, "", "String length is out of bound", 
 RT_ERROR_MSG(JSERR_InvalidIterableObject, 5671, "%s : Invalid iterable object", "Invalid iterable object", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_InvalidIteratorObject, 5672, "%s : Invalid iterator object", "Invalid iterator object", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_NoAccessors, 5673, "Invalid property descriptor: accessors not supported on this object", "", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_RegExpInvalidEscape, 5674, "", "Invalid regular expression: invalid escape in unicode pattern", kjstSyntaxError, 0)
 
 //Host errors
 RT_ERROR_MSG(JSERR_HostMaybeMissingPromiseContinuationCallback, 5700, "", "Host may not have set any promise continuation callback. Promises may not be executed.", kjstTypeError, 0)

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -93,6 +93,12 @@
   </test>
   <test>
     <default>
+      <files>unicode_forbidden_escapes.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>toString.js</files>
       <baseline>toString.baseline</baseline>
     </default>

--- a/test/Regex/unicode_forbidden_escapes.js
+++ b/test/Regex/unicode_forbidden_escapes.js
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Unicode-mode RegExp Forbidden Escapes",
+        body: function () {
+            let forbidden = [
+                '\\p',
+                '\\P',
+                '\\a',
+                '\\A',
+                '\\e',
+                '\\E',
+                '\\y',
+                '\\Y',
+                '\\z',
+                '\\Z',
+            ];
+
+            for (re of forbidden) {
+                assert.throws(function () { new RegExp(re, 'u') }, SyntaxError, 'Invalid regular expression: invalid escape in unicode pattern');
+                assert.doesNotThrow(function () { new RegExp(re) });
+            }
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fixes #4368 