### PR TITLE
Eliminate some redundant aux slot pointer loads

### DIFF
--- a/lib/Backend/JITTypeHandler.cpp
+++ b/lib/Backend/JITTypeHandler.cpp
@@ -56,3 +56,14 @@ JITTypeHandler::IsTypeHandlerCompatibleForObjectHeaderInlining(const JITTypeHand
             oldTypeHandler->GetInlineSlotCapacity() - Js::DynamicTypeHandler::GetObjectHeaderInlinableSlotCapacity()
         );
 }
+
+bool 
+JITTypeHandler::NeedSlotAdjustment(const JITTypeHandler * oldTypeHandler, const JITTypeHandler * newTypeHandler, int *poldCount, int *pnewCount, Js::PropertyIndex *poldInlineSlotCapacity, Js::PropertyIndex *pnewInlineSlotCapacity)
+{
+    int oldCount = *poldCount = oldTypeHandler->GetSlotCapacity();
+    int newCount = *pnewCount = newTypeHandler->GetSlotCapacity();
+    int oldInlineSlotCapacity = *poldInlineSlotCapacity = oldTypeHandler->GetInlineSlotCapacity();
+    *pnewInlineSlotCapacity = newTypeHandler->GetInlineSlotCapacity();
+
+    return !(oldCount >= newCount || newCount <= oldInlineSlotCapacity);
+}    

--- a/lib/Backend/JITTypeHandler.h
+++ b/lib/Backend/JITTypeHandler.h
@@ -19,6 +19,7 @@ public:
     int GetSlotCapacity() const;
 
     static bool IsTypeHandlerCompatibleForObjectHeaderInlining(const JITTypeHandler * oldTypeHandler, const JITTypeHandler * newTypeHandler);
+    static bool NeedSlotAdjustment(const JITTypeHandler * oldTypeHandler, const JITTypeHandler * newTypeHandler, int *oldCount, int *newCount, Js::PropertyIndex *oldInlineSlotCapacity, Js::PropertyIndex *newInlineSlotCapacity);
 private:
     TypeHandlerIDL m_data;
 };

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -673,7 +673,7 @@ private:
     static IR::RegOpnd *    LoadGeneratorArgsPtr(IR::Instr *instrInsert);
     static IR::Instr *      LoadGeneratorObject(IR::Instr *instrInsert);
 
-    IR::Opnd *      LoadSlotArrayWithCachedLocalType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd);
+    IR::Opnd *      LoadSlotArrayWithCachedLocalType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd, bool canReuseAuxSlotPtr);
     IR::Opnd *      LoadSlotArrayWithCachedProtoType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd);
     IR::Instr *     LowerLdAsmJsEnv(IR::Instr *instr);
     IR::Instr *     LowerLdEnv(IR::Instr *instr);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -1045,6 +1045,24 @@ bool PropertySymOpnd::HasFinalType() const
     return this->finalType != nullptr;
 }
 
+bool PropertySymOpnd::NeedsAuxSlotPtrSymLoad() const
+{
+    // Consider: reload based on guarded prop ops' use of aux slots
+    return this->GetAuxSlotPtrSym() != nullptr;
+}
+
+void PropertySymOpnd::GenerateAuxSlotPtrSymLoad(IR::Instr * instrInsert)
+{
+    StackSym * auxSlotPtrSym = GetAuxSlotPtrSym();
+    Assert(auxSlotPtrSym);
+    Func * func = instrInsert->m_func;
+
+    IR::Opnd *opndIndir = IR::IndirOpnd::New(this->CreatePropertyOwnerOpnd(func), Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, func);
+    IR::RegOpnd *regOpnd = IR::RegOpnd::New(auxSlotPtrSym, TyMachReg, func);
+    regOpnd->SetIsJITOptimizedReg(true);
+    Lowerer::InsertMove(regOpnd, opndIndir, instrInsert);
+}
+
 PropertySymOpnd *
 PropertySymOpnd::CloneDefInternalSub(Func *func)
 {

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -660,6 +660,16 @@ public:
     StackSym * GetObjectTypeSym() const { return this->m_sym->AsPropertySym()->GetObjectTypeSym(); };
     PropertySym* GetPropertySym() const { return this->m_sym->AsPropertySym(); }
 
+    StackSym *EnsureAuxSlotPtrSym(Func * func)
+    {
+        return this->GetPropertySym()->EnsureAuxSlotPtrSym(func);
+    }
+
+    StackSym *GetAuxSlotPtrSym() const
+    {
+        return this->GetPropertySym()->GetAuxSlotPtrSym();
+    }
+
     void TryDisableRuntimePolymorphicCache()
     {
         if (this->m_runtimePolymorphicInlineCache && (this->m_polyCacheUtil < PolymorphicInlineCacheUtilizationThreshold))
@@ -1142,6 +1152,9 @@ public:
     {
         this->finalType = JITTypeHolder(nullptr);
     }
+
+    bool NeedsAuxSlotPtrSymLoad() const;
+    void GenerateAuxSlotPtrSymLoad(IR::Instr * instrInsert);
 
     BVSparse<JitArenaAllocator>* GetGuardedPropOps()
     {

--- a/lib/Backend/Sym.cpp
+++ b/lib/Backend/Sym.cpp
@@ -904,6 +904,17 @@ StackSym const *StackSym::GetVarEquivStackSym_NoCreate(Sym const * const sym)
     return stackSym;
 }
 
+StackSym *StackSym::EnsureAuxSlotPtrSym(Func * func)
+{
+    Assert(HasObjectInfo());
+    StackSym * auxSlotPtrSym = GetObjectInfo()->m_auxSlotPtrSym;
+    if (auxSlotPtrSym == nullptr)
+    {
+        auxSlotPtrSym = GetObjectInfo()->m_auxSlotPtrSym = StackSym::New(func);
+    }
+    return auxSlotPtrSym;
+}
+
 ///----------------------------------------------------------------------------
 ///
 /// PropertySym::New

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -71,10 +71,11 @@ public:
     static ObjectSymInfo * New(Func * func);
     static ObjectSymInfo * New(StackSym * typeSym, Func * func);
 
-    ObjectSymInfo(): m_typeSym(nullptr), m_propertySymList(nullptr) {};
+    ObjectSymInfo(): m_typeSym(nullptr), m_auxSlotPtrSym(nullptr), m_propertySymList(nullptr) {};
 
 public:
     StackSym *      m_typeSym;
+    StackSym *      m_auxSlotPtrSym;
     PropertySym *   m_propertySymList;
 };
 
@@ -185,6 +186,9 @@ public:
     StackSym *      GetObjectTypeSym() const { Assert(HasObjectTypeSym()); return GetObjectInfo()->m_typeSym; }
     int             GetSymSize(){ return TySize[m_type]; }
     void            FixupStackOffset(Func * currentFunc);
+
+    StackSym *      EnsureAuxSlotPtrSym(Func * func);
+    StackSym *      GetAuxSlotPtrSym() const { return HasObjectInfo() ? GetObjectInfo()->m_auxSlotPtrSym : nullptr; }
 
 private:
     StackSym *      GetTypeEquivSym(IRType type, Func *func);
@@ -310,6 +314,8 @@ public:
     bool HasObjectTypeSym() const { return this->m_stackSym->HasObjectTypeSym(); }
     bool HasWriteGuardSym() const { return this->m_writeGuardSym != nullptr; }
     StackSym * GetObjectTypeSym() const { return this->m_stackSym->GetObjectTypeSym(); }
+    StackSym * GetAuxSlotPtrSym() const { return this->m_stackSym->GetAuxSlotPtrSym(); }
+    StackSym * EnsureAuxSlotPtrSym(Func * func) { return this->m_stackSym->EnsureAuxSlotPtrSym(func); }
 
 public:
     PropertyKind    m_fieldKind;

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -140,6 +140,7 @@ PHASE(All)
                     PHASE(TraceObjTypeSpecWriteGuards)
                     PHASE(LiveOutFields)
                     PHASE(DisabledObjTypeSpec)
+                    PHASE(ReuseAuxSlotPtr)
                     #if DBG
                         PHASE(SimulatePolyCacheWithOneTypeForFunction)
                     #endif


### PR DESCRIPTION
Use objtypespec analysis to do this. Load the aux slot pointer only at type checks and points where the aux slots are reallocated. At optimized load/stores, reuse the aux slot pointer.