### PR TITLE
Support disabling interpreter thunks in JSRT

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -66,6 +66,7 @@ namespace JsRTApiTest
         WithSetup(JsRuntimeAttributeAllowScriptInterrupt, handler);
         WithSetup(JsRuntimeAttributeEnableIdleProcessing, handler);
         WithSetup(JsRuntimeAttributeDisableNativeCodeGeneration, handler);
+        WithSetup(JsRuntimeAttributeDisableExecutablePageAllocation, handler);
         WithSetup(JsRuntimeAttributeDisableEval, handler);
         WithSetup((JsRuntimeAttributes)(JsRuntimeAttributeDisableBackgroundWork | JsRuntimeAttributeAllowScriptInterrupt | JsRuntimeAttributeEnableIdleProcessing), handler);
     }

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -323,6 +323,11 @@ void* InterpreterThunkEmitter::ConvertToEntryPoint(PVOID dynamicInterpreterThunk
 
 bool InterpreterThunkEmitter::NewThunkBlock()
 {
+    if (this->scriptContext->GetConfig()->IsNoDynamicThunks())
+    {
+        return false;
+    }
+
 #ifdef ENABLE_OOP_NATIVE_CODEGEN
     if (CONFIG_FLAG(ForceStaticInterpreterThunk))
     {

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -454,6 +454,15 @@ typedef unsigned short uint16_t;
         ///     Disable Failfast fatal error on OOM
         /// </summary>
         JsRuntimeAttributeDisableFatalOnOOM = 0x00000080,
+        /// <summary>
+        ///     Runtime will not allocate executable code pages
+        ///     This also implies that Native Code generation will be turned off
+        ///     Note that this will break JavaScript stack decoding in tools
+        //      like WPA since they rely on allocation of unique thunks to
+        //      interpret each function and allocation of those thunks will be
+        //      disabled as well
+        /// </summary>
+        JsRuntimeAttributeDisableExecutablePageAllocation = 0x00000100,
 
     } JsRuntimeAttributes;
 

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -285,6 +285,7 @@ JsErrorCode CreateRuntimeCore(_In_ JsRuntimeAttributes attributes,
             JsRuntimeAttributeEnableIdleProcessing |
             JsRuntimeAttributeDisableEval |
             JsRuntimeAttributeDisableNativeCodeGeneration |
+            JsRuntimeAttributeDisableExecutablePageAllocation |
             JsRuntimeAttributeEnableExperimentalFeatures |
             JsRuntimeAttributeDispatchSetExceptionsToDebugger |
             JsRuntimeAttributeDisableFatalOnOOM
@@ -337,6 +338,12 @@ JsErrorCode CreateRuntimeCore(_In_ JsRuntimeAttributes attributes,
         if (attributes & JsRuntimeAttributeDisableNativeCodeGeneration)
         {
             threadContext->SetThreadContextFlag(ThreadContextFlagNoJIT);
+        }
+
+        if (attributes & JsRuntimeAttributeDisableExecutablePageAllocation)
+        {
+            threadContext->SetThreadContextFlag(ThreadContextFlagNoJIT);
+            threadContext->SetThreadContextFlag(ThreadContextFlagNoDynamicThunks);
         }
 
         if (attributes & JsRuntimeAttributeDisableFatalOnOOM)

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3664,6 +3664,23 @@ namespace Js
         {
             this->SetOriginalEntryPoint((JavascriptMethod)InterpreterThunkEmitter::ConvertToEntryPoint(this->m_dynamicInterpreterThunk));
         }
+
+#if DBG
+        if (GetScriptContext()->GetThreadContext()->NoDynamicThunks())
+        {
+            Assert(this->m_dynamicInterpreterThunk == nullptr);
+#ifdef ASMJS_PLAT
+            if (m_isAsmJsFunction)
+            {
+                Assert(this->GetOriginalEntryPoint_Unchecked() == (JavascriptMethod)&Js::InterpreterStackFrame::StaticInterpreterAsmThunk);
+            }
+            else
+#endif
+            {
+                Assert(this->GetOriginalEntryPoint_Unchecked() == (JavascriptMethod)&Js::InterpreterStackFrame::StaticInterpreterThunk);
+            }
+        }
+#endif
     }
 
     JavascriptMethod FunctionBody::EnsureDynamicInterpreterThunk(FunctionEntryPointInfo* entryPointInfo)
@@ -3673,7 +3690,6 @@ namespace Js
         // We need to ensure dynamic profile info even if we didn't generate a dynamic interpreter thunk
         // This happens when we go through CheckCodeGen thunk, to DelayDynamicInterpreterThunk, to here
         // but the background codegen thread updated the entry point with the native entry point.
-
         this->EnsureDynamicProfileInfo();
 
         Assert(HasValidEntryPoint());

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -273,6 +273,7 @@ namespace Js
             WinRTConstructorAllowed(Configuration::Global.flags.WinRTConstructorAllowed),
 #endif
             NoNative(Configuration::Global.flags.NoNative),
+            NoDynamicThunks(false),
             isOptimizedForManyInstances(isOptimizedForManyInstances),
             threadConfig(threadConfig)
         {
@@ -297,6 +298,9 @@ namespace Js
 #undef FORWARD_THREAD_CONFIG
 
         bool SupportsCollectGarbage() const { return true; }
+
+        void ForceNoDynamicThunks() { this->NoDynamicThunks = true; }
+        bool IsNoDynamicThunks() const { return this->NoDynamicThunks; }
 
         void ForceNoNative() { this->NoNative = true; }
         void ForceNative() { this->NoNative = false; }
@@ -341,6 +345,7 @@ namespace Js
 
         // Per script configurations
         bool NoNative;
+        bool NoDynamicThunks;
         BOOL fCanOptimizeGlobalLookup;
         const bool isOptimizedForManyInstances;
         const ThreadConfiguration * const threadConfig;
@@ -1056,6 +1061,7 @@ private:
         inline bool IsHeapEnumInProgress() { return GetRecycler()->IsHeapEnumInProgress(); }
 
         bool IsInterpreted() { return config.IsNoNative(); }
+        void ForceNoDynamicThunks() { config.ForceNoDynamicThunks(); }
         void ForceNoNative() { config.ForceNoNative(); }
         void ForceNative() { config.ForceNative(); }
         ScriptConfiguration const * GetConfig(void) const { return &config; }

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2415,6 +2415,12 @@ ThreadContext::RegisterScriptContext(Js::ScriptContext *scriptContext)
     {
         scriptContext->ForceNoNative();
     }
+
+    if (NoDynamicThunks())
+    {
+        scriptContext->ForceNoDynamicThunks();
+    }
+
 #if DBG || defined(RUNTIME_DATA_COLLECTION)
     scriptContextCount++;
 #endif

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -44,6 +44,7 @@ enum ThreadContextFlags
     ThreadContextFlagEvalDisabled                  = 0x00000002,
     ThreadContextFlagNoJIT                         = 0x00000004,
     ThreadContextFlagDisableFatalOnOOM             = 0x00000008,
+    ThreadContextFlagNoDynamicThunks               = 0x00000010,
 };
 
 const int LS_MAX_STACK_SIZE_KB = 300;
@@ -943,6 +944,11 @@ public:
     bool NoJIT() const
     {
         return this->TestThreadContextFlag(ThreadContextFlagNoJIT);
+    }
+
+    bool NoDynamicThunks() const
+    {
+        return this->TestThreadContextFlag(ThreadContextFlagNoDynamicThunks);
     }
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS


### PR DESCRIPTION
JsRuntimeAttributeDisableNativeCodeGeneration is not sufficient to disable all allocation of executable memory. Added a new attribute with explicitly this intent so that hosts running in locked down processes can embed ChakraCore