### PR TITLE
OS#16244108: Small refactor of Parser::CreateCallNode and Parser::CreateSuperCallNode

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -251,10 +251,7 @@ public:
     static ParseNodePtr StaticCreateNodeT(ArenaAllocator* alloc, charcount_t ichMin = 0, charcount_t ichLim = 0)
     {
         ParseNodePtr pnode = StaticAllocNode<nop>(alloc);
-        InitNode(nop,pnode);
-        // default - may be changed
-        pnode->ichMin = ichMin;
-        pnode->ichLim = ichLim;
+        pnode->Init(nop, ichMin, ichLim);
 
         return pnode;
     }
@@ -299,20 +296,15 @@ public:
         pnode->AsParseNodeSpecialName()->isSuper = false;
         return pnode;
     }
-    ParseNodePtr CreateBlockNode(PnodeBlockType blockType = PnodeBlockType::Regular)
-    {
-        ParseNodePtr pnode = CreateNode(knopBlock);
-        InitBlockNode(pnode, m_nextBlockId++, blockType);
-        return pnode;
-    }
-    // Creating parse nodes.
 
+    // Creating parse nodes.
     ParseNodePtr CreateNode(OpCode nop, charcount_t ichMin);
     ParseNodePtr CreateTriNode(OpCode nop, ParseNodePtr pnode1, ParseNodePtr pnode2, ParseNodePtr pnode3);
     ParseNodePtr CreateIntNode(int32 lw);
     ParseNodePtr CreateStrNode(IdentPtr pid);
 
     ParseNodePtr CreateUniNode(OpCode nop, ParseNodePtr pnodeOp);
+    ParseNodePtr CreateBlockNode(PnodeBlockType blockType = PnodeBlockType::Regular);
     ParseNodePtr CreateBinNode(OpCode nop, ParseNodePtr pnode1, ParseNodePtr pnode2);
     ParseNodePtr CreateSuperReferenceNode(OpCode nop, ParseNodePtr pnode1, ParseNodePtr pnode2);
     ParseNodePtr CreateCallNode(OpCode nop, ParseNodePtr pnode1, ParseNodePtr pnode2);
@@ -379,9 +371,6 @@ private:
     ParseNodePtr CreateStrNodeWithScanner(IdentPtr pid);
     ParseNodePtr CreateIntNodeWithScanner(int32 lw);
     ParseNodePtr CreateProgNodeWithScanner(bool isModuleSource);
-
-    static void InitNode(OpCode nop,ParseNodePtr pnode);
-    static void InitBlockNode(ParseNodePtr pnode, int blockId, PnodeBlockType blockType);
 
 private:
     ParseNodePtr m_currentNodeNonLambdaFunc; // current function or NULL

--- a/lib/Parser/ptree.cpp
+++ b/lib/Parser/ptree.cpp
@@ -4,6 +4,21 @@
 //-------------------------------------------------------------------------------------------------------
 #include "ParserPch.h"
 
+void ParseNode::Init(OpCode nop, charcount_t ichMin, charcount_t ichLim)
+{
+    this->nop = nop;
+    this->grfpn = PNodeFlags::fpnNone;
+    this->location = Js::Constants::NoRegister;
+    this->emitLabels = false;
+    this->isUsed = true;
+    this->notEscapedUse = false;
+    this->isInList = false;
+    this->isCallApplyTargetLoad = false;
+    this->isSpecialName = false;
+    this->ichMin = ichMin;
+    this->ichLim = ichLim;
+}
+
 ParseNodeUni * ParseNode::AsParseNodeUni()
 {
     Assert(((this->Grfnop() & fnopUni) && this->nop != knopParamPattern) || this->nop == knopThrow);
@@ -251,4 +266,51 @@ ParseNodePtr ParseNode::GetFormalNext()
         pnodeNext = this->AsParseNodeVar()->pnodeNext;
     }
     return pnodeNext;
+}
+
+void ParseNodeCall::Init(OpCode nop, ParseNodePtr pnodeTarget, ParseNodePtr pnodeArgs, charcount_t ichMin, charcount_t ichLim)
+{
+    __super::Init(nop, ichMin, ichLim);
+
+    this->pnodeTarget = pnodeTarget;
+    this->pnodeArgs = pnodeArgs;
+    this->argCount = 0;
+    this->spreadArgCount = 0;
+    this->callOfConstants = false;
+    this->isApplyCall = false;
+    this->isEvalCall = false;
+    this->isSuperCall = false;
+    this->hasDestructuring = false;
+}
+
+void ParseNodeSuperCall::Init(OpCode nop, ParseNodePtr pnodeTarget, ParseNodePtr pnodeArgs, charcount_t ichMin, charcount_t ichLim)
+{
+    __super::Init(nop, pnodeTarget, pnodeArgs, ichMin, ichLim);
+
+    this->isSuperCall = true;
+    this->pnodeThis = nullptr;
+    this->pnodeNewTarget = nullptr;
+}
+
+void ParseNodeBlock::Init(int blockId, PnodeBlockType blockType, charcount_t ichMin, charcount_t ichLim)
+{
+    __super::Init(knopBlock, ichMin, ichLim);
+
+    this->pnodeScopes = nullptr;
+    this->pnodeNext = nullptr;
+    this->scope = nullptr;
+    this->enclosingBlock = nullptr;
+    this->pnodeLexVars = nullptr;
+    this->pnodeStmt = nullptr;
+    this->pnodeLastValStmt = nullptr;
+
+    this->callsEval = false;
+    this->childCallsEval = false;
+    this->blockType = blockType;
+    this->blockId = blockId;
+
+    if (blockType != PnodeBlockType::Regular)
+    {
+        this->grfpn |= PNodeFlags::fpnSyntheticNode;
+    }
 }

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -109,6 +109,8 @@ class ParseNodeModule;
 class ParseNode
 {
 public:
+    void Init(OpCode nop, charcount_t ichMin, charcount_t ichLim);
+
     ParseNodeUni * AsParseNodeUni();
     ParseNodeBin * AsParseNodeBin();
     ParseNodeTri * AsParseNodeTri();
@@ -652,6 +654,8 @@ public:
     BYTE isEvalCall : 1;
     BYTE isSuperCall : 1;
     BYTE hasDestructuring : 1;
+
+    void Init(OpCode nop, ParseNodePtr pnodeTarget, ParseNodePtr pnodeArgs, charcount_t ichMin, charcount_t ichLim);
 };
 
 // base for statement nodes
@@ -684,6 +688,8 @@ public:
     PnodeBlockType blockType:2;
     BYTE         callsEval:1;
     BYTE         childCallsEval:1;
+
+    void Init(int blockId, PnodeBlockType blockType, charcount_t ichMin, charcount_t ichLim);
 
     void SetCallsEval(bool does) { callsEval = does; }
     bool GetCallsEval() const { return callsEval; }
@@ -862,6 +868,8 @@ class ParseNodeSuperCall : public ParseNodeCall
 public:
     ParseNodePtr pnodeThis;
     ParseNodePtr pnodeNewTarget;
+
+    void Init(OpCode nop, ParseNodePtr pnodeTarget, ParseNodePtr pnodeArgs, charcount_t ichMin, charcount_t ichLim);
 };
 
 const int kcbPnNone           = sizeof(ParseNode);


### PR DESCRIPTION
https://microsoft.visualstudio.com/OS/_workitems/edit/16244108

The uninitialized field was introduced by https://github.com/Microsoft/ChakraCore/pull/3917. The only read of the field is in EmitArgList, and if it ends up "true" instead of the default "false" an extra defensive load will be emitted for the constructor parameters so not a security/correctness concern.

