### PR TITLE
Support shared builds of Chakra.ICU

### DIFF
--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -59,6 +59,15 @@
         %(PreprocessorDefinitions);
         INTL_ICU=1
       </PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraICU)'=='static'">
+        %(PreprocessorDefinitions);
+        U_STATIC_IMPLEMENTATION=1
+      </PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseICU)'=='true'">
+        U_DISABLE_RENAMING=1; <!-- Disable renaming to maintain compatibility with Windows Kit ICU's icuuc/icuin.lib -->
+        ICU_VERSION=$(IcuVersionMajor);
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ForceSWB)'=='true'">
         %(PreprocessorDefinitions);
         GLOBAL_ENABLE_WRITE_BARRIER=1

--- a/deps/Chakra.ICU/Chakra.ICU.Build.props
+++ b/deps/Chakra.ICU/Chakra.ICU.Build.props
@@ -18,7 +18,7 @@
         UCONFIG_NO_REGULAR_EXPRESSIONS=1;
         UCONFIG_NO_SERVICE=1;
         %(PreprocessorDefinitions)
-      </PreprocessorDefinitions>
+    </PreprocessorDefinitions>
 
       <!-- Default ICU Configuration (see source\common\common.vcxproj) -->
       <!-- Note that we already configure most of what common.vcxproj handles elsewhere -->

--- a/deps/Chakra.ICU/Chakra.ICU.Common.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Common.vcxproj
@@ -27,6 +27,9 @@
         U_COMMON_IMPLEMENTATION=1
       </PreprocessorDefinitions>
     </ClCompile>
+    <Link Condition="'$(ChakraICU)'=='shared'">
+      <SubSystem>Console</SubSystem>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(ChakraICU)'!='false'">
     <ClCompile Include="$(IcuCommonSources)" />

--- a/deps/Chakra.ICU/Chakra.ICU.Data.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Data.vcxproj
@@ -21,6 +21,12 @@
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <GenCCodePath>$(OutBaseDir)\bin\$(PlatformPathName.ToLower())_$(Configuration.ToLower())\Chakra.ICU.GenCCode.exe</GenCCodePath>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <Link Condition="'$(ChakraICU)'=='shared'">
+      <SubSystem>Console</SubSystem>
+      <NoEntryPoint>true</NoEntryPoint>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemGroup Condition="'$(ChakraICU)'!='false'">
     <None Include="$(IntDir)icudt$(IcuVersionMajor)l_dat.obj" /> <!-- forces the automagic build system to create a lib from the obj -->
     <CustomBuild Include="$(MSBuildThisFileDirectory)source\data\in\icudt$(IcuVersionMajor)l.dat">

--- a/deps/Chakra.ICU/Chakra.ICU.Stubdata.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Stubdata.vcxproj
@@ -9,7 +9,8 @@
     <ProjectName>Chakra.ICU.Stubdata</ProjectName>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType Condition="'$(ChakraICU)'!='shared'">StaticLibrary</ConfigurationType>
+    <ConfigurationType Condition="'$(ChakraICU)'=='shared'">DynamicLibrary</ConfigurationType>
   </PropertyGroup>
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -31,6 +32,12 @@
         $(IcuSourceDirectory)\common
       </AdditionalIncludeDirectories>
     </ClCompile>
+    <Link Condition="'$(ChakraICU)'=='shared'">
+      <SubSystem>Console</SubSystem>
+      <!-- Make Chakra.ICU.Stubdata pretend like its Chakra.ICU.Data for linking purposes -->
+      <OutputFile>$(OutDir)\Chakra.ICU.Data.dll</OutputFile>
+      <ImportLibrary>$(OutDir)\Chakra.ICU.Data.lib</ImportLibrary>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(ChakraICU)'!='false'">
     <ClCompile Include="$(IcuStubdataSources)" />

--- a/deps/Chakra.ICU/Chakra.ICU.i18n.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.i18n.vcxproj
@@ -35,13 +35,18 @@
       <!-- Some ICU files use embedded UTF-8 -->
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
+    <Link Condition="'$(ChakraICU)'=='shared'">
+      <SubSystem>Console</SubSystem>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup Condition="'$(ChakraICU)'!='false'">
     <ClCompile Include="$(IcuI18nSources)" />
     <ClInclude Include="$(IcuI18nHeaders)" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)Chakra.ICU.Stubdata.vcxproj">
       <Project>{E14F373D-05A0-4259-A5E9-AFE8405FB847}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Chakra.ICU.Common.vcxproj">
+      <Project>{EE2A3111-4D85-427C-B0AB-E6B0EA7FFB44}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -110,6 +110,19 @@
 #define ENABLE_UNICODE_API 1                        // Enable use of Unicode-related APIs
 #endif
 
+// ICU Configuration
+#if defined(HAS_ICU) || defined(HAS_REAL_ICU)
+#define U_SHOW_CPLUSPLUS_API 0
+// ICU 55 (Ubuntu 16.04 system default) has uloc_toUnicodeLocale* marked as draft, which is required for Intl
+#if ICU_VERSION > 56
+#define U_DEFAULT_SHOW_DRAFT 0
+#define U_HIDE_DRAFT_API 1
+#endif
+#define U_HIDE_DEPRECATED_API 1
+#define U_HIDE_OBSOLETE_API 1
+#define U_HIDE_INTERNAL_API 1
+#endif
+
 // Language features
 
 #if !defined(CHAKRACORE_LITE) && (defined(_WIN32) || defined(INTL_ICU))

--- a/lib/Runtime/PlatformAgnostic/ICU.h
+++ b/lib/Runtime/PlatformAgnostic/ICU.h
@@ -8,8 +8,6 @@
 #ifdef WINDOWS10_ICU
 #include <icu.h>
 #else
-#define U_STATIC_IMPLEMENTATION 1
-#define U_SHOW_CPLUSPLUS_API 0
 #include "unicode/ucal.h"
 #include "unicode/ucol.h"
 #include "unicode/udat.h"


### PR DESCRIPTION
This PR enables Chakra.ICU to be built into DLLs, both for ease of embedding and for internal testing scenarios. I have confirmed that the DLLs produced here work on Windows ~8, including with binaries that linked to Windows Kit ICU in Windows 10.

The full workflow for using these binaries with Windows Kit ICU-linked exes:
1) Build host exe targeting RS2+, importing <icu.h>/<icucommon.h>/<icuin.h> from the Windows Kit and linking to icuuc.lib and icuin.lib from System32
1) Copy exe to Windows 8
1) Copy Chakra.ICU.Common.dll, Chakra.ICU.i18n.dll, and Chakra.ICU.Data.dll to the same folder on the Windows 8 machine as the exe
1) Make a copy of Chakra.ICU.Common.dll to icuuc.dll, or symlink it (if thats a thing on Windows 8? I couldn't get it to work on chakrafs, which was my scratchpad here). Do the same for Chakra.ICU.i18n.dll -> icuin.dll
1) With 6 resulting files (exe, 3x Chakra.ICU.dll, icuuc, icuin), the exe should be runnable.
