### PR TITLE
Properly set name property of named class expressions assigned to object property

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -9107,7 +9107,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
 
                     if (pnode->sxBin.pnode1->nop == knopDot)
                     {
-                        pnode->sxBin.pnode2->sxFnc.isNameIdentifierRef  = false;
+                        pnode->sxBin.pnode2->sxFnc.isNameIdentifierRef = false;
                     }
                     else if (pnode->sxBin.pnode1->nop == knopName)
                     {
@@ -9118,7 +9118,11 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
                 if (pnode->sxBin.pnode2->nop == knopClassDecl && pnode->sxBin.pnode1->nop == knopDot)
                 {
                     Assert(pnode->sxBin.pnode2->sxClass.pnodeConstructor);
-                    pnode->sxBin.pnode2->sxClass.pnodeConstructor->sxFnc.isNameIdentifierRef  = false;
+
+                    if (!pnode->sxBin.pnode2->sxClass.pnodeConstructor->sxFnc.pid)
+                    {
+                        pnode->sxBin.pnode2->sxClass.pnodeConstructor->sxFnc.isNameIdentifierRef = false;
+                    }
                 }
             }
             pNameHint = NULL;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -7670,21 +7670,21 @@ void EmitCallTarget(
     {
         if (!pnodeTarget->IsSpecialName())
         {
-        funcInfo->AcquireLoc(pnodeTarget);
-        // Assign the call target operand(s), putting them into expression temps if necessary to protect
-        // them from side-effects.
-        if (fSideEffectArgs)
-        {
-            SaveOpndValue(pnodeTarget, funcInfo);
-        }
-        byteCodeGenerator->EmitLoadInstance(pnodeTarget->sxPid.sym, pnodeTarget->sxPid.pid, thisLocation, callObjLocation, funcInfo);
-        if (*callObjLocation != Js::Constants::NoRegister)
-        {
-            // Load the call target as a property of the instance.
-            Js::PropertyId propertyId = pnodeTarget->sxPid.PropertyIdFromNameNode();
-            EmitMethodFld(pnodeTarget, *callObjLocation, propertyId, byteCodeGenerator, funcInfo);
-            break;
-        }
+            funcInfo->AcquireLoc(pnodeTarget);
+            // Assign the call target operand(s), putting them into expression temps if necessary to protect
+            // them from side-effects.
+            if (fSideEffectArgs)
+            {
+                SaveOpndValue(pnodeTarget, funcInfo);
+            }
+            byteCodeGenerator->EmitLoadInstance(pnodeTarget->sxPid.sym, pnodeTarget->sxPid.pid, thisLocation, callObjLocation, funcInfo);
+            if (*callObjLocation != Js::Constants::NoRegister)
+            {
+                // Load the call target as a property of the instance.
+                Js::PropertyId propertyId = pnodeTarget->sxPid.PropertyIdFromNameNode();
+                EmitMethodFld(pnodeTarget, *callObjLocation, propertyId, byteCodeGenerator, funcInfo);
+                break;
+            }
         }
 
         // FALL THROUGH to evaluate call target.

--- a/test/es6/bug_issue_4635.js
+++ b/test/es6/bug_issue_4635.js
@@ -15,11 +15,35 @@ var tests = [
     }
   },
   {
-    name: "Unnamed function expression should not have a name property",
+    name: "Unnamed function expression should have an empty name property",
     body: function () {
         var obj = {};
         obj.a = class { };
-        assert.areEqual('', obj.a.name, "Since the class expression is unnamed, it should not have a name property");
+        assert.areEqual('', obj.a.name, "Since the class expression is unnamed, it should have an empty name property");
+    }
+  },
+  {
+    name: "Instance of a named function expression",
+    body: function () {
+        var obj = {};
+        obj.a = class A { 
+            n() { return this.constructor.name; }
+        };
+        var a = new obj.a();
+        assert.areEqual('A', a.constructor.name, "Constructor should be class itself which should have a name property");
+        assert.areEqual('A', a.n(), "Name property lookup via instance method");
+    }
+  },
+  {
+    name: "Instance of an unnamed function expression",
+    body: function () {
+        var obj = {};
+        obj.a = class {
+            n() { return this.constructor.name; }
+        };
+        var a = new obj.a();
+        assert.areEqual('', a.constructor.name, "Constructor should be class itself which should have an empty name property");
+        assert.areEqual('', a.n(), "Name property lookup via instance method");
     }
   },
 ];

--- a/test/es6/bug_issue_4635.js
+++ b/test/es6/bug_issue_4635.js
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Named function expression should have a name property even if it's being assigned to an object property",
+    body: function () {
+        var obj = {};
+        obj.a = class A { };
+        assert.areEqual('A', obj.a.name, "Since the class expression is named, it should have a name property");
+    }
+  },
+  {
+    name: "Unnamed function expression should not have a name property",
+    body: function () {
+        var obj = {};
+        obj.a = class { };
+        assert.areEqual('', obj.a.name, "Since the class expression is unnamed, it should not have a name property");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1423,6 +1423,13 @@
   </test>
   <test>
     <default>
+      <files>bug_issue_4635.js</files>
+      <tags>BugFix</tags>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>DeferParseLambda.js</files>
       <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
When we have a named class expression in an object property assignment, we ignore the name of the class and don't set it as the 'name' property of the class.

Fixes #4635
