### PR TITLE
Minor tracing improvements

### DIFF
--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -765,7 +765,7 @@ bool InliningDecider::DeciderInlineIntoInliner(Js::FunctionBody * inlinee, Js::F
             isConstructorCall ||                                                     // If the function is constructor with loops, don't inline.
             PHASE_OFF(Js::InlineFunctionsWithLoopsPhase, this->topFunc))
         {
-            INLINE_TESTTRACE(_u("INLINING: Skip Inline: Has loops \tBytecode size: %d \tgetNumberOfInlineesWithLoop: %d\tloopCount: %d\thasNestedLoop: %B\tisConstructorCall:%B\tInlinee: %s (%s)\tCaller: %s (%s) \tRoot: %s (%s)\n"),
+            INLINE_TESTTRACE(_u("INLINING: Skip Inline: Has loops \tBytecode size: %d \tgetNumberOfInlineesWithLoop: %d\tloopCount: %d\thasNestedLoop: %d\tisConstructorCall:%d\tInlinee: %s (%s)\tCaller: %s (%s) \tRoot: %s (%s)\n"),
                 inlinee->GetByteCodeCount(),
                 GetNumberOfInlineesWithLoop(),
                 inlinee->GetLoopCount(),
@@ -859,6 +859,12 @@ bool InliningDecider::DeciderInlineIntoInliner(Js::FunctionBody * inlinee, Js::F
     }
     else
     {
+        INLINE_TESTTRACE(_u("INLINING: Skip Inline: Too long \tBytecode size: %d\tThreshold: %d\tInlinee: %s (%s)\tCaller: %s (%s) \tRoot: %s (%s)\n"),
+            inlinee->GetByteCodeCount(),
+            inlineThreshold,
+            inlinee->GetDisplayName(), inlinee->GetDebugNumberSet(debugStringBuffer),
+            inliner->GetDisplayName(), inliner->GetDebugNumberSet(debugStringBuffer2),
+            topFunc->GetDisplayName(), topFunc->GetDebugNumberSet(debugStringBuffer3));
         return false;
     }
 }

--- a/lib/Backend/ObjTypeSpecFldInfo.h
+++ b/lib/Backend/ObjTypeSpecFldInfo.h
@@ -204,8 +204,9 @@ public:
     static ObjTypeSpecFldInfo* CreateFrom(uint id, Js::PolymorphicInlineCache* cache, uint cacheId,
         Js::EntryPointInfo *entryPoint, Js::FunctionBody* const topFunctionBody, Js::FunctionBody *const functionBody, Js::FieldAccessStatsPtr inlineCacheStats);
 
-    // TODO: OOP JIT, implement this
-    char16* GetCacheLayoutString() { __debugbreak(); return nullptr; }
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+    const char16* GetCacheLayoutString() const { return _u("ObjTypeSpecFldInfo"); }
+#endif
 
 private:
     ObjTypeSpecFldInfoFlags GetFlags() const;


### PR DESCRIPTION
1. Change a format string so it doesn't crash.
2. Remove a debug breakpoint that was hitting very frequently and getting annoying.
3. Add a new trace message for functions that weren't inlined due to length.
