### PR TITLE
Share SimpleTypeHandler types on function objects. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1290,6 +1290,8 @@ namespace Js
         ProxyEntryPointInfo* GetDefaultEntryPointInfo() const;
         ScriptFunctionType * GetDeferredPrototypeType() const;
         ScriptFunctionType * EnsureDeferredPrototypeType();
+        ScriptFunctionType * GetUndeferredFunctionType() const;
+        void SetUndeferredFunctionType(ScriptFunctionType * type);
         JavascriptMethod GetDirectEntryPoint(ProxyEntryPointInfo* entryPoint) const;
 
         // Function object type list methods
@@ -1368,6 +1370,7 @@ namespace Js
         FieldNoBarrier(ScriptContext*) m_scriptContext;   // Memory context for this function body
         FieldWithBarrier(Utf8SourceInfo*) m_utf8SourceInfo;
         FieldWithBarrier(ScriptFunctionType*) deferredPrototypeType;
+        FieldWithBarrier(ScriptFunctionType*) undeferredFunctionType;
         FieldWithBarrier(ProxyEntryPointInfo*) m_defaultEntryPointInfo; // The default entry point info for the function proxy
 
         FieldWithBarrier(uint) m_functionNumber;  // Per thread global function number

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -268,22 +268,10 @@ namespace Js
     {
         // Update deferred parsed/serialized function to the real function body
         Assert(this->functionInfo->HasBody());
+        Assert(this->functionInfo == newFunctionInfo->GetFunctionInfo());
         Assert(this->functionInfo->GetFunctionBody() == newFunctionInfo);
         Assert(!newFunctionInfo->IsDeferred());
 
-        DynamicType * type = this->GetDynamicType();
-
-        // If the type is shared, it must be the shared one in the old function proxy
-
-        this->functionInfo = newFunctionInfo->GetFunctionInfo();
-
-        if (type->GetIsShared())
-        {
-            // the type is still shared, we can't modify it, just migrate to the shared one in the function body
-            this->ReplaceType(newFunctionInfo->EnsureDeferredPrototypeType());
-        }
-
-        // The type has change from the default, it is not share, just use that one.
         JavascriptMethod directEntryPoint = newFunctionInfo->GetDirectEntryPoint(newFunctionInfo->GetDefaultEntryPointInfo());
 #if defined(ENABLE_SCRIPT_PROFILING) || defined(ENABLE_SCRIPT_DEBUGGING)
         Assert(directEntryPoint != DefaultDeferredParsingThunk

--- a/lib/Runtime/Types/DeferredTypeHandler.h
+++ b/lib/Runtime/Types/DeferredTypeHandler.h
@@ -21,7 +21,7 @@ namespace Js
         }
 
     public:
-        void Convert(DynamicObject * instance, DynamicTypeHandler * handler);
+        void ConvertFunction(JavascriptFunction * instance, DynamicTypeHandler * handler);
         void Convert(DynamicObject * instance, DeferredInitializeMode mode, int initSlotCapacity,  BOOL hasAccessor = false);
 
         virtual void SetAllPropertiesToUndefined(DynamicObject* instance, bool invalidateFixedFields) override {};

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -67,15 +67,9 @@ namespace Js
 
         friend class JavascriptArray; // for xplat offsetof field access
         friend class JavascriptNativeArray; // for xplat offsetof field access
-        friend class JavascriptOperators; // for ReplaceType
-        friend class PathTypeHandlerBase; // for ReplaceType
-        friend class SimplePathTypeHandlerNoAttr;
-        friend class SimplePathTypeHandlerWithAttr;
-        friend class PathTypeHandlerNoAttr;
-        friend class JavascriptLibrary;  // for ReplaceType
-        friend class ScriptFunction; // for ReplaceType;
-        friend class JSON::JSONParser; //for ReplaceType
-        friend class ModuleNamespace; // for slot setting.
+        friend class JavascriptOperators;
+        friend class JavascriptLibrary;
+        friend class ModuleNamespace; // for slot setting.       
 
 #if ENABLE_OBJECT_SOURCE_TRACKING
     public:
@@ -111,8 +105,6 @@ namespace Js
 
         void InitSlots(DynamicObject * instance, ScriptContext * scriptContext);
         void SetTypeHandler(DynamicTypeHandler * typeHandler, bool hasChanged);
-        void ReplaceType(DynamicType * type);
-        void ReplaceTypeWithPredecessorType(DynamicType * previousType);
 
     protected:
         DEFINE_VTABLE_CTOR(DynamicObject, RecyclableObject);
@@ -138,6 +130,8 @@ namespace Js
 
         void EnsureSlots(int oldCount, int newCount, ScriptContext * scriptContext, DynamicTypeHandler * newTypeHandler = nullptr);
         void EnsureSlots(int newCount, ScriptContext *scriptContext);
+        void ReplaceType(DynamicType * type);
+        void ReplaceTypeWithPredecessorType(DynamicType * previousType);
 
         DynamicTypeHandler * GetTypeHandler() const;
 


### PR DESCRIPTION
Currently when we transition from DeferredTypeHandler to SimpleTypeHandler on first access to a function object's properties, we don't share the new type we create. Track an undeferred type along with the deferredPrototypeType on FunctionProxy and re-use it whenever possible for multiple instances of the same function. (This is a first step in broader sharing of function object types.)