### PR TITLE
[MSFT:16140069] Let PathTypeHandlerWithAttr::SetProperty intercept write when a setter is present

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -482,6 +482,9 @@ namespace Js
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetAttributesWithPropertyIndex(DynamicObject * instance, PropertyId propertyId, BigPropertyIndex index, PropertyAttributes * attributes) override;
 
+        virtual BOOL SetProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
+        virtual BOOL SetProperty(DynamicObject* instance, JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
+
         virtual BOOL GetAccessors(DynamicObject* instance, PropertyId propertyId, Var* getter, Var* setter) override;
         virtual BOOL SetAccessors(DynamicObject* instance, PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override;
         virtual DescriptorFlags GetSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1450,4 +1450,10 @@
     <compile-flags>-force:deferparse</compile-flags>
   </default>
 </test>
+<test>
+  <default>
+    <files>supersetter.js</files>
+    <baseline>supersetter.baseline</baseline>
+  </default>
+</test>
 </regress-exe>

--- a/test/es6/supersetter.baseline
+++ b/test/es6/supersetter.baseline
@@ -1,0 +1,2 @@
+goodbye
+hello

--- a/test/es6/supersetter.js
+++ b/test/es6/supersetter.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// NOTE: Correct the baseline when setter behavior with 'super' is corrected
+
+(function() {
+    function __f_2530() {};
+    __f_2530.prototype = {
+      mSloppy() {
+          super.ownReadonlyAccessor = 25;
+          this.ownReadonlyAccessor;
+      }
+    }
+    var __v_11980 = new __f_2530();
+    Object.defineProperty(__v_11980, 'ownReadonlyAccessor', { 
+        get: function () { console.log('hello');
+        }, set: function () { console.log('goodbye'); }
+    })
+    __v_11980.mSloppy()
+})();
+


### PR DESCRIPTION
The detection and calling of setters in the prototype chain in JavascriptOperators::SetProperty_Internal can fail when 'super' is involved. This change restores the safety of the behavior by bringing PathTypeHandler into line with DictionaryTypeHandler. There is still a functional issue involving writes through 'super' calling setters incorrectly.