### PR TITLE
Correcting memory allocation in LiteralStringWithPropertyStringPtr::NewFromCString

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -4662,7 +4662,7 @@ CHAKRA_API JsCreateString(
         length = strlen(content);
     }
 
-    if (length > static_cast<CharCount>(-1))
+    if (length > MaxCharCount)
     {
         return JsErrorOutOfMemory;
     }

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -99,24 +99,24 @@ namespace Js
         }
 
         ScriptContext * scriptContext = library->GetScriptContext();
-        size_t cbDestString = (charCount + 1) * sizeof(WCHAR);
-        if ((CharCount)cbDestString < charCount) // overflow
+        if (charCount > MaxCharCount)
         {
             Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
         }
 
         Recycler * recycler = library->GetRecycler();
-        char16* destString = RecyclerNewArrayLeaf(recycler, WCHAR, cbDestString);
+        char16* destString = RecyclerNewArrayLeaf(recycler, WCHAR, charCount + 1);
         if (destString == nullptr)
         {
             Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);
         }
 
-        HRESULT result = utf8::NarrowStringToWideNoAlloc(cString, charCount, destString, charCount + 1, &cbDestString);
+        charcount_t cchDestString = 0;
+        HRESULT result = utf8::NarrowStringToWideNoAlloc(cString, charCount, destString, charCount + 1, &cchDestString);
 
         if (result == S_OK)
         {
-            return (JavascriptString*) RecyclerNew(library->GetRecycler(), LiteralStringWithPropertyStringPtr, destString, (CharCount)cbDestString, library);
+            return (JavascriptString*) RecyclerNew(library->GetRecycler(), LiteralStringWithPropertyStringPtr, destString, cchDestString, library);
         }
 
         Js::JavascriptError::ThrowOutOfMemoryError(scriptContext);

--- a/lib/Runtime/Library/WabtInterface.cpp
+++ b/lib/Runtime/Library/WabtInterface.cpp
@@ -18,11 +18,11 @@ struct Context
     ScriptContext* scriptContext;
 };
 
-char16* NarrowStringToWide(Context* ctx, const char* src, const size_t* srcSize = nullptr, size_t* dstSize = nullptr)
+char16* NarrowStringToWide(Context* ctx, const char* src, const size_t* srcSize = nullptr, charcount_t* dstSize = nullptr)
 {
     auto allocator = [&ctx](size_t size) {return (char16*)AnewArray(ctx->allocator, char16, size); };
     char16* dst = nullptr;
-    size_t size;
+    charcount_t size;
     HRESULT hr = utf8::NarrowStringToWide(allocator, src, srcSize ? *srcSize : strlen(src), &dst, &size);
     if (hr != S_OK)
     {
@@ -86,11 +86,11 @@ Js::Var Int64ToVar(int64 value, void* user_data)
 Js::Var StringToVar(const char* src, uint length, void* user_data)
 {
     Context* ctx = (Context*)user_data;
-    size_t bufSize = 0;
+    charcount_t bufSize = 0;
     size_t slength = (size_t)length;
     char16* buf = NarrowStringToWide(ctx, src, &slength, &bufSize);
     Assert(bufSize < UINT32_MAX);
-    return JavascriptString::NewCopyBuffer(buf, (charcount_t)bufSize, ctx->scriptContext);
+    return JavascriptString::NewCopyBuffer(buf, bufSize, ctx->scriptContext);
 }
 
 Js::Var CreateBuffer(const uint8* buf, uint size, void* user_data)


### PR DESCRIPTION
A confusion between bytes and character count meant that JsCreateString
was creating strings that used twice as much space as they needed.

While I was at it, I also tried to clean up the types in `Utf8Helper.h` to make it more clear what the values referred to.