### PR TITLE
Fix errors when building with /Zc:strictStrings

### DIFF
--- a/lib/Common/DataStructures/StringBuilder.h
+++ b/lib/Common/DataStructures/StringBuilder.h
@@ -284,7 +284,7 @@ namespace Js
             }
         }
 
-        inline char16* Buffer()
+        inline const char16* Buffer()
         {
             if (this->IsChained())
             {


### PR DESCRIPTION
* Add const qualifier to static lists of string literals and other variables which are only assigned string literals.
* Add const to string parameters where it would not cause issues.
* Explicitly const_cast to remove const qualifiers in certain situations where a method might return either a non-const string or a literal, or to avoid viral const behavior.

Found while investigating #1942