### PR TITLE
fix assert in JIT data serialization

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -440,7 +440,8 @@ namespace Js
             if (this->serializedRpcData != nullptr)
             {
                 // We may have multiple codegens happen for same entrypoint
-                HeapDeleteArray(this->serializedRpcDataSize, this->serializedRpcData);
+                const unsigned char* rpcData = this->serializedRpcData;
+                HeapDeleteArray(this->serializedRpcDataSize, rpcData);
             }
             serializedRpcData = data;
             serializedRpcDataSize = size;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -437,7 +437,11 @@ namespace Js
     public:
         void SetSerializedRpcData(const unsigned char* data, size_t size)
         {
-            Assert(serializedRpcData == nullptr);
+            if (this->serializedRpcData != nullptr)
+            {
+                // We may have multiple codegens happen for same entrypoint
+                HeapDeleteArray(this->serializedRpcDataSize, this->serializedRpcData);
+            }
             serializedRpcData = data;
             serializedRpcDataSize = size;
         }


### PR DESCRIPTION
We may have multiple codegen calls for same entrypoint, so replace the old JIT data if this happens

OS: 15845157