### PR TITLE
OS#15679026 Fix incorrect type check in OP_SetProperty

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2573,7 +2573,7 @@ CommonNumber:
         {
             thisInstance = instance;
         }
-        TypeId typeId = JavascriptOperators::GetTypeId(thisInstance);
+        TypeId typeId = JavascriptOperators::GetTypeId(instance);
 
         if (JavascriptOperators::IsUndefinedOrNullType(typeId))
         {
@@ -2592,7 +2592,7 @@ CommonNumber:
             return TRUE;
         }
 
-        if (!TaggedNumber::Is(thisInstance))
+        if (!TaggedNumber::Is(instance))
         {
             return JavascriptOperators::SetProperty(RecyclableObject::UnsafeFromVar(thisInstance), RecyclableObject::UnsafeFromVar(instance), propertyId, newValue, info, scriptContext, flags);
         }

--- a/test/es6/bug_OS15679026.js
+++ b/test/es6/bug_OS15679026.js
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Class which extends null won't assert when we do super property references",
+    body: function () {
+        class c extends null {
+            constructor() {
+                return {}
+            }
+            meth() {
+                super['prop'] = 'something';
+                super.prop = 'something'
+            }
+        }
+        assert.throws(()=>c.prototype.meth.call({}), TypeError, "This shouldn't crash but does throw a TypeError", "Unable to set property 'prop' of undefined or null reference");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1399,6 +1399,12 @@
   </test>
   <test>
     <default>
+      <files>bug_OS15679026.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug_issue_4635.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
`OP_SetProperty` takes an optional `thisInstance` parameter which is used only in the super property reference case because we need to maintain 'this' binding for class member accessors. Problem is when `thisInstance` is provided, we check the type of it instead of the type of the receiver object to determine if the property assignment is invalid due to the receiver object being null, undefined, etc.

This has the unfortunate side-effect of forcing us to try and do the property set when the receiver is null which results in an assert down in the CacheOperators because they assume that the receiver is an object with a `DynamicType`. We can only hit this code path when we have a super property reference in a class member of a class which extends from null.

```
class c extends null {
    constructor() {
        return {}
    }
    meth() {
        super['prop'] = 'something';
        super.prop = 'something'
    }
}
c.prototype.meth.call({})
```

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/15679026
