### PR TITLE
Use unsigned for capturing groups in Regex interfaces

### DIFF
--- a/lib/Parser/RegexParser.h
+++ b/lib/Parser/RegexParser.h
@@ -81,14 +81,11 @@ namespace UnifiedRegex
         // considered a capturing group.  Using INT16_MAX allows us to pass one value for each
         // group, plus a few additional values, to a JavaScript function without overflowing the
         // number of arguments.  This is important, for example, in the implementation of
-        // String.prototype.replace, where the second argument is a function.
-        //
-        // This should really be an unsigned, but we compare it against numGroups, so make it
-        // an int for now to avoid a bunch of compiler warnings until we can go back and clean this up.
-        static const int MAX_NUM_GROUPS = INT16_MAX;
+        // String.prototype.replace where the second argument is a function.
+        static const uint16 MAX_NUM_GROUPS = INT16_MAX;
 
-        int numGroups; // determined in first parse
-        int nextGroupId;
+        uint16 numGroups; // determined in first parse
+        uint16 nextGroupId;
         // Buffer accumulating all literals.
         // In compile-time allocator, must be transferred to runtime allocator when build program
         Char* litbuf;

--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -72,7 +72,7 @@ namespace UnifiedRegex
         return rep.unified.program->flags;
     }
 
-    int RegexPattern::NumGroups() const
+    uint16 RegexPattern::NumGroups() const
     {
         return rep.unified.program->numGroups;
     }

--- a/lib/Parser/RegexPattern.h
+++ b/lib/Parser/RegexPattern.h
@@ -58,7 +58,7 @@ namespace UnifiedRegex
         Js::ScriptContext *GetScriptContext() const;
 
         inline bool IsLiteral() const { return isLiteral; }
-        int NumGroups() const;
+        uint16 NumGroups() const;
         bool IsIgnoreCase() const;
         bool IsGlobal() const;
         bool IsMultiline() const;

--- a/lib/Parser/RegexRuntime.h
+++ b/lib/Parser/RegexRuntime.h
@@ -60,7 +60,7 @@ namespace UnifiedRegex
         Field(Char*) source;
         Field(CharCount) sourceLen; // length in char16's, NOT including terminating null
         // Number of capturing groups (including implicit overall group at index 0)
-        Field(int) numGroups;
+        Field(uint16) numGroups;
         Field(int) numLoops;
         Field(RegexFlags) flags;
 
@@ -1847,7 +1847,7 @@ namespace UnifiedRegex
             return !groupInfos[0].IsUndefined();
         }
 
-        inline int NumGroups() const
+        inline uint16 NumGroups() const
         {
             return program->numGroups;
         }

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -1261,7 +1261,9 @@ namespace Js
         Var nonMatchValue = NonMatchValue(scriptContext, false);
         UnifiedRegex::GroupInfo lastMatch; // initially undefined
 
-        AssertOrFailFast(numGroups <= INT16_MAX);
+        // numGroups is always positive because the entire regular expression
+        // itself counts as a capturing group.
+        AssertOrFailFast(0 < numGroups && numGroups <= INT16_MAX);
 
 #if ENABLE_REGEX_CONFIG_OPTIONS
         RegexHelperTrace(scriptContext, UnifiedRegex::RegexStats::Replace, regularExpression, input, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("<replace function>")));

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -773,11 +773,8 @@ namespace Js
             {
                 // We've found a substitution ref, like $32.  In accordance with the standard (sec-getsubstitution),
                 // we recognize at most two decimal digits after the dollar sign.
-
-                // This should be unsigned, but this would cause lots of compiler warnings unless we also make
-                // numGroups unsigned, because of a comparison below.
-                int captureIndex = (int)(currentChar - _u('0'));
-                Assert(0 <= captureIndex && captureIndex <= 9); // numeric value of single decimal digit
+                uint16 captureIndex = (uint16)(currentChar - _u('0'));
+                Assert(captureIndex <= 9); // numeric value of single decimal digit
 
                 offset = substitutionOffset + 2;
 
@@ -786,9 +783,8 @@ namespace Js
                     currentChar = replaceStr[substitutionOffset + 2];
                     if (currentChar >= _u('0') && currentChar <= _u('9'))
                     {
-                        // Should also be unsigned; see captureIndex above.
-                        int tempCaptureIndex = (10 * captureIndex) + (int)(currentChar - _u('0'));
-                        Assert(0 <= tempCaptureIndex && tempCaptureIndex < 100); // numeric value of 2-digit positive decimal number
+                        uint16 tempCaptureIndex = (10 * captureIndex) + (uint16)(currentChar - _u('0'));
+                        Assert(tempCaptureIndex < 100); // numeric value of 2-digit positive decimal number
                         if (tempCaptureIndex < numGroups)
                         {
                             captureIndex = tempCaptureIndex;
@@ -797,7 +793,7 @@ namespace Js
                     }
                 }
 
-                Assert(0 <= captureIndex && captureIndex < 100); // as above, value of 2-digit positive decimal number
+                Assert(captureIndex < 100); // as above, value of 2-digit positive decimal number
                 if (captureIndex < numGroups && (captureIndex != 0))
                 {
                     Var group = getGroup(captureIndex, nonMatchValue);
@@ -1261,12 +1257,11 @@ namespace Js
         JavascriptString* newString = nullptr;
         const char16* inputStr = input->GetString();
         CharCount inputLength = input->GetLength();
-        const int rawNumGroups = pattern->NumGroups();
+        const uint16 numGroups = pattern->NumGroups();
         Var nonMatchValue = NonMatchValue(scriptContext, false);
         UnifiedRegex::GroupInfo lastMatch; // initially undefined
 
-        AssertOrFailFast(0 < rawNumGroups && rawNumGroups <= INT16_MAX);
-        const uint16 numGroups = uint16(rawNumGroups);
+        AssertOrFailFast(numGroups <= INT16_MAX);
 
 #if ENABLE_REGEX_CONFIG_OPTIONS
         RegexHelperTrace(scriptContext, UnifiedRegex::RegexStats::Replace, regularExpression, input, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("<replace function>")));


### PR DESCRIPTION
In RegexParser, RegexPattern, and RegexRuntime, change the type of the
number of capturing groups from int to uint16 (since we limit the number of
groups to 2^15-1 in the parser).

Follow-on to MSRC 41416 (for 1712), which addressed a potential arithmetic overflow and subsequent illegal array access.