### PR TITLE
Fix a recent regression where we could hit an assert when attempting to recursively inline a function that came from dynamic script.

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7514,7 +7514,8 @@ namespace Js
 
     bool FunctionBody::CheckCalleeContextForInlining(FunctionProxy* calleeFunctionProxy)
     {
-        return this->GetScriptContext() == calleeFunctionProxy->GetScriptContext();
+        return this->GetScriptContext() == calleeFunctionProxy->GetScriptContext() &&
+            this->GetSecondaryHostSourceContext() == calleeFunctionProxy->GetSecondaryHostSourceContext();
     }
 
 #if ENABLE_NATIVE_CODEGEN

--- a/test/inlining/callToDynamicScript.js
+++ b/test/inlining/callToDynamicScript.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Minimal switches: -bgjit- -loopinterpretcount:1
+
+// Either a.b.call() should not be inlined, or a.b should be constructed in such a way that
+// attempting to recursively inline its contents does not assert.
+function test0(){
+    const a = { b: new Function("[].slice();") };
+    for (let i = 0; i < 2; ++i)
+        a.b.call();
+};
+
+test0();
+WScript.Echo("Passed");

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -290,4 +290,10 @@
       <files>bug12528802.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>callToDynamicScript.js</files>
+      <compile-flags>-loopinterpretcount:1 -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
I recently removed a check for matching secondary host source context when deciding whether to inline a getter or call/apply target. In certain circumstances, that change can cause an assertion to fail, so this change adds back the check.

The assertion in question is in `DynamicProfileInfo::GetCallSiteInfo`, and it asserts that the function must either be built-in, a public library function, or `HasCallSiteInfo(functionBody)`. `HasCallSiteInfo` checks whether the function body's source context matches the `noContextSourceContextInfo`, which is the case for functions generated from strings. However, if I ignore the assertion and continue, `callSiteInfo` seems to exist and contain correct data, which leads me to think that `HasCallSiteInfo` might be overly restrictive. If anyone knows more about that possibility, I'd welcome feedback. Otherwise, the safe change is just to block this particular inlining case.

Fixes OS:15987143