### PR TITLE
OS#15775563: Fix-up previous change. Explicitly allow RegExp identity escapes.

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -1750,11 +1750,27 @@ namespace UnifiedRegex
                 }
                 // Take to be identity escape if ill-formed as per Annex B
                 break;
+            case '^':
+            case '$':
+            case '\\':
+            case '.':
+            case '*':
+            case '+':
+            case '?':
+            case '(':
+            case ')':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+            case '|':
+            case '/':
+                break; // fall-through for identity escape
             default:
                 if (this->unicodeFlagPresent)
                 {
                     // As per #sec-forbidden-extensions, if unicode flag is present, we must disallow any other escape.
-                    Js::JavascriptError::ThrowSyntaxError(scriptContext, JSERR_RegExpInvalidEscape);
+                    this->Fail(JSERR_RegExpInvalidEscape); // throw SyntaxError
                 }
                 // As per Annex B, allow anything other than newlines and above. Embedded 0 is ok
                 break;

--- a/test/Regex/unicode_forbidden_escapes.js
+++ b/test/Regex/unicode_forbidden_escapes.js
@@ -5,29 +5,110 @@
 
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
+let forbidden = [
+    '\\p',
+    '\\P',
+    '\\a',
+    '\\A',
+    '\\e',
+    '\\E',
+    '\\y',
+    '\\Y',
+    '\\z',
+    '\\Z',
+];
+
+let identity = [
+    "^",
+    "$",
+    "\\",
+    ".",
+    "*",
+    "+",
+    "?",
+    "(",
+    ")",
+    "[",
+    "]",
+    "{",
+    "}",
+    "|",
+    "/",
+];
+
+let pseudoIdentity = [
+    ["f", "\f"],
+    ["n", "\n"],
+    ["r", "\r"],
+    ["t", "\t"],
+    ["v", "\v"],
+]
+
 var tests = [
     {
-        name: "Unicode-mode RegExp Forbidden Escapes",
+        name: "Unicode-mode RegExp Forbidden Escapes (RegExp constructor)",
         body: function () {
-            let forbidden = [
-                '\\p',
-                '\\P',
-                '\\a',
-                '\\A',
-                '\\e',
-                '\\E',
-                '\\y',
-                '\\Y',
-                '\\z',
-                '\\Z',
-            ];
-
             for (re of forbidden) {
                 assert.throws(function () { new RegExp(re, 'u') }, SyntaxError, 'Invalid regular expression: invalid escape in unicode pattern');
                 assert.doesNotThrow(function () { new RegExp(re) });
             }
         }
-    }
+    },
+    {
+        name: "Unicode-mode RegExp Forbidden Escapes (literal)",
+        body: function () {
+            for (re of forbidden) {
+                assert.throws(function () { eval(`/${re}/u`); }, SyntaxError, 'Invalid regular expression: invalid escape in unicode pattern');
+                assert.doesNotThrow(function () { eval(`/${re}/`); }, SyntaxError, 'Invalid regular expression: invalid escape in unicode pattern');
+            }
+        }
+    },
+    {
+        name: "Allow IdentityEscapes (RegExp constructor)",
+        body: function () {
+            for (c of identity) {
+                assert.doesNotThrow(function () { new RegExp(`\\${c}`, 'u') });
+                assert.doesNotThrow(function () { new RegExp(`\\${c}`) });
+            }
+        }
+    },
+    {
+        name: "Allow IdentityEscapes (literal)",
+        body: function () {
+            for (c of identity) {
+                assert.doesNotThrow(function () { eval(`/\\${c}/u`); });
+                assert.doesNotThrow(function () { eval(`/\\${c}/`); });
+            }
+        }
+    },
+    {
+        name: "Allow Pseudo-Identity Escapes (RegExpconstructor)",
+        body: function () {
+            for (test of pseudoIdentity) {
+                let c = test[0];
+                let rendered = test[1];
+                let re;
+                assert.doesNotThrow(function () { re = new RegExp(`\\${c}`, 'u') });
+                assert.isTrue(re.test(rendered));
+                assert.doesNotThrow(function () { re = new RegExp(`\\${c}`) });
+                assert.isTrue(re.test(rendered));
+            }
+        }
+    },
+    {
+        name: "Allow Pseudo-Identity Escapes (literal)",
+        body: function () {
+            for (test of pseudoIdentity) {
+                let c = test[0];
+                let rendered = test[1];
+                let re;
+                assert.doesNotThrow(function () { re = eval(`/\\${c}/u`) });
+                assert.isTrue(re.test(rendered));
+                assert.doesNotThrow(function () { re = eval(`/\\${c}/`) });
+                assert.isTrue(re.test(rendered));
+            }
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
See #4637: Fix #4368: In unicode-mode RegExp, explicitly disallow invalid escapes.

Fixes OS#15775563