### PR TITLE
fixes for dynamic profile caching

### DIFF
--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1971,11 +1971,13 @@ namespace Js
 
             if (!reader->Read(functionId))
             {
+                AssertOrFailFast(false);
                 return nullptr;
             }
 
             if (!reader->Read(&paramInfoCount))
             {
+                AssertOrFailFast(false);
                 return nullptr;
             }
 
@@ -2206,6 +2208,7 @@ namespace Js
         }
 
     Error:
+        AssertOrFailFast(false);
         return nullptr;
     }
 

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -889,6 +889,7 @@ namespace Js
         {
             if (lengthLeft < sizeof(T))
             {
+                AssertOrFailFast(false);
                 return false;
             }
             *data = *(T *)current;
@@ -914,6 +915,7 @@ namespace Js
             size_t size = sizeof(T) * len;
             if (lengthLeft < size)
             {
+                AssertOrFailFast(false);
                 return false;
             }
             memcpy_s(data, size, current, size);

--- a/lib/Runtime/Language/DynamicProfileStorage.cpp
+++ b/lib/Runtime/Language/DynamicProfileStorage.cpp
@@ -626,8 +626,7 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
         Assert(FALSE);
         return false;
     }
-    uint recordWritten = 0;
-    for (uint i = 0; recordWritten < recordCount; i++)
+    for (uint i = 0; i < recordCount; i++)
     {
         char16 const * url = infoMap.GetKeyAt(i);
         if (url == nullptr)
@@ -675,8 +674,6 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
             Assert(FALSE);
             return false;
         }
-
-        recordWritten++;
     }
     writer.Close();
 #if DBG_DUMP

--- a/lib/Runtime/Language/DynamicProfileStorage.cpp
+++ b/lib/Runtime/Language/DynamicProfileStorage.cpp
@@ -1057,9 +1057,15 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
             AssertOrFailFast(!useCacheDir);
             if (info->record != nullptr)
             {
-                DeleteRecord(info->record);
+                // Here it can be in GC and generated new record, and the GC call an be from 
+                // allocation that deserializing info->record. So not replacing the old record 
+                // since we might be loading data from it, and drop the new generated one.
+                DeleteRecord(record);
             }
-            info->record = record;
+            else
+            {
+                info->record = record;
+            }
             return;
         }
         AssertOrFailFast(useCacheDir);

--- a/lib/Runtime/Language/DynamicProfileStorage.cpp
+++ b/lib/Runtime/Language/DynamicProfileStorage.cpp
@@ -22,9 +22,8 @@ int32 DynamicProfileStorage::lastOffset = 0;
 DWORD const DynamicProfileStorage::MagicNumber = 20100526;
 DWORD const DynamicProfileStorage::FileFormatVersion = 2;
 DWORD DynamicProfileStorage::nextFileId = 0;
-#if DBG
 bool DynamicProfileStorage::locked = false;
-#endif
+
 
 class DynamicProfileStorageReaderWriter
 {
@@ -67,7 +66,7 @@ DynamicProfileStorageReaderWriter::~DynamicProfileStorageReaderWriter()
 
 bool DynamicProfileStorageReaderWriter::Init(char16 const * filename, char16 const * mode, bool deleteNonClosed, errno_t * err = nullptr)
 {
-    Assert(file == nullptr);
+    AssertOrFailFast(file == nullptr);
     errno_t e = _wfopen_s(&file, filename, mode);
     if (e != 0)
     {
@@ -91,7 +90,7 @@ bool DynamicProfileStorageReaderWriter::Read(T * t)
 template <typename T>
 bool DynamicProfileStorageReaderWriter::ReadArray(T * t, size_t len)
 {
-    Assert(file);
+    AssertOrFailFast(file);
     int32 pos = ftell(file);
     if (fread(t, sizeof(T), len, file) != len)
     {
@@ -149,7 +148,7 @@ bool DynamicProfileStorageReaderWriter::Write(T const& t)
 template <typename T>
 bool DynamicProfileStorageReaderWriter::WriteArray(T * t, size_t len)
 {
-    Assert(file);
+    AssertOrFailFast(file);
     if (fwrite(t, sizeof(T), len, file) != len)
     {
         Output::Print(_u("ERROR: DynamicProfileStorage: Unable to write to file '%s'\n"), filename);
@@ -177,19 +176,19 @@ bool DynamicProfileStorageReaderWriter::WriteUtf8String(char16 const * str)
 
 bool DynamicProfileStorageReaderWriter::Seek(int32 offset)
 {
-    Assert(file);
+    AssertOrFailFast(file);
     return fseek(file, offset, SEEK_SET) == 0;
 }
 
 bool DynamicProfileStorageReaderWriter::SeekToEnd()
 {
-    Assert(file);
+    AssertOrFailFast(file);
     return fseek(file, 0, SEEK_END) == 0;
 }
 
 int32 DynamicProfileStorageReaderWriter::Size()
 {
-    Assert(file);
+    AssertOrFailFast(file);
     int32 current = ftell(file);
     SeekToEnd();
     int32 end = ftell(file);
@@ -199,7 +198,7 @@ int32 DynamicProfileStorageReaderWriter::Size()
 
 void DynamicProfileStorageReaderWriter::Close(bool deleteFile)
 {
-    Assert(file);
+    AssertOrFailFast(file);
     fflush(file);
     fclose(file);
     file = nullptr;
@@ -296,7 +295,7 @@ char16 const * DynamicProfileStorage::GetMessageType()
 
 bool DynamicProfileStorage::Initialize()
 {
-    AssertMsg(!initialized, "Initialize called multiple times");
+    AssertOrFailFastMsg(!initialized, "Initialize called multiple times");
     if (initialized)
     {
         return true;
@@ -405,7 +404,7 @@ bool DynamicProfileStorage::Initialize()
 
 bool DynamicProfileStorage::Uninitialize()
 {
-    AssertMsg(!uninitialized, "Uninitialize called multiple times");
+    AssertOrFailFastMsg(!uninitialized, "Uninitialize called multiple times");
     if (!initialized || uninitialized)
     {
         return true;
@@ -418,7 +417,7 @@ bool DynamicProfileStorage::Uninitialize()
     bool success = true;
     if (Js::Configuration::Global.flags.DynamicProfileCache != nullptr)
     {
-        Assert(enabled);
+        AssertOrFailFast(enabled);
         if (!ExportFile(Js::Configuration::Global.flags.DynamicProfileCache))
         {
             success = false;
@@ -473,7 +472,7 @@ void DynamicProfileStorage::ClearInfoMap(bool deleteFileStorage)
         StorageInfo const& info = infoMap.GetValueAt(i);
         if (info.isFileStorage)
         {
-            Assert(useCacheDir);
+            AssertOrFailFast(useCacheDir);
             if (deleteFileStorage)
             {
                 char16 filename[_MAX_PATH];
@@ -493,7 +492,7 @@ void DynamicProfileStorage::ClearInfoMap(bool deleteFileStorage)
 
 bool DynamicProfileStorage::ImportFile(__in_z char16 const * filename, bool allowNonExistingFile)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     DynamicProfileStorageReaderWriter reader;
     errno_t e;
     if (!reader.Init(filename, _u("rb"), false, &e))
@@ -552,14 +551,14 @@ bool DynamicProfileStorage::ImportFile(__in_z char16 const * filename, bool allo
         char16 * name;
         if (!reader.ReadUtf8String(&name, &len))
         {
-            Assert(false);
+            AssertOrFailFast(false);
             return false;
         }
 
         DWORD recordLen;
         if (!reader.Read(&recordLen))
         {
-            Assert(false);
+            AssertOrFailFast(false);
             return false;
         }
 
@@ -576,7 +575,7 @@ bool DynamicProfileStorage::ImportFile(__in_z char16 const * filename, bool allo
         {
             NoCheckHeapDeleteArray(len + 1, name);
             DeleteRecord(record);
-            Assert(false);
+            AssertOrFailFast(false);
             return false;
         }
 
@@ -592,20 +591,20 @@ bool DynamicProfileStorage::ImportFile(__in_z char16 const * filename, bool allo
         Output::Flush();
     }
 #endif
-    AssertMsg(recordCount == (uint)infoMap.Count(), "failed to read all the records");
+    AssertOrFailFastMsg(recordCount == (uint)infoMap.Count(), "failed to read all the records");
     return true;
 }
 
 bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
 
     if (useCacheDir && AcquireLock())
     {
         if (!LoadCacheCatalog()) // refresh the cache catalog
         {
             ReleaseLock();
-            Assert(FALSE);
+            AssertOrFailFast(FALSE);
             return false;
         }
     }
@@ -623,7 +622,7 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
         || !writer.Write(FileFormatVersion)
         || !writer.Write(recordCount))
     {
-        Assert(FALSE);
+        AssertOrFailFast(FALSE);
         return false;
     }
     for (uint i = 0; i < recordCount; i++)
@@ -631,7 +630,7 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
         char16 const * url = infoMap.GetKeyAt(i);
         if (url == nullptr)
         {
-            Assert(false);
+            AssertOrFailFast(false);
             continue;
         }
 
@@ -640,19 +639,19 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
         char const * record;
         if (info.isFileStorage)
         {
-            Assert(useCacheDir);
+            AssertOrFailFast(useCacheDir);
             record = info.ReadRecord();
             if (record == nullptr)
             {
                 ReleaseLock();
-                Assert(FALSE);
+                AssertOrFailFast(FALSE);
                 return false;
             }
         }
         else
         {
-            Assert(!useCacheDir);
-            Assert(!locked);
+            AssertOrFailFast(!useCacheDir);
+            AssertOrFailFast(!locked);
             record = info.record;
         }
         DWORD recordSize = GetRecordSize(record);
@@ -671,7 +670,7 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
             {
                 ReleaseLock();
             }
-            Assert(FALSE);
+            AssertOrFailFast(FALSE);
             return false;
         }
     }
@@ -688,7 +687,7 @@ bool DynamicProfileStorage::ExportFile(__in_z char16 const * filename)
 
 void DynamicProfileStorage::DisableCacheDir()
 {
-    Assert(useCacheDir);
+    AssertOrFailFast(useCacheDir);
     ClearInfoMap(false);
     useCacheDir = false;
 #ifdef FORCE_DYNAMIC_PROFILE_STORAGE
@@ -698,8 +697,8 @@ void DynamicProfileStorage::DisableCacheDir()
 
 bool DynamicProfileStorage::AcquireLock()
 {
-    Assert(mutex != nullptr);
-    Assert(!locked);
+    AssertOrFailFast(mutex != nullptr);
+    AssertOrFailFast(!locked);
     DWORD ret = WaitForSingleObject(mutex, INFINITE);
     if (ret == WAIT_OBJECT_0 || ret == WAIT_ABANDONED)
     {
@@ -717,8 +716,8 @@ bool DynamicProfileStorage::AcquireLock()
 
 bool DynamicProfileStorage::ReleaseLock()
 {
-    Assert(locked);
-    Assert(mutex != nullptr);
+    AssertOrFailFast(locked);
+    AssertOrFailFast(mutex != nullptr);
 #if DBG
     locked = false;
 #endif
@@ -734,7 +733,7 @@ bool DynamicProfileStorage::ReleaseLock()
 
 bool DynamicProfileStorage::SetupCacheDir(__in_z char16 const * dirname)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
 
     mutex = CreateMutex(NULL, FALSE, _u("JSDPCACHE"));
     if (mutex == nullptr)
@@ -789,9 +788,9 @@ bool DynamicProfileStorage::SetupCacheDir(__in_z char16 const * dirname)
 
 bool DynamicProfileStorage::CreateCacheCatalog()
 {
-    Assert(enabled);
-    Assert(useCacheDir);
-    Assert(locked);
+    AssertOrFailFast(enabled);
+    AssertOrFailFast(useCacheDir);
+    AssertOrFailFast(locked);
     nextFileId = 0;
     creationTime = GetCreationTime();
     DynamicProfileStorageReaderWriter catalogFile;
@@ -822,9 +821,9 @@ bool DynamicProfileStorage::CreateCacheCatalog()
 
 bool DynamicProfileStorage::AppendCacheCatalog(__in_z char16 const * url)
 {
-    Assert(enabled);
-    Assert(useCacheDir);
-    Assert(locked);
+    AssertOrFailFast(enabled);
+    AssertOrFailFast(useCacheDir);
+    AssertOrFailFast(locked);
     DWORD magic;
     DWORD version;
     DWORD count;
@@ -893,9 +892,9 @@ bool DynamicProfileStorage::AppendCacheCatalog(__in_z char16 const * url)
 
 bool DynamicProfileStorage::LoadCacheCatalog()
 {
-    Assert(enabled);
-    Assert(useCacheDir);
-    Assert(locked);
+    AssertOrFailFast(enabled);
+    AssertOrFailFast(useCacheDir);
+    AssertOrFailFast(locked);
     DynamicProfileStorageReaderWriter catalogFile;
     DWORD magic;
     DWORD version;
@@ -933,16 +932,16 @@ bool DynamicProfileStorage::LoadCacheCatalog()
 
     DWORD start = 0;
 
-    Assert(useCacheDir);
+    AssertOrFailFast(useCacheDir);
     if (time == creationTime)
     {
         // We can reuse existing data
         start = infoMap.Count();
-        Assert(count >= start);
-        Assert(catalogFile.Size() >= lastOffset);
+        AssertOrFailFast(count >= start);
+        AssertOrFailFast(catalogFile.Size() >= lastOffset);
         if (count == nextFileId)
         {
-            Assert(catalogFile.Size() == lastOffset);
+            AssertOrFailFast(catalogFile.Size() == lastOffset);
             return true;
         }
 
@@ -981,7 +980,7 @@ bool DynamicProfileStorage::LoadCacheCatalog()
         StorageInfo * oldInfo;
         if (infoMap.TryGetReference(url, &oldInfo))
         {
-            Assert(oldInfo->isFileStorage);
+            AssertOrFailFast(oldInfo->isFileStorage);
             oldInfo->fileId = i;
         }
         else
@@ -1009,7 +1008,7 @@ bool DynamicProfileStorage::LoadCacheCatalog()
 
 void DynamicProfileStorage::ClearCacheCatalog()
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     if (useCacheDir)
     {
         if (!AcquireLock())
@@ -1038,7 +1037,7 @@ void DynamicProfileStorage::ClearCacheCatalog()
 
 void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecount(sizeof(DWORD) + *record) char const * record)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     AutoCriticalSection autocs(&cs);
 
     StorageInfo * info;
@@ -1055,7 +1054,7 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
     {
         if (!info->isFileStorage)
         {
-            Assert(!useCacheDir);
+            AssertOrFailFast(!useCacheDir);
             if (info->record != nullptr)
             {
                 DeleteRecord(info->record);
@@ -1063,7 +1062,7 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
             info->record = record;
             return;
         }
-        Assert(useCacheDir);
+        AssertOrFailFast(useCacheDir);
 
         char16 cacheFilename[_MAX_PATH];
         info->GetFilename(cacheFilename);
@@ -1091,7 +1090,7 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
         }
 
         // Can't add a new file. Disable and use memory mode
-        Assert(!useCacheDir);
+        AssertOrFailFast(!useCacheDir);
         ReleaseLock();
     }
 
@@ -1100,7 +1099,7 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
     if (newFilename == nullptr)
     {
         // out of memory, don't save anything
-        AssertMsg(false, "OOM");
+        AssertOrFailFastMsg(false, "OOM");
         DeleteRecord(record);
         if (useCacheDir)
         {
@@ -1131,8 +1130,8 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
         ReleaseLock();
     }
 
-    Assert(!useCacheDir);
-    Assert(!locked);
+    AssertOrFailFast(!useCacheDir);
+    AssertOrFailFast(!locked);
 
     newInfo.isFileStorage = false;
     newInfo.record = record;
@@ -1141,7 +1140,7 @@ void DynamicProfileStorage::SaveRecord(__in_z char16 const * filename, __in_ecou
 
 char * DynamicProfileStorage::AllocRecord(DWORD bufferSize)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     char * buffer = NoCheckHeapNewArray(char, bufferSize + sizeof(DWORD));
     if (buffer != nullptr)
     {
@@ -1152,25 +1151,25 @@ char * DynamicProfileStorage::AllocRecord(DWORD bufferSize)
 
 DWORD DynamicProfileStorage::GetRecordSize(__in_ecount(sizeof(DWORD) + *buffer) char const * buffer)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     return *(DWORD *)buffer;
 }
 
 char const * DynamicProfileStorage::GetRecordBuffer(__in_ecount(sizeof(DWORD) + *buffer) char const * buffer)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     return buffer + sizeof(DWORD);
 }
 
 char * DynamicProfileStorage::GetRecordBuffer(__in_ecount(sizeof(DWORD) + *buffer) char * buffer)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     return buffer + sizeof(DWORD);
 }
 
 void DynamicProfileStorage::DeleteRecord(__in_ecount(sizeof(DWORD) + *buffer) char const * buffer)
 {
-    Assert(enabled);
+    AssertOrFailFast(enabled);
     NoCheckHeapDeleteArray(GetRecordSize(buffer) + sizeof(DWORD), buffer);
 }
 #endif

--- a/lib/Runtime/Language/DynamicProfileStorage.h
+++ b/lib/Runtime/Language/DynamicProfileStorage.h
@@ -62,9 +62,7 @@ private:
     static HANDLE mutex;
     static CriticalSection cs;
     static DWORD nextFileId;
-#if DBG
     static bool locked;
-#endif
 #if DBG_DUMP
     static bool DoTrace();
 #endif

--- a/lib/Runtime/Language/DynamicProfileStorage.h
+++ b/lib/Runtime/Language/DynamicProfileStorage.h
@@ -135,7 +135,12 @@ DynamicProfileStorage::Load(char16 const * filename, Fn loadFn)
     {
         record = info->record;
     }
-    Js::SourceDynamicProfileManager * sourceDynamicProfileManager = loadFn(GetRecordBuffer(record), GetRecordSize(record));
+    DWORD recordSize = GetRecordSize(record);
+    if (recordSize == 0) 
+    {
+        return nullptr;
+    }
+    Js::SourceDynamicProfileManager * sourceDynamicProfileManager = loadFn(GetRecordBuffer(record), recordSize);
     if (info->isFileStorage)
     {
         // The data is backed by a file, we can delete the memory
@@ -156,6 +161,7 @@ DynamicProfileStorage::Load(char16 const * filename, Fn loadFn)
         {
             Output::Print(_u("%s: DynamicProfileStorage: Dynamic Profile Data corrupted: '%s'\n"), messageType, filename);
             Output::Flush();
+            Assert(false);
         }
     }
     return sourceDynamicProfileManager;

--- a/lib/Runtime/Language/SourceDynamicProfileManager.cpp
+++ b/lib/Runtime/Language/SourceDynamicProfileManager.cpp
@@ -337,7 +337,7 @@ namespace Js
         dynamicProfileInfoMapSaving.Reset();
     }
 
-    void SourceDynamicProfileManager::AddItem(LocalFunctionId functionId, DynamicProfileInfo *info)
+    void SourceDynamicProfileManager::AddSavingItem(LocalFunctionId functionId, DynamicProfileInfo *info)
     {
         try
         {
@@ -351,19 +351,11 @@ namespace Js
         }
     }
 
-    void SourceDynamicProfileManager::CopySavingData()
-    {
-        dynamicProfileInfoMap.Map([&](LocalFunctionId functionId, DynamicProfileInfo *info)
-        {
-            this->AddItem(functionId, info);
-        });
-    }
-
     void
     SourceDynamicProfileManager::SaveDynamicProfileInfo(LocalFunctionId functionId, DynamicProfileInfo * dynamicProfileInfo)
     {
         Assert(dynamicProfileInfo->GetFunctionBody()->HasExecutionDynamicProfileInfo());
-        this->AddItem(functionId, dynamicProfileInfo);
+        this->AddSavingItem(functionId, dynamicProfileInfo);
     }
 
     template <typename T>
@@ -373,6 +365,7 @@ namespace Js
         uint functionCount;
         if (!reader->Peek(&functionCount))
         {
+            Assert(false);
             return nullptr;
         }
 
@@ -380,6 +373,7 @@ namespace Js
         if (!reader->ReadArray(((char *)startupFunctions),
             BVFixed::GetAllocSize(functionCount)))
         {
+            Assert(false);
             return nullptr;
         }
 
@@ -387,6 +381,7 @@ namespace Js
 
         if (!reader->Read(&profileCount))
         {
+            Assert(false);
             return nullptr;
         }
 
@@ -410,9 +405,11 @@ namespace Js
             DynamicProfileInfo * dynamicProfileInfo = DynamicProfileInfo::Deserialize(reader, recycler, &functionId);
             if (dynamicProfileInfo == nullptr || functionId >= functionCount)
             {
+                Assert(false);
                 return nullptr;
             }
             sourceDynamicProfileManager->dynamicProfileInfoMap.Add(functionId, dynamicProfileInfo);
+            sourceDynamicProfileManager->AddSavingItem(functionId, dynamicProfileInfo);
         }
         return sourceDynamicProfileManager;
     }

--- a/lib/Runtime/Language/SourceDynamicProfileManager.h
+++ b/lib/Runtime/Language/SourceDynamicProfileManager.h
@@ -46,7 +46,6 @@ namespace Js
         uint GetStartupFunctionsLength() { return (this->startupFunctions ? this->startupFunctions->Length() : 0); }
 #ifdef DYNAMIC_PROFILE_STORAGE
         void ClearSavingData();
-        void CopySavingData();
 #endif
 
     private:
@@ -54,12 +53,14 @@ namespace Js
         FieldNoBarrier(Recycler*) recycler;
 
 #ifdef DYNAMIC_PROFILE_STORAGE
+        // while Finalizing Javascript library we can't allocate memory from recycler, 
+        // dynamicProfileInfoMapSaving is heap allocated and used for serializing dynamic profile cache
         typedef JsUtil::BaseDictionary<LocalFunctionId, DynamicProfileInfo *, HeapAllocator> DynamicProfileInfoMapSavingType;
         FieldNoBarrier(DynamicProfileInfoMapSavingType) dynamicProfileInfoMapSaving;
         
         void SaveDynamicProfileInfo(LocalFunctionId functionId, DynamicProfileInfo * dynamicProfileInfo);
         void SaveToDynamicProfileStorage(char16 const * url);
-        void AddItem(LocalFunctionId functionId, DynamicProfileInfo *info);
+        void AddSavingItem(LocalFunctionId functionId, DynamicProfileInfo *info);
         template <typename T>
         static SourceDynamicProfileManager * Deserialize(T * reader, Recycler* allocator);
         template <typename T>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -137,7 +137,6 @@
       <baseline>proto_basic.baseline</baseline>
     </default>
   </test>
-  <!-- Microsoft/ChakraCore#2667 - Fix and Re-enable flaky tests proto_disable.js and proto_initializer.js
   <test>
     <default>
       <files>proto_disable.js</files>
@@ -158,7 +157,6 @@
       <tags>exclude_serialized</tags>
     </default>
   </test>
-  -->
   <test>
     <default>
       <files>proto_addprop.js</files>


### PR DESCRIPTION
Previously there's leak because dynamic profile info is pinned and causes two roots(another is global function body) on a ring.
The fix is to use a heap allocated structure to save the information to dump to dynamic profile cache.
The fix missed a scenario the while loading from cache, it didn't save to the heap allocated dynamicProfileInfoMap,
and later some function is inlined, cause the info is missed while saving to the cache file, causes the cache file mismatch with the script code
