### PR TITLE
Array profile data usage optimzation

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1464,6 +1464,11 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
     {
         newInstance->OrFlags(Js::InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall);
     }
+    else if (bailOutKind == IR::BailOutOnNotNativeArray)
+    {
+        newInstance->OrFlags(Js::InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization);
+    }
+
     if (isInlinee)
     {
         newInstance->OrFlags(Js::InterpreterStackFrameFlags_FromBailOutInInlinee);

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3421,7 +3421,7 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
                     if(instr->GetSrc1()->IsIndirOpnd() && opnd == instr->GetSrc1()->AsIndirOpnd()->GetBaseOpnd())
                     {
                         profiledArrayType = profiledInstr->u.ldElemInfo->GetArrayType();
-                        useAggressiveSpecialization = !profiledInstr->u.ldElemInfo->DisableAggressiveSpecialization();
+                        useAggressiveSpecialization = !profiledInstr->u.ldElemInfo->IsAggressiveSpecializationDisabled();
                     }
                     break;
 
@@ -3431,7 +3431,7 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
                     if(instr->GetDst()->IsIndirOpnd() && opnd == instr->GetDst()->AsIndirOpnd()->GetBaseOpnd())
                     {
                         profiledArrayType = profiledInstr->u.stElemInfo->GetArrayType();
-                        useAggressiveSpecialization = !profiledInstr->u.stElemInfo->DisableAggressiveSpecialization();
+                        useAggressiveSpecialization = !profiledInstr->u.stElemInfo->IsAggressiveSpecializationDisabled();
                     }
                     break;
 
@@ -3439,7 +3439,7 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
                     if(instr->GetSrc1()->IsRegOpnd() && opnd == instr->GetSrc1())
                     {
                         profiledArrayType = profiledInstr->u.LdLenInfo().GetArrayType();
-                        useAggressiveSpecialization = !profiledInstr->u.LdLenInfo().DisableAggressiveSpecialization();
+                        useAggressiveSpecialization = !profiledInstr->u.LdLenInfo().IsAggressiveSpecializationDisabled();
                     }
                     break;
             }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3406,20 +3406,22 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
     {
         ValueType valueType(val->GetValueInfo()->Type());
 
-        // This block uses local profiling data to optimize the case of a native array being passed to a function that fills it with other types. When the function is inlined
-        // into different call paths which use different types this can cause a perf hit by performing unnecessary array conversions, so only perform this optimization when
-        // the function is not inlined.
-        if (valueType.IsLikelyNativeArray() && !valueType.IsObject() && instr->IsProfiledInstr() && !instr->m_func->IsInlined())
+        // This block uses per-instruction profile information on array types to optimize using the best available profile
+        // information and to prevent infinite bailouts by ensuring array type information is updated on bailouts.
+        if (valueType.IsLikelyArray() && !valueType.IsObject() && instr->IsProfiledInstr())
         {
             // See if we have profile data for the array type
             IR::ProfiledInstr *const profiledInstr = instr->AsProfiledInstr();
             ValueType profiledArrayType;
+
+            bool useAggressiveSpecialization = true;
             switch(instr->m_opcode)
             {
                 case Js::OpCode::LdElemI_A:
                     if(instr->GetSrc1()->IsIndirOpnd() && opnd == instr->GetSrc1()->AsIndirOpnd()->GetBaseOpnd())
                     {
                         profiledArrayType = profiledInstr->u.ldElemInfo->GetArrayType();
+                        useAggressiveSpecialization = !profiledInstr->u.ldElemInfo->DisableAggressiveSpecialization();
                     }
                     break;
 
@@ -3429,6 +3431,7 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
                     if(instr->GetDst()->IsIndirOpnd() && opnd == instr->GetDst()->AsIndirOpnd()->GetBaseOpnd())
                     {
                         profiledArrayType = profiledInstr->u.stElemInfo->GetArrayType();
+                        useAggressiveSpecialization = !profiledInstr->u.stElemInfo->DisableAggressiveSpecialization();
                     }
                     break;
 
@@ -3436,16 +3439,28 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
                     if(instr->GetSrc1()->IsRegOpnd() && opnd == instr->GetSrc1())
                     {
                         profiledArrayType = profiledInstr->u.LdLenInfo().GetArrayType();
+                        useAggressiveSpecialization = !profiledInstr->u.LdLenInfo().DisableAggressiveSpecialization();
                     }
                     break;
             }
-            if(profiledArrayType.IsLikelyObject() &&
-                profiledArrayType.GetObjectType() == valueType.GetObjectType() &&
-                (profiledArrayType.HasVarElements() || (valueType.HasIntElements() && profiledArrayType.HasFloatElements())))
+
+            if (profiledArrayType.IsLikelyObject() && profiledArrayType.GetObjectType() == valueType.GetObjectType())
             {
-                // Merge array type we pulled from profile with type propagated by dataflow.
-                valueType = valueType.Merge(profiledArrayType).SetHasNoMissingValues(valueType.HasNoMissingValues());
-                ChangeValueType(this->currentBlock, CurrentBlockData()->FindValue(opnd->AsRegOpnd()->m_sym), valueType, false);
+                // Ideally we want to use the most specialized type seen by this path, but when that causes bailouts use the least specialized type instead.
+                if (useAggressiveSpecialization && !valueType.IsLikelyNativeIntArray() &&
+                    (profiledArrayType.HasIntElements() || (valueType.HasVarElements() && profiledArrayType.HasFloatElements())))
+                {
+                    // use the more specialized type profiled by the instruction.
+                    valueType = profiledArrayType.SetHasNoMissingValues(valueType.HasNoMissingValues());
+                    ChangeValueType(this->currentBlock, CurrentBlockData()->FindValue(opnd->AsRegOpnd()->m_sym), valueType, false);
+                }
+                else if (!useAggressiveSpecialization && valueType.IsLikelyNativeArray() &&
+                    (profiledArrayType.HasVarElements() || (valueType.HasIntElements() && profiledArrayType.HasFloatElements())))
+                {
+                    // Merge array type we pulled from profile with type propagated by dataflow.
+                    valueType = valueType.Merge(profiledArrayType).SetHasNoMissingValues(valueType.HasNoMissingValues());
+                    ChangeValueType(this->currentBlock, CurrentBlockData()->FindValue(opnd->AsRegOpnd()->m_sym), valueType, false);
+                }
             }
         }
 
@@ -13391,11 +13406,9 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
                 if (!baseValueInLoopLandingPad->GetValueInfo()->CanMergeToSpecificObjectType())
                 {
                     ValueType landingPadValueType = baseValueInLoopLandingPad->GetValueInfo()->Type();
-                    Assert(landingPadValueType.IsSimilar(baseValueType) ||
-                        (
-                            landingPadValueType.IsLikelyNativeArray() &&
-                            landingPadValueType.Merge(baseValueType).IsSimilar(baseValueType)
-                        )
+                    Assert(landingPadValueType.IsSimilar(baseValueType) 
+                        || (landingPadValueType.IsLikelyNativeArray() && landingPadValueType.Merge(baseValueType).IsSimilar(baseValueType))
+                        || (baseValueType.IsLikelyNativeArray() && baseValueType.Merge(landingPadValueType).IsSimilar(landingPadValueType))
                     );
                 }
 #endif

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -4482,9 +4482,10 @@ IRBuilder::BuildProfiledElementCP(Js::OpCode newOpcode, uint32 offset, Js::RegSl
 
     ValueType arrayType = ValueType::Uninitialized;
 
+    const Js::LdLenInfo * ldLenInfo = nullptr;
     if (m_func->HasProfileInfo())
     {
-        const Js::LdLenInfo * ldLenInfo = m_func->GetReadOnlyProfileInfo()->GetLdLenInfo(profileId);
+        ldLenInfo = m_func->GetReadOnlyProfileInfo()->GetLdLenInfo(profileId);
         arrayType = (ldLenInfo->GetArrayType());
         if (arrayType.IsLikelyNativeArray() &&
             (
@@ -4522,7 +4523,8 @@ IRBuilder::BuildProfiledElementCP(Js::OpCode newOpcode, uint32 offset, Js::RegSl
         IR::ProfiledInstr * profiledInstr = IR::ProfiledInstr::New(newOpcode, dstOpnd, fieldSymOpnd, m_func);
         instr = profiledInstr;
         profiledInstr->u.FldInfo() = *(m_func->GetReadOnlyProfileInfo()->GetFldInfo(inlineCacheIndex));
-        profiledInstr->u.LdLenInfo().GetArrayType() = arrayType;
+        profiledInstr->u.LdLenInfo() = *ldLenInfo;
+        profiledInstr->u.LdLenInfo().arrayType = arrayType;
         wasNotProfiled = !profiledInstr->u.FldInfo().WasLdFldProfiled();
         dstOpnd->SetValueType(instr->AsProfiledInstr()->u.FldInfo().valueType);
 #if ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Backend/JITTimeProfileInfo.cpp
+++ b/lib/Backend/JITTimeProfileInfo.cpp
@@ -25,6 +25,7 @@ JITTimeProfileInfo::InitializeJITProfileData(
         return;
     }
 
+    CompileAssert(sizeof(LdLenIDL) == sizeof(Js::LdLenInfo));
     CompileAssert(sizeof(LdElemIDL) == sizeof(Js::LdElemInfo));
     CompileAssert(sizeof(StElemIDL) == sizeof(Js::StElemInfo));
 

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -8694,11 +8694,13 @@ void Lowerer::LowerProfiledLdElemI(IR::JitProfilingInstr *const instr)
             const Var varIndex,
             FunctionBody *const functionBody,
             const ProfileId profileId,
-            bool didArrayAccessHelperCall)
+            bool didArrayAccessHelperCall,
+            bool bailedOutOnArraySpecialization)
     */
 
     Func *const func = instr->m_func;
 
+    m_lowererMD.LoadHelperArgument(instr, IR::IntConstOpnd::New(false, TyInt8, func));
     m_lowererMD.LoadHelperArgument(instr, IR::IntConstOpnd::New(false, TyInt8, func));
     m_lowererMD.LoadHelperArgument(instr, IR::Opnd::CreateProfileIdOpnd(instr->profileId, func));
     m_lowererMD.LoadHelperArgument(instr, CreateFunctionBodyOpnd(func));
@@ -8729,7 +8731,8 @@ void Lowerer::LowerProfiledStElemI(IR::JitProfilingInstr *const instr, const Js:
             FunctionBody *const functionBody,
             const ProfileId profileId,
             const PropertyOperationFlags flags,
-            bool didArrayAccessHelperCall)
+            bool didArrayAccessHelperCall,
+            bool bailedOutOnArraySpecialization)
     */
 
     Func *const func = instr->m_func;
@@ -8742,6 +8745,7 @@ void Lowerer::LowerProfiledStElemI(IR::JitProfilingInstr *const instr, const Js:
     else
     {
         helper = IR::HelperProfiledStElem;
+        m_lowererMD.LoadHelperArgument(instr, IR::IntConstOpnd::New(false, TyInt8, func));
         m_lowererMD.LoadHelperArgument(instr, IR::IntConstOpnd::New(false, TyInt8, func));
         m_lowererMD.LoadHelperArgument(instr, IR::IntConstOpnd::New(flags, TyInt32, func, true));
     }

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -243,6 +243,8 @@ typedef struct ArrayCallSiteIDL
 typedef struct LdLenIDL
 {
     unsigned short arrayType;
+    byte bits;
+    IDL_PAD1(0)
 } LdLenIDL;
 
 typedef struct LdElemIDL

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -179,9 +179,22 @@ namespace Js
 
     struct LdLenInfo
     {
-        typedef struct { ValueType::TSize f1; } TSize;
+        typedef struct { ValueType::TSize f1; byte f2; } TSize;
 
         ValueType arrayType;
+
+        union
+        {
+            struct
+            {
+                bool disableAggressiveSpecialization : 1;
+            };
+            byte bits;
+        };
+
+        LdLenInfo() : bits(0)
+        {
+        }
 
         void Merge(const LdLenInfo & other)
         {
@@ -191,6 +204,11 @@ namespace Js
         ValueType GetArrayType() const
         {
             return arrayType;
+        }
+
+        bool DisableAggressiveSpecialization() const
+        {
+            return disableAggressiveSpecialization;
         }
     };
     CompileAssert(sizeof(LdLenInfo::TSize) == sizeof(LdLenInfo));
@@ -206,6 +224,7 @@ namespace Js
             {
                 bool wasProfiled : 1;
                 bool neededHelperCall : 1;
+                bool disableAggressiveSpecialization : 1;
             };
             byte bits;
         };
@@ -241,6 +260,11 @@ namespace Js
         {
             return neededHelperCall;
         }
+
+        bool DisableAggressiveSpecialization() const
+        {
+            return disableAggressiveSpecialization;
+        }
     };
 
     struct StElemInfo
@@ -257,6 +281,7 @@ namespace Js
                 bool neededHelperCall : 1;
                 bool storedOutsideHeadSegmentBounds : 1;
                 bool storedOutsideArrayBounds : 1;
+                bool disableAggressiveSpecialization : 1;
             };
             byte bits;
         };
@@ -305,6 +330,11 @@ namespace Js
         bool LikelyStoresOutsideArrayBounds() const
         {
             return storedOutsideArrayBounds;
+        }
+
+        bool DisableAggressiveSpecialization() const
+        {
+            return disableAggressiveSpecialization;
         }
     };
 

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -206,7 +206,7 @@ namespace Js
             return arrayType;
         }
 
-        bool DisableAggressiveSpecialization() const
+        bool IsAggressiveSpecializationDisabled() const
         {
             return disableAggressiveSpecialization;
         }
@@ -261,7 +261,7 @@ namespace Js
             return neededHelperCall;
         }
 
-        bool DisableAggressiveSpecialization() const
+        bool IsAggressiveSpecializationDisabled() const
         {
             return disableAggressiveSpecialization;
         }
@@ -332,7 +332,7 @@ namespace Js
             return storedOutsideArrayBounds;
         }
 
-        bool DisableAggressiveSpecialization() const
+        bool IsAggressiveSpecializationDisabled() const
         {
             return disableAggressiveSpecialization;
         }

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -4977,9 +4977,10 @@ namespace Js
                 GetReg(playout->Element),
                 m_functionBody,
                 playout->profileId,
-                this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall)));
+                this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall),
+                this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization)));
 
-        this->ClearFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall);
+        this->ClearFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall | InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization);
 
         threadContext->CheckAndResetImplicitCallAccessorFlag();
         threadContext->AddImplicitCallFlags(savedImplicitCallFlags);
@@ -5077,9 +5078,10 @@ namespace Js
             m_functionBody,
             playout->profileId,
             flags,
-            this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall));
+            this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall),
+            this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization));
 
-        this->ClearFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall);
+        this->ClearFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall | InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization);
 
         threadContext->CheckAndResetImplicitCallAccessorFlag();
         threadContext->AddImplicitCallFlags(savedImplicitCallFlags);
@@ -8411,6 +8413,12 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
         LdLenInfo ldLenInfo;
         ldLenInfo.arrayType = ValueType::Uninitialized.Merge(instance);
         profileData->RecordLengthLoad(functionBody, playout->profileId, ldLenInfo);
+
+        if (this->TestFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization))
+        {
+            ldLenInfo.disableAggressiveSpecialization = true;
+            this->ClearFlags(InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization);
+        }
 
         ThreadContext* threadContext = this->GetScriptContext()->GetThreadContext();
         ImplicitCallFlags savedImplicitCallFlags = threadContext->GetImplicitCallFlags();

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -28,6 +28,7 @@ namespace Js
         InterpreterStackFrameFlags_ProcessingBailOutOnArrayAccessHelperCall = 0x10,
         InterpreterStackFrameFlags_ProcessingBailOutFromEHCode = 0x20,
         InterpreterStackFrameFlags_FromBailOutInInlinee = 0x40,
+        InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization = 0x80,
         InterpreterStackFrameFlags_All = 0xFFFF,
     };
 

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -12,7 +12,8 @@ namespace Js
         const Var varIndex,
         FunctionBody *const functionBody,
         const ProfileId profileId,
-        bool didArrayAccessHelperCall)
+        bool didArrayAccessHelperCall,
+        bool bailedOutOnArraySpecialization)
     {
         Assert(base);
         Assert(varIndex);
@@ -20,6 +21,11 @@ namespace Js
         Assert(profileId != Constants::NoProfileId);
 
         LdElemInfo ldElemInfo;
+
+        if (bailedOutOnArraySpecialization)
+        {
+            ldElemInfo.disableAggressiveSpecialization = true;
+        }
 
         // Only enable fast path if the javascript array is not cross site
 #if ENABLE_COPYONACCESS_ARRAY
@@ -197,7 +203,7 @@ namespace Js
         FunctionBody *const functionBody,
         const ProfileId profileId)
     {
-        ProfiledStElem(base, varIndex, value, functionBody, profileId, PropertyOperation_None, false);
+        ProfiledStElem(base, varIndex, value, functionBody, profileId, PropertyOperation_None, false, false);
     }
 
     void ProfilingHelpers::ProfiledStElem(
@@ -207,7 +213,8 @@ namespace Js
         FunctionBody *const functionBody,
         const ProfileId profileId,
         const PropertyOperationFlags flags,
-        bool didArrayAccessHelperCall)
+        bool didArrayAccessHelperCall,
+        bool bailedOutOnArraySpecialization)
     {
         Assert(base);
         Assert(varIndex);
@@ -216,6 +223,11 @@ namespace Js
         Assert(profileId != Constants::NoProfileId);
 
         StElemInfo stElemInfo;
+
+        if (bailedOutOnArraySpecialization)
+        {
+            stElemInfo.disableAggressiveSpecialization = true;
+        }
 
         // Only enable fast path if the javascript array is not cross site
         const bool isJsArray = !TaggedNumber::Is(base) && VirtualTableInfo<JavascriptArray>::HasVirtualTable(base);

--- a/lib/Runtime/Language/ProfilingHelpers.h
+++ b/lib/Runtime/Language/ProfilingHelpers.h
@@ -10,12 +10,12 @@ namespace Js
     class ProfilingHelpers
     {
     public:
-        static Var ProfiledLdElem(const Var base, const Var varIndex, FunctionBody *const functionBody, const ProfileId profileId, bool didArrayAccessHelperCall);
+        static Var ProfiledLdElem(const Var base, const Var varIndex, FunctionBody *const functionBody, const ProfileId profileId, bool didArrayAccessHelperCall, bool bailedOutOnArraySpecialization);
         static Var ProfiledLdElem_FastPath(JavascriptArray *const array, const Var varIndex, ScriptContext *const scriptContext, LdElemInfo *const ldElemInfo = nullptr);
 
     public:
         static void ProfiledStElem_DefaultFlags(const Var base, const Var varIndex, const Var value, FunctionBody *const functionBody, const ProfileId profileId);
-        static void ProfiledStElem(const Var base, const Var varIndex, const Var value, FunctionBody *const functionBody, const ProfileId profileId, const PropertyOperationFlags flags, bool didArrayAccessHelperCall);
+        static void ProfiledStElem(const Var base, const Var varIndex, const Var value, FunctionBody *const functionBody, const ProfileId profileId, const PropertyOperationFlags flags, bool didArrayAccessHelperCall, bool bailedOutOnArraySpecialization);
         static void ProfiledStElem_FastPath(JavascriptArray *const array, const Var varIndex, const Var value, ScriptContext *const scriptContext, const PropertyOperationFlags flags, StElemInfo *const stElemInfo = nullptr);
 
     public:


### PR DESCRIPTION
This commit changes usage of array profile data in an attempt to better handle certain cases (such as inlined common functions) by using the most specialized (int>float>var) array type profiled when merging profile data, unless the instruction has previous bailed out on NotNativeArray, in which case it will use the least specialized type to avoid infinite bailouts.

This also fixes an infinite bailout in Ares-6 ML benchmark which was introduced by #3169
