### PR TITLE
OS#15659337: Try to allocate JIT code in PreReservedSegment even if CFG is not enabled

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1144,8 +1144,7 @@ bool Func::CanAllocInPreReservedHeapPageSegment ()
 {
 #ifdef _CONTROL_FLOW_GUARD
     return PHASE_FORCE1(Js::PreReservedHeapAllocPhase) || (!PHASE_OFF1(Js::PreReservedHeapAllocPhase) &&
-        !IsJitInDebugMode() && GetThreadContextInfo()->IsCFGEnabled()
-        //&& !GetScriptContext()->IsScriptContextInDebugMode()
+        !IsJitInDebugMode()
 #if _M_IX86
         && m_workItem->GetJitMode() == ExecutionMode::FullJit
 

--- a/lib/Common/Memory/SectionAllocWrapper.cpp
+++ b/lib/Common/Memory/SectionAllocWrapper.cpp
@@ -868,7 +868,7 @@ LPVOID PreReservedSectionAllocWrapper::AllocPages(LPVOID lpAddress, DECLSPEC_GUA
     size_t dwSize = pageCount * AutoSystemInfo::PageSize;
     
     AssertMsg(isCustomHeapAllocation, "PreReservation used for allocations other than CustomHeap?");
-    AssertMsg(AutoSystemInfo::Data.IsCFGEnabled() || PHASE_FORCE1(Js::PreReservedHeapAllocPhase), "PreReservation without CFG ?");
+
     Assert(dwSize != 0);
 
     {

--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -279,7 +279,7 @@ LPVOID PreReservedVirtualAllocWrapper::AllocPages(LPVOID lpAddress, size_t pageC
     size_t dwSize = pageCount * AutoSystemInfo::PageSize;
     
     AssertMsg(isCustomHeapAllocation, "PreReservation used for allocations other than CustomHeap?");
-    AssertMsg(AutoSystemInfo::Data.IsCFGEnabled() || PHASE_FORCE1(Js::PreReservedHeapAllocPhase), "PreReservation without CFG ?");
+
     Assert(dwSize != 0);
 
     {


### PR DESCRIPTION
This speeds up stack walking IsNativeAddress checks when CFG is not enabled.
