### PR TITLE
 Fix for re-entrancy in splice and unshift

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -568,6 +568,7 @@ namespace Js
 
         template<typename T>
         static void UnshiftHelper(JavascriptArray* pArr, uint32 unshiftElements, Js::Var * elements);
+        static Var UnshiftObjectHelper(Js::Arguments& args, ScriptContext * scriptContext);
 
         template<typename T>
         static void GrowArrayHeadHelperForUnshift(JavascriptArray* pArr, uint32 unshiftElements, ScriptContext * scriptContext);

--- a/test/Array/array_splice2.baseline
+++ b/test/Array/array_splice2.baseline
@@ -74,8 +74,8 @@ length: 4294967295
   4294967297: 100
   4294967298: 101
   4294967299: 102
-  4294967300: 103
   4294967301: 104
+  4294967300: 103
 --- splice overflow 3
 RangeError : Array length must be assigned a finite positive integer
 length: 4294967295

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -83,7 +83,24 @@ var tests = [
       {
       }
     }
+  },
+  {
+    name: "splice an array which has getter/setter at 4294967295 should not fail due to re-entrancy error",
+    body: function () {
+        var base = 4294967290;
+        var arr = [];
+        for (var i = 0; i < 10; i++) {
+            arr[base + i] = 100 + i;
+        }
+        Object.defineProperty(arr, 4294967295, {
+          get: function () { }, set : function(b) {  }
+            }
+        );
+
+        assert.throws(()=> {arr.splice(4294967290, 0, 200, 201, 202, 203, 204, 205, 206);});
+    }
   }
+  
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
When we have getter/setter at 4294967295, we go out in the user code and we end up throwing the re-entrancy error.
For splice we now take the slow path for the overflow case.
for unshift - just put the re-entrant macro around it and also handle the es5 array case.
