### PR TITLE
Fix a possible null dereference in PopulateMetadataFromException

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -1091,6 +1091,48 @@ namespace JsRTApiTest
         REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
         REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
         CHECK(type == JsString);
+
+        // Following requires eval to be enabled - no point in testing it if we've disabled eval
+        if (!(attributes & JsRuntimeAttributeDisableEval))
+        {
+            REQUIRE(JsRunScript(_u("eval('var a = b');"), JS_SOURCE_CONTEXT_NONE, _u(""), nullptr) == JsErrorScriptException);
+            REQUIRE(JsHasException(&value) == JsNoError);
+            CHECK(value == true);
+
+            REQUIRE(JsGetAndClearExceptionWithMetadata(&exceptionMetadata) == JsNoError);
+            REQUIRE(JsHasException(&value) == JsNoError);
+            CHECK(value == false);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("exception"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsError);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("line"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsNumber);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("column"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsNumber);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("length"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsNumber);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("url"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsString);
+
+            REQUIRE(JsGetPropertyIdFromName(_u("source"), &property) == JsNoError);
+            REQUIRE(JsGetProperty(exceptionMetadata, property, &metadataValue) == JsNoError);
+            REQUIRE(JsGetValueType(metadataValue, &type) == JsNoError);
+            CHECK(type == JsString);
+        }
     }
 
     TEST_CASE("ApiTest_ExceptionHandlingTest", "[ApiTest]")

--- a/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
+++ b/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
@@ -91,7 +91,7 @@ namespace Js {
             Js::JavascriptNumber::New(0, scriptContext), scriptContext);
 
         Js::JavascriptOperators::OP_SetProperty(metadata, Js::PropertyIds::url,
-            Js::JavascriptString::NewCopySz(functionBody->GetSourceContextInfo()->url, scriptContext), scriptContext);
+            Js::JavascriptString::NewCopySz(functionBody->GetSourceName(), scriptContext), scriptContext);
 
         LPCUTF8 functionSource = sourceInfo->GetSource(_u("Jsrt::JsExperimentalGetAndClearExceptionWithMetadata"));
 


### PR DESCRIPTION
If the code throwing the exception is dynamic (eval or otherwise doesn't have a url) the url of the `functionBody` can be null. In that case, we would pass null to JavascriptString::NewCopySz which dereferences it and crashes. Fix is to use GetSourceName instead which handles this case providing the string 'eval code' instead of nullptr.
