### PR TITLE
Improve regex API, UX

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -2981,6 +2981,8 @@ namespace UnifiedRegex
 #ifdef PROFILE_EXEC
         this->scriptContext->ProfileEnd(Js::RegexCompilePhase);
 #endif
+        // CaptureSourceAndGroups throws if this condition doesn't hold.
+        Assert(0 < pattern->NumGroups() && pattern->NumGroups() <= MAX_NUM_GROUPS);
 
         return pattern;
     }

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -2982,7 +2982,13 @@ namespace UnifiedRegex
         this->scriptContext->ProfileEnd(Js::RegexCompilePhase);
 #endif
 
-        AssertOrFailFast(0 < pattern->NumGroups() && pattern->NumGroups() <= MAX_NUM_GROUPS);
+        // We expect pattern->NumGroups() to be positive, because the full regexp itself always
+        // counts as a capturing group.
+        Assert(pattern->NumGroups() > 0);
+        if (pattern->NumGroups() > MAX_NUM_GROUPS)
+        {
+            Js::JavascriptError::ThrowSyntaxError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
+        }
 
         return pattern;
     }
@@ -3016,7 +3022,13 @@ namespace UnifiedRegex
 
         program->numGroups = nextGroupId;
 
-        AssertOrFailFast(0 < program->numGroups && program->numGroups <= MAX_NUM_GROUPS);
+        // We expect program->numGroups to be positive, because the full regexp itself always
+        // counts as a capturing group.
+        Assert(program->numGroups > 0);
+        if (program->numGroups > MAX_NUM_GROUPS)
+        {
+            Js::JavascriptError::ThrowSyntaxError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
+        }
 
         // Remaining to set during compilation: litbuf, litbufLen, numLoops, insts, instsLen, entryPointLabel
     }

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -3019,7 +3019,7 @@ namespace UnifiedRegex
         Assert(nextGroupId > 0);
         if (nextGroupId > MAX_NUM_GROUPS)
         {
-            Js::JavascriptError::ThrowSyntaxError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
+            Js::JavascriptError::ThrowRangeError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
         }
         else
         {

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -2982,14 +2982,6 @@ namespace UnifiedRegex
         this->scriptContext->ProfileEnd(Js::RegexCompilePhase);
 #endif
 
-        // We expect pattern->NumGroups() to be positive, because the full regexp itself always
-        // counts as a capturing group.
-        Assert(pattern->NumGroups() > 0);
-        if (pattern->NumGroups() > MAX_NUM_GROUPS)
-        {
-            Js::JavascriptError::ThrowSyntaxError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
-        }
-
         return pattern;
     }
 
@@ -3020,14 +3012,16 @@ namespace UnifiedRegex
         program->source[bodyChars] = 0;
         program->sourceLen = bodyChars;
 
-        program->numGroups = nextGroupId;
-
-        // We expect program->numGroups to be positive, because the full regexp itself always
+        // We expect nextGroupId to be positive, because the full regexp itself always
         // counts as a capturing group.
-        Assert(program->numGroups > 0);
-        if (program->numGroups > MAX_NUM_GROUPS)
+        Assert(nextGroupId > 0);
+        if (nextGroupId > MAX_NUM_GROUPS)
         {
             Js::JavascriptError::ThrowSyntaxError(this->scriptContext, JSERR_RegExpTooManyCapturingGroups);
+        }
+        else
+        {
+            program->numGroups = static_cast<uint16>(nextGroupId);
         }
 
         // Remaining to set during compilation: litbuf, litbufLen, numLoops, insts, instsLen, entryPointLabel

--- a/lib/Parser/RegexParser.h
+++ b/lib/Parser/RegexParser.h
@@ -82,13 +82,18 @@ namespace UnifiedRegex
         // group, plus a few additional values, to a JavaScript function without overflowing the
         // number of arguments.  This is important, for example, in the implementation of
         // String.prototype.replace, where the second argument is a function.
-        //
-        // This should really be an unsigned, but we compare it against numGroups, so make it
-        // an int for now to avoid a bunch of compiler warnings until we can go back and clean this up.
-        static const int MAX_NUM_GROUPS = INT16_MAX;
+        static const uint16 MAX_NUM_GROUPS = INT16_MAX;
 
-        int numGroups; // determined in first parse
+        uint16 numGroups; // determined in first parse
+
+        // Keeps track of how many capturing groups we've seen during parsing.  We use an int, rather than
+        // a uint16, to be sure we don't overflow during parsing and only check it against MAX_NUM_GROUPS at
+        // the end.  (We know we can't overflow an int because strings and regex literals are limited to
+        // 2G characters and therefore to 1G pairs of parentheses, which can fit into an int.  I'd prefer
+        // to use size_t here, but making that change would go down a serious rabbit hole changing the
+        // interface to UnifiedRegex::Node::AccumDefineGroups.)
         int nextGroupId;
+
         // Buffer accumulating all literals.
         // In compile-time allocator, must be transferred to runtime allocator when build program
         Char* litbuf;

--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -72,7 +72,7 @@ namespace UnifiedRegex
         return rep.unified.program->flags;
     }
 
-    int RegexPattern::NumGroups() const
+    uint16 RegexPattern::NumGroups() const
     {
         return rep.unified.program->numGroups;
     }

--- a/lib/Parser/RegexPattern.h
+++ b/lib/Parser/RegexPattern.h
@@ -58,7 +58,7 @@ namespace UnifiedRegex
         Js::ScriptContext *GetScriptContext() const;
 
         inline bool IsLiteral() const { return isLiteral; }
-        int NumGroups() const;
+        uint16 NumGroups() const;
         bool IsIgnoreCase() const;
         bool IsGlobal() const;
         bool IsMultiline() const;

--- a/lib/Parser/RegexRuntime.h
+++ b/lib/Parser/RegexRuntime.h
@@ -60,7 +60,7 @@ namespace UnifiedRegex
         Field(Char*) source;
         Field(CharCount) sourceLen; // length in char16's, NOT including terminating null
         // Number of capturing groups (including implicit overall group at index 0)
-        Field(int) numGroups;
+        Field(uint16) numGroups;
         Field(int) numLoops;
         Field(RegexFlags) flags;
 
@@ -1847,7 +1847,7 @@ namespace UnifiedRegex
             return !groupInfos[0].IsUndefined();
         }
 
-        inline int NumGroups() const
+        inline uint16 NumGroups() const
         {
             return program->numGroups;
         }

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -364,7 +364,7 @@ RT_ERROR_MSG(JSERR_InvalidIterableObject, 5671, "%s : Invalid iterable object", 
 RT_ERROR_MSG(JSERR_InvalidIteratorObject, 5672, "%s : Invalid iterator object", "Invalid iterator object", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_NoAccessors, 5673, "Invalid property descriptor: accessors not supported on this object", "", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RegExpInvalidEscape, 5674, "", "Invalid regular expression: invalid escape in unicode pattern", kjstSyntaxError, 0)
-RT_ERROR_MSG(JSERR_RegExpTooManyCapturingGroups, 5675, "", "Too many capturing groups in regular expression", kjstSyntaxError, 0)
+RT_ERROR_MSG(JSERR_RegExpTooManyCapturingGroups, 5675, "", "Regular expression cannot have more than 32,767 capturing groups", kjstRangeError, 0)
 
 //Host errors
 RT_ERROR_MSG(JSERR_HostMaybeMissingPromiseContinuationCallback, 5700, "", "Host may not have set any promise continuation callback. Promises may not be executed.", kjstTypeError, 0)

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -364,6 +364,7 @@ RT_ERROR_MSG(JSERR_InvalidIterableObject, 5671, "%s : Invalid iterable object", 
 RT_ERROR_MSG(JSERR_InvalidIteratorObject, 5672, "%s : Invalid iterator object", "Invalid iterator object", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_NoAccessors, 5673, "Invalid property descriptor: accessors not supported on this object", "", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RegExpInvalidEscape, 5674, "", "Invalid regular expression: invalid escape in unicode pattern", kjstSyntaxError, 0)
+RT_ERROR_MSG(JSERR_RegExpTooManyCapturingGroups, 5675, "", "Too many capturing groups in regular expression", kjstSyntaxError, 0)
 
 //Host errors
 RT_ERROR_MSG(JSERR_HostMaybeMissingPromiseContinuationCallback, 5700, "", "Host may not have set any promise continuation callback. Promises may not be executed.", kjstTypeError, 0)

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -773,11 +773,8 @@ namespace Js
             {
                 // We've found a substitution ref, like $32.  In accordance with the standard (sec-getsubstitution),
                 // we recognize at most two decimal digits after the dollar sign.
-
-                // This should be unsigned, but this would cause lots of compiler warnings unless we also make
-                // numGroups unsigned, because of a comparison below.
-                int captureIndex = (int)(currentChar - _u('0'));
-                Assert(0 <= captureIndex && captureIndex <= 9); // numeric value of single decimal digit
+                uint16 captureIndex = (uint16)(currentChar - _u('0'));
+                Assert(captureIndex < 10); // numeric value of single decimal digit
 
                 offset = substitutionOffset + 2;
 
@@ -786,9 +783,8 @@ namespace Js
                     currentChar = replaceStr[substitutionOffset + 2];
                     if (currentChar >= _u('0') && currentChar <= _u('9'))
                     {
-                        // Should also be unsigned; see captureIndex above.
-                        int tempCaptureIndex = (10 * captureIndex) + (int)(currentChar - _u('0'));
-                        Assert(0 <= tempCaptureIndex && tempCaptureIndex < 100); // numeric value of 2-digit positive decimal number
+                        uint16 tempCaptureIndex = (10 * captureIndex) + (uint16)(currentChar - _u('0'));
+                        Assert(tempCaptureIndex < 100); // numeric value of 2-digit positive decimal number
                         if (tempCaptureIndex < numGroups)
                         {
                             captureIndex = tempCaptureIndex;
@@ -797,7 +793,7 @@ namespace Js
                     }
                 }
 
-                Assert(0 <= captureIndex && captureIndex < 100); // as above, value of 2-digit positive decimal number
+                Assert(captureIndex < 100); // as above, value of 2-digit positive decimal number
                 if (captureIndex < numGroups && (captureIndex != 0))
                 {
                     Var group = getGroup(captureIndex, nonMatchValue);
@@ -1261,12 +1257,13 @@ namespace Js
         JavascriptString* newString = nullptr;
         const char16* inputStr = input->GetString();
         CharCount inputLength = input->GetLength();
-        const int rawNumGroups = pattern->NumGroups();
+        const uint16 numGroups = pattern->NumGroups();
         Var nonMatchValue = NonMatchValue(scriptContext, false);
         UnifiedRegex::GroupInfo lastMatch; // initially undefined
 
-        AssertOrFailFast(0 < rawNumGroups && rawNumGroups <= INT16_MAX);
-        const uint16 numGroups = uint16(rawNumGroups);
+        // Regex parser should ensure this condition holds, but let's be doubly sure.
+        // numGroups is always positive because the entire regex counts as a capturing group.
+        AssertOrFailFast(0 < numGroups && numGroups <= INT16_MAX);
 
 #if ENABLE_REGEX_CONFIG_OPTIONS
         RegexHelperTrace(scriptContext, UnifiedRegex::RegexStats::Replace, regularExpression, input, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("<replace function>")));

--- a/test/Regex/Bug15992535.js
+++ b/test/Regex/Bug15992535.js
@@ -3,39 +3,27 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-// This test case constructs a regex with 0x40000 capturing groups.  At time of writing, the
-// intended behavior is that the regex parser hits an AssertOrFailFast; we may revisit
-// that error behavior in the future.
-
-try { function i_want_to_break_free() {
-    var n = 0x8000;
-    var m = 2;
-    var regex = new RegExp("(ab)".repeat(n), "g");
-    var part = "ab".repeat(n); // matches have to be at least size 2 to prevent interning
-    var s = (part + "|").repeat(m);
-    while (true) {
-        var cnt = 0;
-        var ary = (function () {
-            Object.toUpperCase(asinh, (() => {
-                let arguments;
-            }));
-            decodeURIComponent.splice(0);        // head seg is now length=0
-            trim.length = 100000;  // increase the length of the array to 100000 so to access head segment
-            return 42;
-        });
-        s.replace(regex, function() {
-            for (var i = 1; i < arguments.length-2; ++i) {
-                if (typeof arguments[i] !== 'string') {
-                    i_am_free = arguments[i];
-                    throw "success";
-                }
-                (call.valueOf) = ((EvalError + includes) ? ( ary[(test - 1)]) : 0);  // root everything to force GC
-            }
-            return "x";
-        });
-    }
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 }
-try { i_want_to_break_free(); } catch (e) { }
-((search.valueOf)); } catch(err) { }
 
-print("Didn't get expected fail fast");
+var tests = [
+    {
+        name: "Regex parser correctly throws error if too many capturing groups",
+        body: function () {
+            assert.doesNotThrow(
+                // Should succeed.  Use 2^15 - 2 pairs of parens, because
+                // the entire regex always counts as a capturing group.
+                () => { return new RegExp("(ab)".repeat(0x7ffe)); }
+            );
+            assert.throws(
+                () => { return new RegExp("(ab)".repeat(0x8000)); },
+                SyntaxError,
+                "regex parsing throws when the regex has more than 2^15 - 1 capturing groups",
+                "Too many capturing groups in regular expression"
+            );
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Regex/Bug15992535.js
+++ b/test/Regex/Bug15992535.js
@@ -18,9 +18,9 @@ var tests = [
             );
             assert.throws(
                 () => { return new RegExp("(ab)".repeat(0x8000)); },
-                SyntaxError,
+                RangeError,
                 "regex parsing throws when the regex has more than 2^15 - 1 capturing groups",
-                "Too many capturing groups in regular expression"
+                "Regular expression cannot have more than 32,767 capturing groups"
             );
         }
     }

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -221,15 +221,7 @@
   <test>
     <default>
       <files>Bug15992535.js</files>
-      <!-- Test should fail assertion in debug build, so do not run.  Also,
-           our test harness interprets a failfast as test failure on Linux
-           and MacOS (presumably because of a non-zero exit code from ch)
-           but not on Windows, so skip this test on xplat.
-
-           (The failfast here is temporary behavior; see GitHub issue #4722.)
-      -->
-      <tags>exclude_chk,exclude_xplat,slow</tags>
-      <baseline>Bug15992535.baseline</baseline>
+      <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
Use uint16 to store number of capturing groups, where possible; replace a fail-fast with a JavaScript exception.

Fixes GitHub issue #4722.