### PR TITLE
Fix debugger ignoring exceptions thrown after an await

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -889,19 +889,16 @@ namespace Js
         Var handlerResult = nullptr;
         JavascriptExceptionObject* exception = nullptr;
 
+        try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
-            try
-            {
-                handlerResult = CALL_FUNCTION(scriptContext->GetThreadContext(),
-                    handler, Js::CallInfo(Js::CallFlags::CallFlags_Value, 2),
-                    undefinedVar,
-                    argument);
-            }
-            catch (const JavascriptException& err)
-            {
-                exception = err.GetAndClear();
-            }
+            handlerResult = CALL_FUNCTION(scriptContext->GetThreadContext(),
+                handler, Js::CallInfo(Js::CallFlags::CallFlags_Value, 2),
+                undefinedVar,
+                argument);
+        }
+        catch (const JavascriptException& err)
+        {
+            exception = err.GetAndClear();
         }
 
         if (exception != nullptr)
@@ -1034,20 +1031,17 @@ namespace Js
         JavascriptPromiseResolveOrRejectFunction* reject = library->CreatePromiseResolveOrRejectFunction(EntryResolveOrRejectFunction, promise, true, alreadyResolvedRecord);
         JavascriptExceptionObject* exception = nullptr;
 
+        try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
-            try
-            {
-                return CALL_FUNCTION(scriptContext->GetThreadContext(),
-                    thenFunction, Js::CallInfo(Js::CallFlags::CallFlags_Value, 3),
-                    thenable,
-                    resolve,
-                    reject);
-            }
-            catch (const JavascriptException& err)
-            {
-                exception = err.GetAndClear();
-            }
+            return CALL_FUNCTION(scriptContext->GetThreadContext(),
+                thenFunction, Js::CallInfo(Js::CallFlags::CallFlags_Value, 3),
+                thenable,
+                resolve,
+                reject);
+        }
+        catch (const JavascriptException& err)
+        {
+            exception = err.GetAndClear();
         }
 
         Assert(exception != nullptr);


### PR DESCRIPTION
If code such as the snippet below is run under the debugger, the host is not notified of the thrown exception via `JsDiagDebugEventRuntimeException`:

```js
(async () => {
    await null;
    throw new Error();
})();
```

Note that moving the `throw` *before* the `await` makes the debugger able to intercept it again.  This issue occurs because of an `AutoCatchHandlerExists` being in scope when the promise reaction is run:
https://github.com/Microsoft/ChakraCore/blob/ad79be8811806622190b55266c73f20b600ed46c/lib/Runtime/Library/JavascriptPromise.cpp#L1037-L1051

The fix is to not construct an `AutoCatchHandlerExists` in this situation.  While the exception is indeed caught and squelched, it's not actually swallowed but converted to a promise rejection, which may well be fatal depending on the host.  We need the debugger to be able to intercept it before that happens so the user can view the callstack, variables, etc. before the stack is unwound.

There is no test coverage for this yet, I will try to add some in the next day or so.

Fixes #4630.