### PR TITLE
Fix #2949: Class const name binding incorrectly marked as module export storage

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -3058,7 +3058,6 @@ ParseFunctionDecl:
                 IdentPtr localName;
                 if (pnode->nop == knopClassDecl)
                 {
-                    pnode->sxClass.pnodeName->sxVar.sym->SetIsModuleExportStorage(true);
                     pnode->sxClass.pnodeDeclName->sxVar.sym->SetIsModuleExportStorage(true);
                     localName = pnode->sxClass.pnodeName->sxVar.pid;
                 }

--- a/test/es6module/exportBinding.js
+++ b/test/es6module/exportBinding.js
@@ -1,0 +1,88 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+export class A1 {
+    attemptBindingChange() { A1 = 1; }
+    bindingUnmodified() { return A1 !== 1; }
+}
+var A1Inst = new A1();
+
+assert.throws(function () { A1Inst.attemptBindingChange(); }, TypeError, 'Exported class name captured inside class is const', "Assignment to const");
+assert.doesNotThrow(function () { A1 = 1; }, 'Exported class name decl binding is mutable outside class');
+assert.throws(function () { A1Inst.attemptBindingChange(); }, TypeError, 'Mutation of class decl did not change constness', "Assignment to const");
+assert.areEqual(true, A1Inst.bindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { A1Inst.attemptBindingChange(); }, TypeError, 'Exported class name captured inside class is still const', "Assignment to const");
+
+class A2 {
+    attemptBindingChange() { A2 = 1; }
+    bindingUnmodified() { return A2 !== 1; }
+}
+var A2Inst = new A2();
+export { A2 };
+
+assert.throws(function () { A2Inst.attemptBindingChange(); }, TypeError, 'Delay exported class name captured in class is const', "Assignment to const");
+assert.doesNotThrow(function () { A2 = 1; }, 'Delay exported class name decl binding is mutable outside class');
+assert.throws(function () { A2Inst.attemptBindingChange(); }, TypeError, 'Mutation of class decl did not change constness', "Assignment to const");
+assert.areEqual(true, A2Inst.bindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { A2Inst.attemptBindingChange(); }, TypeError, 'Delay exported class name captured in class is still const', "Assignment to const");
+
+export let B1 = class B1 {
+    attemptBindingChange() { B1 = 1; }
+    bindingUnmodified() { return B1 !== 1; }
+}
+var B1Inst = new B1();
+
+assert.throws(function () { B1Inst.attemptBindingChange(); }, TypeError, 'Exported class expr name captured inside class is const', "Assignment to const");
+assert.doesNotThrow(function () { B1 = 1; }, 'Exported class expr name decl binding is mutable outside class');
+assert.throws(function () { B1Inst.attemptBindingChange(); }, TypeError, 'Mutation of class expr decl did not change constness', "Assignment to const");
+assert.areEqual(true, B1Inst.bindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { B1Inst.attemptBindingChange(); }, TypeError, 'Exported class expr name captured inside class is still const', "Assignment to const");
+
+let B2 = class B2 {
+    attemptBindingChange() { B2 = 1; }
+    bindingUnmodified() { return B2 !== 1; }
+}
+var B2Inst = new B2();
+export { B2 };
+
+assert.throws(function () { B2Inst.attemptBindingChange(); }, TypeError, 'Delay exported class expr name captured in class is const', "Assignment to const");
+assert.doesNotThrow(function () { B2 = 1; }, 'Delay exported class expr name decl binding is mutable outside class');
+assert.throws(function () { B2Inst.attemptBindingChange(); }, TypeError, 'Mutation of class expr decl did not change constness', "Assignment to const");
+assert.areEqual(true, B2Inst.bindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { B2Inst.attemptBindingChange(); }, TypeError, 'Delay exported class expr name captured in class is still const', "Assignment to const");
+
+export let C1 = class NotC1 {
+    attemptOuterBindingChange() { C1 = 1; }
+    attemptInnerBindingChange() { NotC1 = 1; }
+    outerbindingUnmodified() { return C1 !== 1; }
+    innerbindingUnmodified() { return NotC1 !== 1; }
+}
+var C1Inst = new C1();
+
+assert.throws(function () { C1Inst.attemptInnerBindingChange(); }, TypeError, 'Exported class expr name captured inside class is const', "Assignment to const");
+assert.doesNotThrow(function () { C1Inst.attemptOuterBindingChange(); }, 'Exported class expr name decl binding is mutable outside class');
+assert.throws(function () { C1Inst.attemptInnerBindingChange(); }, TypeError, 'Mutation of class expr decl did not change constness', "Assignment to const");
+assert.areEqual(false, C1Inst.outerbindingUnmodified(), 'Captured class decl observes mutation');
+assert.areEqual(true, C1Inst.innerbindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { C1Inst.attemptInnerBindingChange(); }, TypeError, 'Exported class expr name captured inside class is still const', "Assignment to const");
+
+let C2 = class NotC2 {
+    attemptOuterBindingChange() { C2 = 1; }
+    attemptInnerBindingChange() { NotC2 = 1; }
+    outerbindingUnmodified() { return C2 !== 1; }
+    innerbindingUnmodified() { return NotC2 !== 1; }
+}
+var C2Inst = new C2();
+export { C2 };
+
+assert.throws(function () { C2Inst.attemptInnerBindingChange(); }, TypeError, 'Exported class expr name captured inside class is const', "Assignment to const");
+assert.doesNotThrow(function () { C2Inst.attemptOuterBindingChange(); }, 'Exported class expr name decl binding is mutable outside class');
+assert.throws(function () { C2Inst.attemptInnerBindingChange(); }, TypeError, 'Mutation of class expr decl did not change constness', "Assignment to const");
+assert.areEqual(false, C2Inst.outerbindingUnmodified(), 'Captured class decl observes mutation');
+assert.areEqual(true, C2Inst.innerbindingUnmodified(), 'Captured class name does not observe mutation');
+assert.throws(function () { C2Inst.attemptInnerBindingChange(); }, TypeError, 'Exported class expr name captured inside class is still const', "Assignment to const");
+
+console.log("PASS");

--- a/test/es6module/exportBindingLoader.js
+++ b/test/es6module/exportBindingLoader.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+WScript.LoadModuleFile('exportBinding.js', 'samethread');

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -99,6 +99,13 @@
   </test>
   <test>
     <default>
+      <files>exportBindingLoader.js</files>
+      <compile-flags>-ES6Module -args summary -endargs</compile-flags>
+      <tags>exclude_dynapogo,exclude_sanitize_address</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>test_bug_2645.js</files>
       <compile-flags>-ES6Module</compile-flags>
       <tags>exclude_sanitize_address</tags>


### PR DESCRIPTION
We were mistakenly marking both the class let and const decls as module export storage. This resulted in empty instantiated scopes and incorrect class behavior in some cases.

The fix is not to mark the const binding as module export storage, as it is visible to the inside of the class only.

Added some tests to verify the bindings of exported classes.
