### PR TITLE
more xdata fix for debugger attaching/detaching

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3117,6 +3117,13 @@ namespace Js
         // Disable QC while functions are re-parsed as this can be time consuming
         AutoDisableInterrupt autoDisableInterrupt(this->threadContext, false /* explicitCompletion */);
 
+#if ENABLE_NATIVE_CODEGEN
+#if PDATA_ENABLED && defined(_WIN32)
+        // RundownSourcesAndReparse can cause code generation immediately, clear the leftovers if background thread didn't finish the work
+        DelayDeletingFunctionTable::Clear();
+#endif
+#endif
+
         hr = this->GetDebugContext()->RundownSourcesAndReparse(shouldPerformSourceRundown, /*shouldReparseFunctions*/ true);
 
         if (this->IsClosed())
@@ -3237,6 +3244,13 @@ namespace Js
 
         // Disable QC while functions are re-parsed as this can be time consuming
         AutoDisableInterrupt autoDisableInterrupt(this->threadContext, false /* explicitCompletion */);
+
+#if ENABLE_NATIVE_CODEGEN
+#if PDATA_ENABLED && defined(_WIN32)
+        // RundownSourcesAndReparse can cause code generation immediately, clear the leftovers if background thread didn't finish the work
+        DelayDeletingFunctionTable::Clear();
+#endif
+#endif
 
         // Force a reparse so that indirect function caches are updated.
         hr = this->GetDebugContext()->RundownSourcesAndReparse(/*shouldPerformSourceRundown*/ false, /*shouldReparseFunctions*/ true);


### PR DESCRIPTION
codegen can happen before OnDebuggerAttach/Detach returns, we need to
clear the function table before the code gen happens.
