### PR TITLE
Fix bug in 'in' fastpath

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -19412,7 +19412,6 @@ void Lowerer::GenerateFastInlineIsIn(IR::Instr * instr)
     }
 
     IR::LabelInstr* helperLabel = IR::LabelInstr::New(Js::OpCode::Label, m_func, true);
-    IR::LabelInstr* doneFalseLabel = IR::LabelInstr::New(Js::OpCode::Label, m_func);
     IR::LabelInstr* doneLabel = IR::LabelInstr::New(Js::OpCode::Label, m_func);
     IR::LabelInstr* isArrayLabel = IR::LabelInstr::New(Js::OpCode::Label, m_func);
 
@@ -19473,21 +19472,12 @@ void Lowerer::GenerateFastInlineIsIn(IR::Instr * instr)
         src1Untagged,
         headSegmentLengthOpnd,
         Js::OpCode::BrGe_A,
-        doneFalseLabel,
-        instr);
-
-    InsertCompareBranch(
-        src1Untagged,
-        IR::IntConstOpnd::New(0, src1Untagged->GetType(), this->m_func),
-        Js::OpCode::BrLt_A,
-        doneFalseLabel,
+        helperLabel,
         instr);
 
     InsertMove(instr->GetDst(), LoadLibraryValueOpnd(instr, LibraryValue::ValueTrue), instr);
     InsertBranch(Js::OpCode::Br, doneLabel, instr);
 
-    instr->InsertBefore(doneFalseLabel);
-    InsertMove(instr->GetDst(), LoadLibraryValueOpnd(instr, LibraryValue::ValueFalse), instr);
     InsertBranch(Js::OpCode::Br, doneLabel, instr);
     instr->InsertBefore(helperLabel);
 

--- a/test/Bugs/inbug.js
+++ b/test/Bugs/inbug.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var arr0 = Array(1, 2);
+  arr0[-7] = 3;
+  return (-7 in arr0);
+}
+
+
+var res = test0();
+res &= test0();
+res &= test0();
+
+function test1() {
+  var arr0 = Array();
+  arr0[11] = -2;
+  return (11 in arr0);
+}
+
+res &= test1();
+res &= test1();
+res &= test1();
+
+if (res) {
+  print("Passed");
+}

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -446,4 +446,9 @@
       <compile-flags>-forceundodefer</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>inbug.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When we have more than 1 segment we cannot rely on HasNoMissingValue flag. This change fixes this assumption in 'in' fastpath.

Fixes OS#16349537
