### PR TITLE
fix issue where memop may scan for missing values even if not in head segment

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -989,7 +989,7 @@ SECOND_PASS:
                         CopyArray(current->elements + endIndex + 1, endSeg->length,
                             ((Js::SparseArraySegment<T>*)endSeg)->elements, endSeg->length);
                         LinkSegments((Js::SparseArraySegment<T>*)startPrev, current);
-                        if (HasNoMissingValues())
+                        if (current == head && HasNoMissingValues())
                         {
                             if (ScanForMissingValues<T>(endIndex + 1, endIndex + growby))
                             {


### PR DESCRIPTION
This may cause us to incorrectly set `HasNoMissingValues(false);`

OS: 15399206