### PR TITLE
Tidy up args.info.count asserts

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1641,7 +1641,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
     if (bailOutRecord->globalBailOutRecordTable->isInlinedConstructor)
     {
         AssertMsg(!executeFunction->IsGenerator(), "Generator functions are not expected to be inlined. If this changes then need to use the real user args here from the generator object");
-        Assert(args.Info.Count != 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         aReturn = Js::JavascriptFunction::FinishConstructor(aReturn, args.Values[0], function);
 
         Js::Var oldValue = aReturn;

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6250,7 +6250,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
     Var JavascriptOperators::NewScObject(const Var callee, const Arguments args, ScriptContext *const scriptContext, const Js::AuxArray<uint32> *spreadIndices)
     {
         Assert(callee);
-        Assert(args.Info.Count != 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(scriptContext);
 
         // Always save and restore implicit call flags when calling out

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -558,7 +558,7 @@ namespace Js
         const ProfileId arrayProfileId)
     {
         Assert(callee);
-        Assert(args.Info.Count != 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(caller);
         Assert(profileId != Constants::NoProfileId);
         Assert(arrayProfileId != Constants::NoProfileId);
@@ -641,7 +641,7 @@ namespace Js
         const Js::AuxArray<uint32> *spreadIndices)
     {
         Assert(callee);
-        Assert(args.Info.Count != 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(callerFunctionBody);
         Assert(profileId != Constants::NoProfileId);
 

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -369,6 +369,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !ArrayBuffer::Is(args[0]))
         {
@@ -564,7 +565,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -120,6 +120,7 @@ namespace Js
     {
         RUNTIME_ARGUMENTS(args, callInfo);
         ScriptContext* scriptContext = function->GetScriptContext();
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {

--- a/lib/Runtime/Library/DataView.cpp
+++ b/lib/Runtime/Library/DataView.cpp
@@ -148,6 +148,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -171,6 +172,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -223,6 +225,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -251,6 +254,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -279,6 +283,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -307,6 +312,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -335,6 +341,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -362,6 +369,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -386,6 +394,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -411,6 +420,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -440,6 +450,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -469,6 +480,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -498,6 +510,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -527,6 +540,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -556,6 +570,7 @@ namespace Js
         BOOL isLittleEndian = FALSE;
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -584,6 +599,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -609,6 +625,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {
@@ -638,6 +655,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !DataView::Is(args[0]))
         {

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -3457,6 +3457,7 @@ namespace Js
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -4332,6 +4333,7 @@ namespace Js
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -4989,6 +4991,7 @@ Case0:
         SETOBJECT_FOR_MUTATION(jsReentLock, args[0]);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -5284,6 +5287,7 @@ Case0:
         ARGUMENTS(args, callInfo);
         ScriptContext* scriptContext = function->GetScriptContext();
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -5341,6 +5345,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -5789,6 +5794,7 @@ Case0:
         SETOBJECT_FOR_MUTATION(jsReentLock, args[0]);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         Var res = scriptContext->GetLibrary()->GetUndefined();
 
@@ -6123,6 +6129,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         Var res = scriptContext->GetLibrary()->GetUndefined();
 
@@ -7730,6 +7737,7 @@ Case0:
         SETOBJECT_FOR_MUTATION(jsReentLock, args[0]);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -7857,6 +7865,7 @@ Case0:
         SETOBJECT_FOR_MUTATION(jsReentLock, args[0]);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         Var res = scriptContext->GetLibrary()->GetUndefined();
 
@@ -8050,6 +8059,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8289,6 +8299,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8454,6 +8465,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8488,6 +8500,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8525,6 +8538,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8562,6 +8576,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8593,6 +8608,7 @@ Case0:
         Assert(!(callInfo.Flags & CallFlags_New));
 
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_every);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8736,6 +8752,7 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_some);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8877,6 +8894,7 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_forEach)
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -8970,7 +8988,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
         SETOBJECT_FOR_MUTATION(jsReentLock, pArr);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         bool isTypedArrayEntryPoint = typedArrayBase != nullptr;
         JavascriptLibrary* library = scriptContext->GetLibrary();
@@ -9168,7 +9186,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
         SETOBJECT_FOR_MUTATION(jsReentLock, pArr);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         JavascriptLibrary* library = scriptContext->GetLibrary();
 
@@ -9285,6 +9303,7 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_map);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -9557,6 +9576,8 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_filter);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
+
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("Array.prototype.filter"));
@@ -9689,6 +9710,7 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_reduce);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -9859,6 +9881,7 @@ Case0:
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Array_Prototype_reduceRight);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -10216,6 +10239,7 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -10239,7 +10263,7 @@ Case0:
     {
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         // args.Info.Count cannot equal zero or we would have thrown above so no chance of underflowing
         uint32 len = args.Info.Count - 1;

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -290,6 +290,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -317,6 +318,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -344,6 +346,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -371,6 +374,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -398,6 +402,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -425,6 +430,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -452,6 +458,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -479,6 +486,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -506,6 +514,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -533,6 +542,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -556,6 +566,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -579,6 +590,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -602,6 +614,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -625,6 +638,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -648,6 +662,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -671,6 +686,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -694,6 +710,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -717,6 +734,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -740,6 +758,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -763,6 +782,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -854,6 +874,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -877,6 +898,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -900,6 +922,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -923,6 +946,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -946,6 +970,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -969,6 +994,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -992,6 +1018,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1013,6 +1040,7 @@ namespace Js
 
         ARGUMENTS(args, callInfo);
         ScriptContext* scriptContext = function->GetScriptContext();
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         Assert(!(callInfo.Flags & CallFlags_New));
 
@@ -1038,6 +1066,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1050,7 +1079,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         double value;
         if (args.Info.Count > 1)
         {
@@ -1078,6 +1106,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1101,6 +1130,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1124,6 +1154,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1147,6 +1178,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1170,6 +1202,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1193,6 +1226,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1216,6 +1250,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1239,6 +1274,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1251,7 +1287,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
             DateImplementation::DateStringFormat::Default, scriptContext,
             DateImplementation::DateTimeFlag::NoTime);
@@ -1266,6 +1301,7 @@ namespace Js
 
         Assert(!(callInfo.Flags & CallFlags_New));
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Date_Prototype_toISOString);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1278,7 +1314,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetISOString(scriptContext);
     }
 
@@ -1290,6 +1325,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -1331,6 +1367,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1367,7 +1404,6 @@ namespace Js
         }
 #endif
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
             DateImplementation::DateStringFormat::Locale, scriptContext,
             DateImplementation::DateTimeFlag::NoTime);
@@ -1381,6 +1417,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1416,7 +1453,6 @@ namespace Js
         }
 #endif
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return JavascriptDate::ToLocaleString(date, scriptContext);
     }
 
@@ -1441,6 +1477,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1476,7 +1513,6 @@ namespace Js
         }
 #endif
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
             DateImplementation::DateStringFormat::Locale, scriptContext,
             DateImplementation::DateTimeFlag::NoDate);
@@ -1490,6 +1526,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1502,8 +1539,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
             DateImplementation::DateStringFormat::Default, scriptContext,
             DateImplementation::DateTimeFlag::NoDate);
@@ -1517,6 +1552,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1529,7 +1565,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
             DateImplementation::DateStringFormat::GMT, scriptContext,
             DateImplementation::DateTimeFlag::None);
@@ -1543,6 +1578,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
@@ -1555,7 +1591,6 @@ namespace Js
         }
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         double value = date->m_date.GetMilliSeconds();
         return JavascriptNumber::ToVarNoCheck(value, scriptContext);
     }
@@ -1568,6 +1603,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -426,6 +426,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         ///
         /// Check Argument[0] has internal [[Call]] property
@@ -590,6 +591,7 @@ namespace Js
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Function_Prototype_bind);
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         ///
         /// Check Argument[0] has internal [[Call]] property
@@ -1526,8 +1528,8 @@ dbl_align:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
-
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
+
         if (args.Info.Count == 0 || !JavascriptFunction::Is(args[0]))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedFunction, _u("Function.prototype.toString"));

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -410,7 +410,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -548,13 +548,12 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedNumber, _u("Number.prototype.toExponential"));
         }
-
-        AssertMsg(args.Info.Count > 0, "negative arg count");
 
         // spec implies ToExp is not generic. 'this' must be a number
         double value;
@@ -616,12 +615,12 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedNumber, _u("Number.prototype.toFixed"));
         }
-        AssertMsg(args.Info.Count > 0, "negative arg count");
 
         // spec implies ToFixed is not generic. 'this' must be a number
         double value;
@@ -690,12 +689,12 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedNumber, _u("Number.prototype.toPrecision"));
         }
-        AssertMsg(args.Info.Count > 0, "negative arg count");
 
         // spec implies ToPrec is not generic. 'this' must be a number
         double value;
@@ -749,6 +748,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -816,6 +816,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
@@ -882,6 +883,7 @@ namespace Js
         Var value = args[0];
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -2167,7 +2167,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -664,7 +664,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         PCWSTR const varName = _u("RegExp.prototype.toString");
 
@@ -907,7 +907,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -285,7 +285,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -124,7 +124,7 @@ namespace Js
         ARGUMENTS(args, callInfo);
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         // SkipDefaultNewObject function flag should have prevented the default object from
         // being created, except when call true a host dispatch.
@@ -839,6 +839,12 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
+
+        if(args.Info.Count == 0)
+        {
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype.concat"));
+        }
 
         //
         // General algorithm:
@@ -855,11 +861,6 @@ case_2:
         // The concat function is intentionally generic; it does not require that its this value be a String object. Therefore it can be transferred to other kinds of objects for use as a method.
         //
 
-        if(args.Info.Count == 0)
-        {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype.concat"));
-        }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
         if (!JavascriptConversion::CheckObjectCoercible(args[0], scriptContext))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("String.prototype.concat"));
@@ -896,16 +897,17 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
+
+        if(args.Info.Count == 0)
+        {
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.fromCharCode"));
+        }
 
         //
         // Construct a new string instance to contain all of the explicit parameters:
         // - Don't include the 'this' parameter.
         //
-        if(args.Info.Count == 0)
-        {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.fromCharCode"));
-        }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         int charLength = args.Info.Count - 1;
 
@@ -942,8 +944,7 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
-
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count <= 1)
         {
@@ -1244,11 +1245,12 @@ case_2:
     // 3. ReturnIfAbrupt(S).
     void JavascriptString::GetThisStringArgument(ArgumentReader& args, ScriptContext* scriptContext, const char16* apiNameForErrorMsg, JavascriptString** ppThis)
     {
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
+
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, apiNameForErrorMsg);
         }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         JavascriptString * pThis = JavascriptOperators::TryFromVar<JavascriptString>(args[0]);
         if (!pThis)
@@ -1297,12 +1299,12 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if(args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype.localeCompare"));
         }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         JavascriptString * pThis;
         JavascriptString * pThat;
@@ -2059,7 +2061,7 @@ case_2:
     JavascriptString* JavascriptString::PadCore(ArgumentReader& args, JavascriptString *mainString, bool isPadStart, ScriptContext* scriptContext)
     {
         Assert(mainString != nullptr);
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 1)
         {
@@ -2179,12 +2181,12 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if(args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype.toString"));
         }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         JavascriptString* str = nullptr;
         if (!GetThisValueVar(args[0], &str, scriptContext))
@@ -2665,12 +2667,12 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if(args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype.valueOf"));
         }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         JavascriptString* str = nullptr;
         if (!GetThisValueVar(args[0], &str, scriptContext))
@@ -2698,12 +2700,12 @@ case_2:
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, _u("String.prototype[Symbol.iterator]"));
         }
-        AssertMsg(args.Info.Count > 0, "Negative argument count");
 
         if (!JavascriptConversion::CheckObjectCoercible(args[0], scriptContext))
         {

--- a/lib/Runtime/Library/SharedArrayBuffer.cpp
+++ b/lib/Runtime/Library/SharedArrayBuffer.cpp
@@ -110,6 +110,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !SharedArrayBuffer::Is(args[0]))
         {
@@ -222,7 +223,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Assert(args.Info.Count > 0);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         return args[0];
     }

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -1297,6 +1297,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {
@@ -1322,6 +1323,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {
@@ -1351,6 +1353,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {
@@ -1380,6 +1383,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {
@@ -1419,6 +1423,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, return undefined.
@@ -1493,6 +1498,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {
@@ -1511,6 +1517,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         Assert(!(callInfo.Flags & CallFlags_New));
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         // This method is only called in pre-ES6 compat modes. In those modes, we need to throw an error
         // if the this argument is not the same type as our TypedArray template instance.
@@ -1574,6 +1581,7 @@ namespace Js
 
         Assert(!(callInfo.Flags & CallFlags_New));
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(TypedArray_Prototype_subarray);
+        AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
 
         if (args.Info.Count == 0 || !TypedArrayBase::Is(args[0]))
         {


### PR DESCRIPTION
**EDIT: significantly revised following feedback** - below description wrong left for ref only

Saw issue #387 and thought why not.

Removed if()s for:
1. ```args.info.count == 0```
2. ```args.info.count > 0```

From Javascript method entry points as there's always an implicit "this" value. Replaced these with assertions.

Additionally tidied up the variety of assertions used for the related condition to consistently be:
```AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");```

Intentionally excluded:
1. JavaScript SIMD as I understand it's soon to be removed
2. WASM as I don't know if it works the same way
3. Anything that isn't an Entry point