### PR TITLE
OS#14057294: don't use param scope for jit loop bodies

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -414,7 +414,7 @@ IRBuilder::Build()
     m_func->m_tailInstr = m_func->m_exitInstr;
     m_func->m_headInstr->InsertAfter(m_func->m_tailInstr);
 
-    if (m_func->GetJITFunctionBody()->IsParamAndBodyScopeMerged())
+    if (m_func->GetJITFunctionBody()->IsParamAndBodyScopeMerged() || this->IsLoopBody())
     {
         this->SetParamScopeDone();
     }

--- a/test/Bugs/bug14057294.js
+++ b/test/Bugs/bug14057294.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo(a, b = (function() {a;})())
+{
+    for (var ii = 0; ii < 200; ++ii)
+    {
+        var c, d = null;
+        function bar()
+        {
+            c;
+            d;
+        };
+        bar();
+    }
+};
+
+foo();
+
+WScript.Echo("Pass")

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -440,4 +440,9 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug14057294.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
jit loop bodies start past the instruction that ends param scope when param and body scopes are split, leading to a Throw::FatalInternalError when there are more scope slots than param scope slots
