### PR TITLE
Add specialized types of Sets and Maps

### DIFF
--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -38,7 +38,7 @@ public:
         return m_charLength;
     }
 
-    static bool Equals(Js::Var aLeft, Js::Var aRight)
+    static bool Equals(JITJavascriptString* aLeft, JITJavascriptString* aRight)
     {
         return Js::JavascriptStringHelpers<JITJavascriptString>::Equals(aLeft, aRight);
     }

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -1522,36 +1522,4 @@ CommonNumber:
         return NumberUtilities::TryToInt64(length);
     }
 
-    Var JavascriptConversion::TryCanonicalizeAsSimpleVar(Var value)
-    {
-        TypeId typeId = JavascriptOperators::GetTypeId(value);
-        switch (typeId)
-        {
-        case TypeIds_Integer:
-        case TypeIds_Number:
-        {
-            Var taggedInt = TryCanonicalizeAsTaggedInt<true>(value);
-            if (taggedInt)
-            {
-                return taggedInt;
-            }
-
-#if FLOATVAR
-            return value;
-#else
-            return nullptr;
-#endif
-        }
-        case TypeIds_String:
-        case TypeIds_Symbol:
-            // TODO: try to canonicalize Int64/Uint64 to TaggedInt
-        case TypeIds_Int64Number:
-        case TypeIds_UInt64Number:
-            return nullptr;
-
-        default:
-            return value;
-        }
-    }
-
 } // namespace Js

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -54,14 +54,19 @@ namespace Js
     template<bool zero>
     bool JavascriptConversion::SameValueCommon(Var aLeft, Var aRight)
     {
+        if (aLeft == aRight)
+        {
+            return true;
+        }
+
         TypeId leftType = JavascriptOperators::GetTypeId(aLeft);
-        TypeId rightType = JavascriptOperators::GetTypeId(aRight);
 
         if (JavascriptOperators::IsUndefinedOrNullType(leftType))
         {
-            return leftType == rightType;
+            return false;
         }
 
+        TypeId rightType = JavascriptOperators::GetTypeId(aRight);
         double dblLeft, dblRight;
 
         switch (leftType)
@@ -70,7 +75,7 @@ namespace Js
             switch (rightType)
             {
             case TypeIds_Integer:
-                return aLeft == aRight;
+                return false;
             case TypeIds_Number:
                 dblLeft     = TaggedInt::ToDouble(aLeft);
                 dblRight    = JavascriptNumber::GetValue(aRight);
@@ -181,17 +186,12 @@ CommonNumber:
             }
             break;
         case TypeIds_Boolean:
-            switch (rightType)
-            {
-            case TypeIds_Boolean:
-                return aLeft == aRight;
-            }
-            break;
+            return false;
         case TypeIds_String:
             switch (rightType)
             {
             case TypeIds_String:
-                return JavascriptString::Equals(aLeft, aRight);
+                return JavascriptString::Equals(JavascriptString::UnsafeFromVar(aLeft), JavascriptString::UnsafeFromVar(aRight));
             }
             break;
         case TypeIds_Symbol:
@@ -208,7 +208,7 @@ CommonNumber:
         default:
             break;
         }
-        return aLeft == aRight;
+        return false;
     }
 
     template bool JavascriptConversion::SameValueCommon<false>(Var aLeft, Var aRight);
@@ -1521,4 +1521,37 @@ CommonNumber:
 
         return NumberUtilities::TryToInt64(length);
     }
+
+    Var JavascriptConversion::TryCanonicalizeAsSimpleVar(Var value)
+    {
+        TypeId typeId = JavascriptOperators::GetTypeId(value);
+        switch (typeId)
+        {
+        case TypeIds_Integer:
+        case TypeIds_Number:
+        {
+            Var taggedInt = TryCanonicalizeAsTaggedInt<true>(value);
+            if (taggedInt)
+            {
+                return taggedInt;
+            }
+
+#if FLOATVAR
+            return value;
+#else
+            return nullptr;
+#endif
+        }
+        case TypeIds_String:
+        case TypeIds_Symbol:
+            // TODO: try to canonicalize Int64/Uint64 to TaggedInt
+        case TypeIds_Int64Number:
+        case TypeIds_UInt64Number:
+            return nullptr;
+
+        default:
+            return value;
+        }
+    }
+
 } // namespace Js

--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -92,11 +92,17 @@ namespace Js {
         static double LongToDouble(__int64 aValue);
         static double ULongToDouble(unsigned __int64 aValue);
 
-        template <bool allowNegOne>
+        template <bool allowNegOne, bool allowLossyConversion>
         static Var TryCanonicalizeAsTaggedInt(Var value);
+        template <bool allowNegOne, bool allowLossyConversion>
+        static Var TryCanonicalizeAsTaggedInt(Var value, TypeId typeId);
+        template <bool allowLossyConversion>
         static Var TryCanonicalizeAsSimpleVar(Var value);
 
     private:
+        template <typename T, bool allowNegOne>
+        static Var TryCanonicalizeIntHelper(T val);
+
         static BOOL ToInt32Finite(double value, int32* result);
         template<bool zero>
         static bool SameValueCommon(Var aValue, Var bValue);

--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -92,6 +92,10 @@ namespace Js {
         static double LongToDouble(__int64 aValue);
         static double ULongToDouble(unsigned __int64 aValue);
 
+        template <bool allowNegOne>
+        static Var TryCanonicalizeAsTaggedInt(Var value);
+        static Var TryCanonicalizeAsSimpleVar(Var value);
+
     private:
         static BOOL ToInt32Finite(double value, int32* result);
         template<bool zero>

--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -203,4 +203,40 @@ namespace Js {
        return SameValueCommon<true>(aValue, bValue);
    }
 
+   template <bool allowNegOne>
+   inline Var JavascriptConversion::TryCanonicalizeAsTaggedInt(Var value)
+   {
+       if (TaggedInt::Is(value))
+       {
+           return (allowNegOne || value != TaggedInt::ToVarUnchecked(-1))
+               ? value
+               : nullptr;
+       }
+
+       if (!JavascriptNumber::Is(value))
+       {
+           return nullptr;
+       }
+
+       double doubleVal = JavascriptNumber::GetValue(value);
+       int32 intVal = 0;
+
+       if (!JavascriptNumber::TryGetInt32Value<true>(doubleVal, &intVal))
+       {
+           return nullptr;
+       }
+
+       if (TaggedInt::IsOverflow(intVal))
+       {
+           return false;
+       }
+
+       if (!allowNegOne && intVal == -1)
+       {
+           return false;
+       }
+
+       return TaggedInt::ToVarUnchecked(intVal);
+   }
+
 } // namespace Js

--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -228,12 +228,12 @@ namespace Js {
 
        if (TaggedInt::IsOverflow(intVal))
        {
-           return false;
+           return nullptr;
        }
 
        if (!allowNegOne && intVal == -1)
        {
-           return false;
+           return nullptr;
        }
 
        return TaggedInt::ToVarUnchecked(intVal);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -746,14 +746,14 @@ namespace Js
         return dblLeft < dblRight;
     }
 
-    BOOL JavascriptOperators::StrictEqualString(Var aLeft, Var aRight)
+    BOOL JavascriptOperators::StrictEqualString(Var aLeft, JavascriptString* aRight)
     {
-        Assert(JavascriptOperators::GetTypeId(aRight) == TypeIds_String);
-
-        if (JavascriptOperators::GetTypeId(aLeft) != TypeIds_String)
+        JavascriptString* leftStr = TryFromVar<JavascriptString>(aLeft);
+        if (!leftStr)
+        {
             return false;
-
-        return JavascriptString::Equals(aLeft, aRight);
+        }
+        return JavascriptString::Equals(leftStr, aRight);
     }
 
     BOOL JavascriptOperators::StrictEqualEmptyString(Var aLeft)
@@ -785,7 +785,7 @@ namespace Js
             switch (rightType)
             {
             case TypeIds_String:
-                return JavascriptString::Equals(aLeft, aRight);
+                return JavascriptString::Equals(JavascriptString::UnsafeFromVar(aLeft), JavascriptString::UnsafeFromVar(aRight));
             }
             return FALSE;
         case TypeIds_Integer:
@@ -5188,7 +5188,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
        return JavascriptBoolean::ToVar(JavascriptOperators::StrictEqual(a, b, scriptContext), scriptContext);
     }
 
-    Var JavascriptOperators::OP_CmSrEq_String(Var a, Var b, ScriptContext *scriptContext)
+    Var JavascriptOperators::OP_CmSrEq_String(Var a, JavascriptString* b, ScriptContext *scriptContext)
     {
         return JavascriptBoolean::ToVar(JavascriptOperators::StrictEqualString(a, b), scriptContext);
     }

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -150,7 +150,7 @@ namespace Js
         static BOOL LessEqual(Var aLeft, Var aRight,ScriptContext* scriptContext);
         static BOOL NotEqual(Var aLeft, Var aRight,ScriptContext* scriptContext);
         static BOOL StrictEqual(Var aLeft, Var aRight,ScriptContext* scriptContext);
-        static BOOL StrictEqualString(Var aLeft, Var aRight);
+        static BOOL StrictEqualString(Var aLeft, JavascriptString* aRight);
         static BOOL StrictEqualEmptyString(Var aLeft);
         static BOOL NotStrictEqual(Var aLeft, Var aRight,ScriptContext* scriptContext);
 
@@ -400,7 +400,7 @@ namespace Js
         static Var OP_CmEq_A(Js::Var a,Js::Var b,ScriptContext* scriptContext);
         static Var OP_CmNeq_A(Js::Var a,Js::Var b,ScriptContext* scriptContext);
         static Var OP_CmSrEq_A(Js::Var a,Js::Var b,ScriptContext* scriptContext);
-        static Var OP_CmSrEq_String(Var a, Var b, ScriptContext *scriptContext);
+        static Var OP_CmSrEq_String(Var a, JavascriptString* b, ScriptContext *scriptContext);
         static Var OP_CmSrEq_EmptyString(Var a, ScriptContext *scriptContext);
         static Var OP_CmSrNeq_A(Js::Var a,Js::Var b,ScriptContext* scriptContext);
         static Var OP_CmLt_A(Js::Var a,Js::Var b,ScriptContext* scriptContext);

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5432,7 +5432,7 @@ namespace Js
             AssertOrFailFast(hasRight);
 
             // If the strings at this index are not equal, the callsite objects are not equal.
-            if (!Js::JavascriptString::Equals(varLeft, varRight))
+            if (!Js::JavascriptString::Equals(JavascriptString::FromVar(varLeft), JavascriptString::FromVar(varRight)))
             {
                 return false;
             }

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -72,6 +72,7 @@ Var JavascriptMap::NewInstance(RecyclableObject* function, CallInfo callInfo, ..
     // REVIEW: This condition seems impossible?
     if (mapObject->kind != MapKind::EmptyMap)
     {
+        Assert(UNREACHED);
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_ObjectIsAlreadyInitialized, _u("Map"), _u("Map"));
     }
 
@@ -130,12 +131,11 @@ Var JavascriptMap::EntryClear(RecyclableObject* function, CallInfo callInfo, ...
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.clear"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     map->Clear();
 
@@ -149,12 +149,11 @@ Var JavascriptMap::EntryDelete(RecyclableObject* function, CallInfo callInfo, ..
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.delete"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
 
@@ -171,12 +170,11 @@ Var JavascriptMap::EntryForEach(RecyclableObject* function, CallInfo callInfo, .
     ScriptContext* scriptContext = function->GetScriptContext();
     AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Map.prototype.forEach"));
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.forEach"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     if (args.Info.Count < 2 || !JavascriptConversion::IsCallable(args[1]))
     {
@@ -206,12 +204,11 @@ Var JavascriptMap::EntryGet(RecyclableObject* function, CallInfo callInfo, ...)
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.get"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
     Var value = nullptr;
@@ -231,12 +228,11 @@ Var JavascriptMap::EntryHas(RecyclableObject* function, CallInfo callInfo, ...)
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.has"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
 
@@ -252,12 +248,11 @@ Var JavascriptMap::EntrySet(RecyclableObject* function, CallInfo callInfo, ...)
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.set"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
     Var value = (args.Info.Count > 2) ? args[2] : scriptContext->GetLibrary()->GetUndefined();
@@ -280,12 +275,11 @@ Var JavascriptMap::EntrySizeGetter(RecyclableObject* function, CallInfo callInfo
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.size"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     int size = map->Size();
 
@@ -299,12 +293,11 @@ Var JavascriptMap::EntryEntries(RecyclableObject* function, CallInfo callInfo, .
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.entries"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     return scriptContext->GetLibrary()->CreateMapIterator(map, JavascriptMapIteratorKind::KeyAndValue);
 }
@@ -316,12 +309,11 @@ Var JavascriptMap::EntryKeys(RecyclableObject* function, CallInfo callInfo, ...)
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.keys"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
 
     return scriptContext->GetLibrary()->CreateMapIterator(map, JavascriptMapIteratorKind::Key);
 }
@@ -333,18 +325,18 @@ Var JavascriptMap::EntryValues(RecyclableObject* function, CallInfo callInfo, ..
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptMap::Is(args[0]))
+    JavascriptMap* map = JavascriptOperators::TryFromVar<JavascriptMap>(args[0]);
+    if (map == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Map.prototype.values"), _u("Map"));
     }
-
-    JavascriptMap* map = JavascriptMap::FromVar(args[0]);
     return scriptContext->GetLibrary()->CreateMapIterator(map, JavascriptMapIteratorKind::Value);
 }
 
 void
 JavascriptMap::Clear()
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     list.Clear();
     switch (this->kind)
     {
@@ -392,6 +384,7 @@ JavascriptMap::DeleteFromSimpleVarMap(Var value)
 bool
 JavascriptMap::Delete(Var key)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -410,6 +403,7 @@ JavascriptMap::Delete(Var key)
 bool
 JavascriptMap::Get(Var key, Var* value)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -453,13 +447,13 @@ JavascriptMap::Get(Var key, Var* value)
         Assume(UNREACHED);
         return false;
     }
-
-    return false;
 }
+
 
 bool
 JavascriptMap::Has(Var key)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -497,7 +491,7 @@ JavascriptMap::PromoteToComplexVarMap()
     AssertOrFailFast(this->kind == MapKind::SimpleVarMap);
 
     uint newMapSize = this->u.simpleVarMap->Count() + 1;
-    ComplexVarDataMap* newMap = RecyclerNew(GetRecycler(), ComplexVarDataMap, GetRecycler(), newMapSize);
+    ComplexVarDataMap* newMap = RecyclerNew(this->GetRecycler(), ComplexVarDataMap, this->GetRecycler(), newMapSize);
 
     JavascriptMap::MapDataList::Iterator iter = this->list.GetIterator();
     // TODO: we can use a more efficient Iterator, since we know there will be no side effects
@@ -516,10 +510,10 @@ JavascriptMap::SetOnEmptyMap(Var key, Var value)
     Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
     if (simpleVar)
     {
-        SimpleVarDataMap* newSimpleMap = RecyclerNew(GetRecycler(), SimpleVarDataMap, GetRecycler());
+        SimpleVarDataMap* newSimpleMap = RecyclerNew(this->GetRecycler(), SimpleVarDataMap, this->GetRecycler());
         MapDataKeyValuePair simplePair(simpleVar, value);
 
-        MapDataNode* node = this->list.Append(simplePair, GetScriptContext()->GetRecycler());
+        MapDataNode* node = this->list.Append(simplePair, this->GetRecycler());
 
         newSimpleMap->Add(simpleVar, node);
 
@@ -528,12 +522,12 @@ JavascriptMap::SetOnEmptyMap(Var key, Var value)
         return;
     }
 
-    ComplexVarDataMap* newComplexSet = RecyclerNew(GetRecycler(), ComplexVarDataMap, GetRecycler());
+    ComplexVarDataMap* newComplexSet = RecyclerNew(this->GetRecycler(), ComplexVarDataMap, this->GetRecycler());
     MapDataKeyValuePair complexPair(key, value);
 
-    MapDataNode* node = this->list.Append(complexPair, GetScriptContext()->GetRecycler());
+    MapDataNode* node = this->list.Append(complexPair, this->GetRecycler());
 
-    newComplexSet->Add(value, node);
+    newComplexSet->Add(key, node);
 
     this->u.complexVarMap = newComplexSet;
     this->kind = MapKind::ComplexVarMap;
@@ -556,7 +550,7 @@ JavascriptMap::TrySetOnSimpleVarMap(Var key, Var value)
     }
 
     MapDataKeyValuePair pair(simpleVar, value);
-    MapDataNode* newNode = this->list.Append(pair, GetScriptContext()->GetRecycler());
+    MapDataNode* newNode = this->list.Append(pair, this->GetRecycler());
     this->u.simpleVarMap->Add(simpleVar, newNode);
     return true;
 }
@@ -572,13 +566,14 @@ JavascriptMap::SetOnComplexVarMap(Var key, Var value)
     }
 
     MapDataKeyValuePair pair(key, value);
-    MapDataNode* newNode = this->list.Append(pair, GetScriptContext()->GetRecycler());
+    MapDataNode* newNode = this->list.Append(pair, this->GetRecycler());
     this->u.complexVarMap->Add(key, newNode);
 }
 
 void
 JavascriptMap::Set(Var key, Var value)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -604,6 +599,7 @@ JavascriptMap::Set(Var key, Var value)
 
 int JavascriptMap::Size()
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case MapKind::EmptyMap:

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -337,7 +337,9 @@ void
 JavascriptMap::Clear()
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     list.Clear();
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -357,6 +359,8 @@ template <bool isComplex>
 bool
 JavascriptMap::DeleteFromVarMap(Var value)
 {
+    Assert(this->kind == isComplex ? MapKind::ComplexVarMap : MapKind::SimpleVarMap);
+
     MapDataNode * node = nullptr;
     if (isComplex
         ? !this->u.complexVarMap->TryGetValueAndRemove(value, &node)
@@ -372,6 +376,8 @@ JavascriptMap::DeleteFromVarMap(Var value)
 bool
 JavascriptMap::DeleteFromSimpleVarMap(Var value)
 {
+    Assert(this->kind == MapKind::SimpleVarMap);
+
     Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
     if (!simpleVar)
     {
@@ -385,6 +391,7 @@ bool
 JavascriptMap::Delete(Var key)
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -404,6 +411,7 @@ bool
 JavascriptMap::Get(Var key, Var* value)
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -454,6 +462,7 @@ bool
 JavascriptMap::Has(Var key)
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -507,6 +516,7 @@ JavascriptMap::PromoteToComplexVarMap()
 void
 JavascriptMap::SetOnEmptyMap(Var key, Var value)
 {
+    Assert(this->kind == MapKind::EmptyMap);
     Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
     if (simpleVar)
     {
@@ -536,6 +546,8 @@ JavascriptMap::SetOnEmptyMap(Var key, Var value)
 bool
 JavascriptMap::TrySetOnSimpleVarMap(Var key, Var value)
 {
+    Assert(this->kind == MapKind::SimpleVarMap);
+
     Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
     if (!simpleVar)
     {
@@ -558,6 +570,8 @@ JavascriptMap::TrySetOnSimpleVarMap(Var key, Var value)
 void
 JavascriptMap::SetOnComplexVarMap(Var key, Var value)
 {
+    Assert(this->kind == MapKind::ComplexVarMap);
+
     MapDataNode* node = nullptr;
     if (this->u.complexVarMap->TryGetValue(key, &node))
     {
@@ -574,6 +588,7 @@ void
 JavascriptMap::Set(Var key, Var value)
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:
@@ -600,6 +615,7 @@ JavascriptMap::Set(Var key, Var value)
 int JavascriptMap::Size()
 {
     JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
+
     switch (this->kind)
     {
     case MapKind::EmptyMap:

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -378,13 +378,13 @@ JavascriptMap::DeleteFromSimpleVarMap(Var value)
 {
     Assert(this->kind == MapKind::SimpleVarMap);
 
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<true /* allowLossyConversion */>(value);
     if (!simpleVar)
     {
         return false;
     }
 
-    return this->DeleteFromVarMap<false>(simpleVar);
+    return this->DeleteFromVarMap<false /* isComplex */>(simpleVar);
 }
 
 bool
@@ -427,7 +427,7 @@ JavascriptMap::Get(Var key, Var* value)
             return true;
         }
         // If the key isn't in the map, check if the canonical value is
-        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<true /* allowLossyConversion */>(key);
         // If the simple var is the same as the original key, we know it isn't in the map
         if (!simpleVar || simpleVar == key)
         {
@@ -476,7 +476,7 @@ JavascriptMap::Has(Var key)
             return true;
         }
         // If the key isn't in the map, check if the canonical value is
-        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<true /* allowLossyConversion */>(key);
         // If the simple var is the same as the original key, we know it isn't in the map
         if (!simpleVar || simpleVar == key)
         {
@@ -517,7 +517,7 @@ void
 JavascriptMap::SetOnEmptyMap(Var key, Var value)
 {
     Assert(this->kind == MapKind::EmptyMap);
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<false /* allowLossyConversion */>(key);
     if (simpleVar)
     {
         SimpleVarDataMap* newSimpleMap = RecyclerNew(this->GetRecycler(), SimpleVarDataMap, this->GetRecycler());
@@ -548,7 +548,7 @@ JavascriptMap::TrySetOnSimpleVarMap(Var key, Var value)
 {
     Assert(this->kind == MapKind::SimpleVarMap);
 
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(key);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<false /* allowLossyConversion */>(key);
     if (!simpleVar)
     {
         return false;

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -359,7 +359,7 @@ template <bool isComplex>
 bool
 JavascriptMap::DeleteFromVarMap(Var value)
 {
-    Assert(this->kind == isComplex ? MapKind::ComplexVarMap : MapKind::SimpleVarMap);
+    Assert(this->kind == (isComplex ? MapKind::ComplexVarMap : MapKind::SimpleVarMap));
 
     MapDataNode * node = nullptr;
     if (isComplex

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -37,7 +37,9 @@ namespace Js
             Field(SimpleVarDataMap*) simpleVarMap;
             Field(ComplexVarDataMap*) complexVarMap;
             MapUnion() {}
-        } u;
+        };
+
+        Field(MapUnion) u;
 
         Field(MapKind) kind = MapKind::EmptyMap;
 

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -32,10 +32,11 @@ namespace Js
 
         Field(MapDataList) list;
 
-        union
+        union MapUnion
         {
             Field(SimpleVarDataMap*) simpleVarMap;
             Field(ComplexVarDataMap*) complexVarMap;
+            MapUnion() {}
         } u;
 
         Field(MapKind) kind = MapKind::EmptyMap;

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -21,7 +21,7 @@ namespace Js
             // An EmptyMap is a map containing no elements
             EmptyMap,
             // A SimpleVarMap is a map containing only Vars which are comparable by pointer, and don't require
-            // pointer comparison
+            // value comparison
             //
             // Addition of a Var that is not comparable by pointer value causes the set to be promoted to a ComplexVarSet
             SimpleVarMap,

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -6,379 +6,669 @@
 
 namespace Js
 {
-    JavascriptSet::JavascriptSet(DynamicType* type)
-        : DynamicObject(type)
+JavascriptSet::JavascriptSet(DynamicType* type)
+    : DynamicObject(type)
+{
+}
+
+JavascriptSet* JavascriptSet::New(ScriptContext* scriptContext)
+{
+    JavascriptSet* set = scriptContext->GetLibrary()->CreateSet();
+
+    return set;
+}
+
+bool JavascriptSet::Is(Var aValue)
+{
+    return JavascriptOperators::GetTypeId(aValue) == TypeIds_Set;
+}
+
+JavascriptSet* JavascriptSet::FromVar(Var aValue)
+{
+    AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+
+    return static_cast<JavascriptSet *>(aValue);
+}
+
+JavascriptSet* JavascriptSet::UnsafeFromVar(Var aValue)
+{
+    AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+
+    return static_cast<JavascriptSet *>(aValue);
+}
+
+JavascriptSet::SetDataList::Iterator JavascriptSet::GetIterator()
+{
+    return this->list.GetIterator();
+}
+
+Var JavascriptSet::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+    JavascriptLibrary* library = scriptContext->GetLibrary();
+    AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Set"));
+
+    Var newTarget = args.GetNewTarget();
+    bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
+    CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Set);
+
+    JavascriptSet* setObject = nullptr;
+
+    if (callInfo.Flags & CallFlags_New)
     {
+        setObject = library->CreateSet();
+    }
+    else
+    {
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set"), _u("Set"));
+    }
+    Assert(setObject != nullptr);
+
+    Var iterable = (args.Info.Count > 1) ? args[1] : library->GetUndefined();
+
+    // REVIEW: This condition seems impossible?
+    if (setObject->kind != SetKind::EmptySet)
+    {
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_ObjectIsAlreadyInitialized, _u("Set"), _u("Set"));
     }
 
-    JavascriptSet* JavascriptSet::New(ScriptContext* scriptContext)
-    {
-        JavascriptSet* set = scriptContext->GetLibrary()->CreateSet();
-        set->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler());
+    RecyclableObject* iter = nullptr;
+    RecyclableObject* adder = nullptr;
 
-        return set;
+    if (JavascriptConversion::CheckObjectCoercible(iterable, scriptContext))
+    {
+        iter = JavascriptOperators::GetIterator(iterable, scriptContext);
+        Var adderVar = JavascriptOperators::GetPropertyNoCache(setObject, PropertyIds::add, scriptContext);
+        if (!JavascriptConversion::IsCallable(adderVar))
+        {
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction);
+        }
+        adder = RecyclableObject::FromVar(adderVar);
     }
 
-    bool JavascriptSet::Is(Var aValue)
+    if (iter != nullptr)
     {
-        return JavascriptOperators::GetTypeId(aValue) == TypeIds_Set;
+        JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
+            CALL_FUNCTION(scriptContext->GetThreadContext(), adder, CallInfo(CallFlags_Value, 2), setObject, nextItem);
+        });
     }
 
-    JavascriptSet* JavascriptSet::FromVar(Var aValue)
-    {
-        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+    return isCtorSuperCall ?
+        JavascriptOperators::OrdinaryCreateFromConstructor(RecyclableObject::FromVar(newTarget), setObject, nullptr, scriptContext) :
+        setObject;
+}
 
-        return static_cast<JavascriptSet *>(aValue);
+Var JavascriptSet::EntryAdd(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
+    {
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.add"), _u("Set"));
     }
 
-    JavascriptSet* JavascriptSet::UnsafeFromVar(Var aValue)
-    {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
-        return static_cast<JavascriptSet *>(aValue);
+    Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
+
+    if (JavascriptNumber::Is(value) && JavascriptNumber::IsNegZero(JavascriptNumber::GetValue(value)))
+    {
+        // Normalize -0 to +0
+        value = JavascriptNumber::New(0.0, scriptContext);
     }
 
-    JavascriptSet::SetDataList::Iterator JavascriptSet::GetIterator()
+    set->Add(value);
+
+    return set;
+}
+
+Var JavascriptSet::EntryClear(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        return list.GetIterator();
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.clear"), _u("Set"));
     }
 
-    Var JavascriptSet::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+    set->Clear();
+
+    return scriptContext->GetLibrary()->GetUndefined();
+}
+
+Var JavascriptSet::EntryDelete(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-        JavascriptLibrary* library = scriptContext->GetLibrary();
-        AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Set"));
-
-        Var newTarget = args.GetNewTarget();
-        bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Set);
-
-        JavascriptSet* setObject = nullptr;
-
-        if (callInfo.Flags & CallFlags_New)
-        {
-            setObject = library->CreateSet();
-        }
-        else
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set"), _u("Set"));
-        }
-        Assert(setObject != nullptr);
-
-        Var iterable = (args.Info.Count > 1) ? args[1] : library->GetUndefined();
-
-        if (setObject->set != nullptr)
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_ObjectIsAlreadyInitialized, _u("Set"), _u("Set"));
-        }
-
-        setObject->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler());
-
-        RecyclableObject* iter = nullptr;
-        RecyclableObject* adder = nullptr;
-
-        if (JavascriptConversion::CheckObjectCoercible(iterable, scriptContext))
-        {
-            iter = JavascriptOperators::GetIterator(iterable, scriptContext);
-            Var adderVar = JavascriptOperators::GetPropertyNoCache(setObject, PropertyIds::add, scriptContext);
-            if (!JavascriptConversion::IsCallable(adderVar))
-            {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction);
-            }
-            adder = RecyclableObject::FromVar(adderVar);
-        }
-
-        if (iter != nullptr)
-        {
-            JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
-                CALL_FUNCTION(scriptContext->GetThreadContext(), adder, CallInfo(CallFlags_Value, 2), setObject, nextItem);
-            });
-        }
-
-        return isCtorSuperCall ?
-            JavascriptOperators::OrdinaryCreateFromConstructor(RecyclableObject::FromVar(newTarget), setObject, nullptr, scriptContext) :
-            setObject;
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.delete"), _u("Set"));
     }
 
-    Var JavascriptSet::EntryAdd(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+    Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
+
+    bool didDelete = set->Delete(value);
+
+    return scriptContext->GetLibrary()->CreateBoolean(didDelete);
+}
+
+Var JavascriptSet::EntryForEach(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+    AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Set.prototype.forEach"));
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.add"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-        Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
-
-        if (JavascriptNumber::Is(value) && JavascriptNumber::IsNegZero(JavascriptNumber::GetValue(value)))
-        {
-            // Normalize -0 to +0
-            value = JavascriptNumber::New(0.0, scriptContext);
-        }
-
-        set->Add(value);
-
-        return set;
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.forEach"), _u("Set"));
     }
 
-    Var JavascriptSet::EntryClear(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+
+    if (args.Info.Count < 2 || !JavascriptConversion::IsCallable(args[1]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("Set.prototype.forEach"));
+    }
+    RecyclableObject* callBackFn = RecyclableObject::FromVar(args[1]);
 
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
+    Var thisArg = (args.Info.Count > 2) ? args[2] : scriptContext->GetLibrary()->GetUndefined();
 
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.clear"), _u("Set"));
-        }
+    auto iterator = set->GetIterator();
 
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+    while (iterator.Next())
+    {
+        Var value = iterator.Current();
 
-        set->Clear();
-
-        return scriptContext->GetLibrary()->GetUndefined();
+        CALL_FUNCTION(scriptContext->GetThreadContext(), callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, value, args[0]);
     }
 
-    Var JavascriptSet::EntryDelete(RecyclableObject* function, CallInfo callInfo, ...)
+    return scriptContext->GetLibrary()->GetUndefined();
+}
+
+Var JavascriptSet::EntryHas(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.delete"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-        Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
-
-        bool didDelete = set->Delete(value);
-
-        return scriptContext->GetLibrary()->CreateBoolean(didDelete);
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.has"), _u("Set"));
     }
 
-    Var JavascriptSet::EntryForEach(RecyclableObject* function, CallInfo callInfo, ...)
+    Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
+
+    bool hasValue = set->Has(value);
+
+    return scriptContext->GetLibrary()->CreateBoolean(hasValue);
+}
+
+Var JavascriptSet::EntrySizeGetter(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-        AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Set.prototype.forEach"));
-
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.forEach"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-
-        if (args.Info.Count < 2 || !JavascriptConversion::IsCallable(args[1]))
-        {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("Set.prototype.forEach"));
-        }
-        RecyclableObject* callBackFn = RecyclableObject::FromVar(args[1]);
-
-        Var thisArg = (args.Info.Count > 2) ? args[2] : scriptContext->GetLibrary()->GetUndefined();
-
-        auto iterator = set->GetIterator();
-
-        while (iterator.Next())
-        {
-            Var value = iterator.Current();
-
-            CALL_FUNCTION(scriptContext->GetThreadContext(), callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, value, args[0]);
-        }
-
-        return scriptContext->GetLibrary()->GetUndefined();
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.size"), _u("Set"));
     }
 
-    Var JavascriptSet::EntryHas(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+    int size = set->Size();
+
+    return JavascriptNumber::ToVar(size, scriptContext);
+}
+
+Var JavascriptSet::EntryEntries(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.has"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-
-        Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
-
-        bool hasValue = set->Has(value);
-
-        return scriptContext->GetLibrary()->CreateBoolean(hasValue);
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.entries"), _u("Set"));
     }
 
-    Var JavascriptSet::EntrySizeGetter(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+    return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::KeyAndValue);
+}
+
+Var JavascriptSet::EntryValues(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+    ARGUMENTS(args, callInfo);
+    ScriptContext* scriptContext = function->GetScriptContext();
+
+    if (!JavascriptSet::Is(args[0]))
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
-
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.size"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-        int size = set->Size();
-
-        return JavascriptNumber::ToVar(size, scriptContext);
+        JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.values"), _u("Set"));
     }
 
-    Var JavascriptSet::EntryEntries(RecyclableObject* function, CallInfo callInfo, ...)
+    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+
+    return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::Value);
+}
+
+Var JavascriptSet::EntryGetterSymbolSpecies(RecyclableObject* function, CallInfo callInfo, ...)
+{
+    ARGUMENTS(args, callInfo);
+
+    Assert(args.Info.Count > 0);
+
+    return args[0];
+}
+
+template <typename T>
+T*
+JavascriptSet::CreateVarSetFromList(uint initialCapacity)
+{
+    T* varSet = RecyclerNew(GetRecycler(), T, GetRecycler(), initialCapacity);
+
+    JavascriptSet::SetDataList::Iterator iter = this->list.GetIterator();
+    // TODO: we can use a more efficient Iterator, since we know there will be no side effects
+    while (iter.Next())
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+        varSet->Add(iter.Current(), iter.CurrentNode());
+    }
+    return varSet;
+}
 
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
+void
+JavascriptSet::PromoteToSimpleVarSet()
+{
+    AssertOrFailFast(this->kind == SetKind::IntSet);
+    SimpleVarDataSet* newSet = this->CreateVarSetFromList<SimpleVarDataSet>(this->u.intSet->Count() + 1);
 
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.entries"), _u("Set"));
-        }
+    this->kind = SetKind::SimpleVarSet;
+    this->u.simpleVarSet = newSet;
+}
 
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
+void
+JavascriptSet::PromoteToComplexVarSet()
+{
+    uint setSize = 0;
+    if (this->kind == SetKind::IntSet)
+    {
+        setSize = this->u.intSet->Count();
+    }
+    else
+    {
+        AssertOrFailFast(this->kind == SetKind::SimpleVarSet);
+        setSize = this->u.simpleVarSet->Count();
+    }
+    ComplexVarDataSet* newSet = this->CreateVarSetFromList<ComplexVarDataSet>(setSize + 1);
 
-        return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::KeyAndValue);
+    this->kind = SetKind::ComplexVarSet;
+    this->u.complexVarSet = newSet;
+}
+
+void
+JavascriptSet::AddToEmptySet(Var value)
+{
+    // We cannot store an int with value -1 inside of a bit vector
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    if (taggedInt)
+    {
+        int32 intVal = TaggedInt::ToInt32(taggedInt);
+
+        BVSparse<Recycler>* newIntSet = RecyclerNew(GetRecycler(), BVSparse<Recycler>, GetRecycler());
+        newIntSet->Set(intVal);
+
+        this->list.Append(taggedInt, GetScriptContext()->GetRecycler());
+
+        this->u.intSet = newIntSet;
+        this->kind = SetKind::IntSet;
+        return;
     }
 
-    Var JavascriptSet::EntryValues(RecyclableObject* function, CallInfo callInfo, ...)
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    if (simpleVar)
     {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+        SimpleVarDataSet* newSimpleSet = RecyclerNew(GetRecycler(), SimpleVarDataSet, GetRecycler());
+        SetDataNode* node = this->list.Append(simpleVar, GetScriptContext()->GetRecycler());
 
-        ARGUMENTS(args, callInfo);
-        ScriptContext* scriptContext = function->GetScriptContext();
+        newSimpleSet->Add(simpleVar, node);
 
-        if (!JavascriptSet::Is(args[0]))
-        {
-            JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.values"), _u("Set"));
-        }
-
-        JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
-        return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::Value);
+        this->u.simpleVarSet = newSimpleSet;
+        this->kind = SetKind::SimpleVarSet;
+        return;
     }
 
-    Var JavascriptSet::EntryGetterSymbolSpecies(RecyclableObject* function, CallInfo callInfo, ...)
+    ComplexVarDataSet* newComplexSet = RecyclerNew(GetRecycler(), ComplexVarDataSet, GetRecycler());
+    SetDataNode* node = this->list.Append(value, GetScriptContext()->GetRecycler());
+
+    newComplexSet->Add(value, node);
+
+    this->u.complexVarSet = newComplexSet;
+    this->kind = SetKind::ComplexVarSet;
+}
+
+bool
+JavascriptSet::TryAddToIntSet(Var value)
+{
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    if (!taggedInt)
     {
-        ARGUMENTS(args, callInfo);
-
-        Assert(args.Info.Count > 0);
-
-        return args[0];
-    }
-
-    void JavascriptSet::Add(Var value)
-    {
-        if (!set->ContainsKey(value))
-        {
-            SetDataNode* node = list.Append(value, GetScriptContext()->GetRecycler());
-            set->Add(value, node);
-        }
-    }
-
-    void JavascriptSet::Clear()
-    {
-        // TODO: (Consider) Should we clear the set here and leave it as large as it has grown, or
-        // toss it away and create a new empty set, letting it grow as needed?
-        list.Clear();
-        set->Clear();
-    }
-
-    bool JavascriptSet::Delete(Var value)
-    {
-        if (set->ContainsKey(value))
-        {
-            SetDataNode* node = set->Item(value);
-            list.Remove(node);
-            return set->Remove(value);
-        }
         return false;
     }
 
-    bool JavascriptSet::Has(Var value)
+    int32 intVal = TaggedInt::ToInt32(taggedInt);
+    if (!this->u.intSet->TestAndSet(intVal))
     {
-        return set->ContainsKey(value);
+        this->list.Append(taggedInt, GetScriptContext()->GetRecycler());
+    }
+    return true;
+}
+
+bool
+JavascriptSet::TryAddToSimpleVarSet(Var value)
+{
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    if (!simpleVar)
+    {
+        return false;
     }
 
-    int JavascriptSet::Size()
+    if (!this->u.simpleVarSet->ContainsKey(simpleVar))
     {
-        return set->Count();
+        SetDataNode* node = this->list.Append(simpleVar, GetScriptContext()->GetRecycler());
+        this->u.simpleVarSet->Add(simpleVar, node);
     }
 
-    BOOL JavascriptSet::GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
+    return true;
+}
+
+void
+JavascriptSet::AddToComplexVarSet(Var value)
+{
+    if (!this->u.complexVarSet->ContainsKey(value))
     {
-        stringBuilder->AppendCppLiteral(_u("Set"));
-        return TRUE;
+        SetDataNode* node = this->list.Append(value, GetScriptContext()->GetRecycler());
+        this->u.complexVarSet->Add(value, node);
     }
+}
+
+void
+JavascriptSet::Add(Var value)
+{
+    switch (this->kind)
+    {
+    case SetKind::EmptySet:
+    {
+        this->AddToEmptySet(value);
+        return;
+    }
+
+    case SetKind::IntSet:
+    {
+        if (this->TryAddToIntSet(value))
+        {
+            return;
+        }
+
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+        if (simpleVar)
+        {
+            this->PromoteToSimpleVarSet();
+            this->Add(simpleVar);
+            return;
+        }
+
+        this->PromoteToComplexVarSet();
+        this->Add(value);
+        return;
+    }
+
+    case SetKind::SimpleVarSet:
+        if (this->TryAddToSimpleVarSet(value))
+        {
+            return;
+        }
+
+        this->PromoteToComplexVarSet();
+        this->Add(value);
+        return;
+
+    case SetKind::ComplexVarSet:
+        this->AddToComplexVarSet(value);
+        return;
+
+    default:
+        Assume(UNREACHED);
+    }
+}
+
+void JavascriptSet::Clear()
+{
+    // TODO: (Consider) Should we clear the set here and leave it as large as it has grown, or
+    // toss it away and create a new empty set, letting it grow as needed?
+    this->list.Clear();
+    switch (this->kind)
+    {
+    case SetKind::EmptySet:
+        return;
+    case SetKind::IntSet:
+        this->u.intSet->ClearAll();
+        return;
+    case SetKind::SimpleVarSet:
+        this->u.simpleVarSet->Clear();
+        return;
+    case SetKind::ComplexVarSet:
+        this->u.complexVarSet->Clear();
+        return;
+    default:
+        Assume(UNREACHED);
+    }
+}
+
+bool
+JavascriptSet::IsInIntSet(Var value)
+{
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    if (!taggedInt)
+    {
+        return false;
+    }
+    int32 intVal = TaggedInt::ToInt32(taggedInt);
+    return this->u.intSet->Test(intVal);
+}
+
+template <bool isComplex>
+bool
+JavascriptSet::DeleteFromVarSet(Var value)
+{
+    SetDataNode * node = nullptr;
+    if (isComplex
+        ? !this->u.complexVarSet->TryGetValueAndRemove(value, &node)
+        : !this->u.simpleVarSet->TryGetValueAndRemove(value, &node))
+    {
+        return false;
+    }
+
+    this->list.Remove(node);
+    return true;
+}
+
+bool
+JavascriptSet::DeleteFromSimpleVarSet(Var value)
+{
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    if (!simpleVar)
+    {
+        return false;
+    }
+
+    return this->DeleteFromVarSet<false>(simpleVar);
+}
+
+bool JavascriptSet::Delete(Var value)
+{
+    switch (this->kind)
+    {
+    case SetKind::EmptySet:
+        return false;
+
+    case SetKind::IntSet:
+        if (!IsInIntSet(value))
+        {
+            return false;
+        }
+        this->PromoteToSimpleVarSet();
+        return this->Delete(value);
+
+    case SetKind::SimpleVarSet:
+        return this->DeleteFromSimpleVarSet(value);
+
+    case SetKind::ComplexVarSet:
+        return this->DeleteFromVarSet<true>(value);
+
+    default:
+        Assume(UNREACHED);
+        return false;
+    }
+}
+
+bool JavascriptSet::Has(Var value)
+{
+    switch (this->kind)
+    {
+    case SetKind::EmptySet:
+        return false;
+
+    case SetKind::IntSet:
+    {
+        Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+        if (!taggedInt)
+        {
+            return false;
+        }
+        int32 intVal = TaggedInt::ToInt32(taggedInt);
+        return this->u.intSet->Test(intVal);
+    }
+
+    case SetKind::SimpleVarSet:
+    {
+        // First check if the value is in the set
+        if (this->u.simpleVarSet->ContainsKey(value))
+        {
+            return true;
+        }
+        // If the value isn't in the set, check if the canonical value is
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+        // If the simple value is the same as the original value, we know it isn't in the set
+        if (!simpleVar || simpleVar == value)
+        {
+            return false;
+        }
+
+        return this->u.simpleVarSet->ContainsKey(simpleVar);
+    }
+
+    case SetKind::ComplexVarSet:
+        return this->u.complexVarSet->ContainsKey(value);
+
+    default:
+        Assume(UNREACHED);
+        return false;
+    }
+}
+
+int JavascriptSet::Size()
+{
+    switch (this->kind)
+    {
+    case SetKind::EmptySet:
+        return 0;
+    case SetKind::IntSet:
+        return this->u.intSet->Count();
+    case SetKind::SimpleVarSet:
+        return this->u.simpleVarSet->Count();
+    case SetKind::ComplexVarSet:
+        return this->u.complexVarSet->Count();
+    default:
+        Assume(UNREACHED);
+        return 0;
+    }
+}
+
+BOOL JavascriptSet::GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
+{
+    stringBuilder->AppendCppLiteral(_u("Set"));
+    return TRUE;
+}
 
 #if ENABLE_TTD
-    void JavascriptSet::MarkVisitKindSpecificPtrs(TTD::SnapshotExtractor* extractor)
+void JavascriptSet::MarkVisitKindSpecificPtrs(TTD::SnapshotExtractor* extractor)
+{
+    auto iterator = this->GetIterator();
+    while(iterator.Next())
     {
-        auto iterator = this->GetIterator();
-        while(iterator.Next())
+        extractor->MarkVisitVar(iterator.Current());
+    }
+}
+
+TTD::NSSnapObjects::SnapObjectType JavascriptSet::GetSnapTag_TTD() const
+{
+    return TTD::NSSnapObjects::SnapObjectType::SnapSetObject;
+}
+
+void JavascriptSet::ExtractSnapObjectDataInto(TTD::NSSnapObjects::SnapObject* objData, TTD::SlabAllocator& alloc)
+{
+    TTD::NSSnapObjects::SnapSetInfo* ssi = alloc.SlabAllocateStruct<TTD::NSSnapObjects::SnapSetInfo>();
+    ssi->SetSize = 0;
+
+    if(this->Size() == 0)
+    {
+        ssi->SetValueArray = nullptr;
+    }
+    else
+    {
+        ssi->SetValueArray = alloc.SlabAllocateArray<TTD::TTDVar>(this->Size());
+
+        auto iter = this->GetIterator();
+        while(iter.Next())
         {
-            extractor->MarkVisitVar(iterator.Current());
+            ssi->SetValueArray[ssi->SetSize] = iter.Current();
+            ssi->SetSize++;
         }
     }
 
-    TTD::NSSnapObjects::SnapObjectType JavascriptSet::GetSnapTag_TTD() const
-    {
-        return TTD::NSSnapObjects::SnapObjectType::SnapSetObject;
-    }
+    TTD::NSSnapObjects::StdExtractSetKindSpecificInfo<TTD::NSSnapObjects::SnapSetInfo*, TTD::NSSnapObjects::SnapObjectType::SnapSetObject>(objData, ssi);
+}
 
-    void JavascriptSet::ExtractSnapObjectDataInto(TTD::NSSnapObjects::SnapObject* objData, TTD::SlabAllocator& alloc)
-    {
-        TTD::NSSnapObjects::SnapSetInfo* ssi = alloc.SlabAllocateStruct<TTD::NSSnapObjects::SnapSetInfo>();
-        ssi->SetSize = 0;
+JavascriptSet* JavascriptSet::CreateForSnapshotRestore(ScriptContext* ctx)
+{
+    JavascriptSet* res = ctx->GetLibrary()->CreateSet();
 
-        if(this->Size() == 0)
-        {
-            ssi->SetValueArray = nullptr;
-        }
-        else
-        {
-            ssi->SetValueArray = alloc.SlabAllocateArray<TTD::TTDVar>(this->Size());
-
-            auto iter = this->GetIterator();
-            while(iter.Next())
-            {
-                ssi->SetValueArray[ssi->SetSize] = iter.Current();
-                ssi->SetSize++;
-            }
-        }
-
-        TTD::NSSnapObjects::StdExtractSetKindSpecificInfo<TTD::NSSnapObjects::SnapSetInfo*, TTD::NSSnapObjects::SnapObjectType::SnapSetObject>(objData, ssi);
-    }
-
-    JavascriptSet* JavascriptSet::CreateForSnapshotRestore(ScriptContext* ctx)
-    {
-        JavascriptSet* res = ctx->GetLibrary()->CreateSet();
-        res->set = RecyclerNew(ctx->GetRecycler(), SetDataSet, ctx->GetRecycler());
-
-        return res;
-    }
+    return res;
+}
 #endif
 }

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -72,6 +72,7 @@ Var JavascriptSet::NewInstance(RecyclableObject* function, CallInfo callInfo, ..
     // REVIEW: This condition seems impossible?
     if (setObject->kind != SetKind::EmptySet)
     {
+        Assert(UNREACHED);
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_ObjectIsAlreadyInitialized, _u("Set"), _u("Set"));
     }
 
@@ -108,12 +109,11 @@ Var JavascriptSet::EntryAdd(RecyclableObject* function, CallInfo callInfo, ...)
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.add"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
 
@@ -135,12 +135,11 @@ Var JavascriptSet::EntryClear(RecyclableObject* function, CallInfo callInfo, ...
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.clear"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     set->Clear();
 
@@ -154,12 +153,11 @@ Var JavascriptSet::EntryDelete(RecyclableObject* function, CallInfo callInfo, ..
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.delete"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     Var value = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
 
@@ -176,13 +174,11 @@ Var JavascriptSet::EntryForEach(RecyclableObject* function, CallInfo callInfo, .
     ScriptContext* scriptContext = function->GetScriptContext();
     AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Set.prototype.forEach"));
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.forEach"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
-
 
     if (args.Info.Count < 2 || !JavascriptConversion::IsCallable(args[1]))
     {
@@ -231,12 +227,11 @@ Var JavascriptSet::EntrySizeGetter(RecyclableObject* function, CallInfo callInfo
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.size"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     int size = set->Size();
 
@@ -250,12 +245,11 @@ Var JavascriptSet::EntryEntries(RecyclableObject* function, CallInfo callInfo, .
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.entries"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::KeyAndValue);
 }
@@ -267,12 +261,11 @@ Var JavascriptSet::EntryValues(RecyclableObject* function, CallInfo callInfo, ..
     ARGUMENTS(args, callInfo);
     ScriptContext* scriptContext = function->GetScriptContext();
 
-    if (!JavascriptSet::Is(args[0]))
+    JavascriptSet* set = JavascriptOperators::TryFromVar<JavascriptSet>(args[0]);
+    if (set == nullptr)
     {
         JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_NeedObjectOfType, _u("Set.prototype.values"), _u("Set"));
     }
-
-    JavascriptSet* set = JavascriptSet::FromVar(args[0]);
 
     return scriptContext->GetLibrary()->CreateSetIterator(set, JavascriptSetIteratorKind::Value);
 }
@@ -290,7 +283,7 @@ template <typename T>
 T*
 JavascriptSet::CreateVarSetFromList(uint initialCapacity)
 {
-    T* varSet = RecyclerNew(GetRecycler(), T, GetRecycler(), initialCapacity);
+    T* varSet = RecyclerNew(this->GetRecycler(), T, this->GetRecycler(), initialCapacity);
 
     JavascriptSet::SetDataList::Iterator iter = this->list.GetIterator();
     // TODO: we can use a more efficient Iterator, since we know there will be no side effects
@@ -339,10 +332,10 @@ JavascriptSet::AddToEmptySet(Var value)
     {
         int32 intVal = TaggedInt::ToInt32(taggedInt);
 
-        BVSparse<Recycler>* newIntSet = RecyclerNew(GetRecycler(), BVSparse<Recycler>, GetRecycler());
+        BVSparse<Recycler>* newIntSet = RecyclerNew(this->GetRecycler(), BVSparse<Recycler>, this->GetRecycler());
         newIntSet->Set(intVal);
 
-        this->list.Append(taggedInt, GetScriptContext()->GetRecycler());
+        this->list.Append(taggedInt, this->GetRecycler());
 
         this->u.intSet = newIntSet;
         this->kind = SetKind::IntSet;
@@ -352,8 +345,8 @@ JavascriptSet::AddToEmptySet(Var value)
     Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
     if (simpleVar)
     {
-        SimpleVarDataSet* newSimpleSet = RecyclerNew(GetRecycler(), SimpleVarDataSet, GetRecycler());
-        SetDataNode* node = this->list.Append(simpleVar, GetScriptContext()->GetRecycler());
+        SimpleVarDataSet* newSimpleSet = RecyclerNew(this->GetRecycler(), SimpleVarDataSet, this->GetRecycler());
+        SetDataNode* node = this->list.Append(simpleVar, this->GetRecycler());
 
         newSimpleSet->Add(simpleVar, node);
 
@@ -362,8 +355,8 @@ JavascriptSet::AddToEmptySet(Var value)
         return;
     }
 
-    ComplexVarDataSet* newComplexSet = RecyclerNew(GetRecycler(), ComplexVarDataSet, GetRecycler());
-    SetDataNode* node = this->list.Append(value, GetScriptContext()->GetRecycler());
+    ComplexVarDataSet* newComplexSet = RecyclerNew(this->GetRecycler(), ComplexVarDataSet, this->GetRecycler());
+    SetDataNode* node = this->list.Append(value, this->GetRecycler());
 
     newComplexSet->Add(value, node);
 
@@ -383,7 +376,7 @@ JavascriptSet::TryAddToIntSet(Var value)
     int32 intVal = TaggedInt::ToInt32(taggedInt);
     if (!this->u.intSet->TestAndSet(intVal))
     {
-        this->list.Append(taggedInt, GetScriptContext()->GetRecycler());
+        this->list.Append(taggedInt, this->GetRecycler());
     }
     return true;
 }
@@ -399,7 +392,7 @@ JavascriptSet::TryAddToSimpleVarSet(Var value)
 
     if (!this->u.simpleVarSet->ContainsKey(simpleVar))
     {
-        SetDataNode* node = this->list.Append(simpleVar, GetScriptContext()->GetRecycler());
+        SetDataNode* node = this->list.Append(simpleVar, this->GetRecycler());
         this->u.simpleVarSet->Add(simpleVar, node);
     }
 
@@ -411,7 +404,7 @@ JavascriptSet::AddToComplexVarSet(Var value)
 {
     if (!this->u.complexVarSet->ContainsKey(value))
     {
-        SetDataNode* node = this->list.Append(value, GetScriptContext()->GetRecycler());
+        SetDataNode* node = this->list.Append(value, this->GetRecycler());
         this->u.complexVarSet->Add(value, node);
     }
 }
@@ -419,6 +412,7 @@ JavascriptSet::AddToComplexVarSet(Var value)
 void
 JavascriptSet::Add(Var value)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case SetKind::EmptySet:
@@ -468,8 +462,7 @@ JavascriptSet::Add(Var value)
 
 void JavascriptSet::Clear()
 {
-    // TODO: (Consider) Should we clear the set here and leave it as large as it has grown, or
-    // toss it away and create a new empty set, letting it grow as needed?
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     this->list.Clear();
     switch (this->kind)
     {
@@ -531,6 +524,7 @@ JavascriptSet::DeleteFromSimpleVarSet(Var value)
 
 bool JavascriptSet::Delete(Var value)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case SetKind::EmptySet:
@@ -558,6 +552,7 @@ bool JavascriptSet::Delete(Var value)
 
 bool JavascriptSet::Has(Var value)
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case SetKind::EmptySet:
@@ -603,6 +598,7 @@ bool JavascriptSet::Has(Var value)
 
 int JavascriptSet::Size()
 {
+    JS_REENTRANCY_LOCK(jsReentLock, this->GetScriptContext()->GetThreadContext());
     switch (this->kind)
     {
     case SetKind::EmptySet:

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -328,7 +328,7 @@ JavascriptSet::AddToEmptySet(Var value)
 {
     Assert(this->kind == SetKind::EmptySet);
     // We cannot store an int with value -1 inside of a bit vector
-    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false /* allowNegOne */, false /* allowLossyConversion */>(value);
     if (taggedInt)
     {
         int32 intVal = TaggedInt::ToInt32(taggedInt);
@@ -343,7 +343,7 @@ JavascriptSet::AddToEmptySet(Var value)
         return;
     }
 
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<false /* allowLossyConversion */>(value);
     if (simpleVar)
     {
         SimpleVarDataSet* newSimpleSet = RecyclerNew(this->GetRecycler(), SimpleVarDataSet, this->GetRecycler());
@@ -369,7 +369,7 @@ bool
 JavascriptSet::TryAddToIntSet(Var value)
 {
     Assert(this->kind == SetKind::IntSet);
-    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false /* allowNegOne */, false /* allowLossyConversion */>(value);
     if (!taggedInt)
     {
         return false;
@@ -387,7 +387,7 @@ bool
 JavascriptSet::TryAddToSimpleVarSet(Var value)
 {
     Assert(this->kind == SetKind::SimpleVarSet);
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<false /* allowLossyConversion */>(value);
     if (!simpleVar)
     {
         return false;
@@ -432,7 +432,7 @@ JavascriptSet::Add(Var value)
             return;
         }
 
-        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<false /* allowLossyConversion */>(value);
         if (simpleVar)
         {
             this->PromoteToSimpleVarSet();
@@ -490,7 +490,7 @@ bool
 JavascriptSet::IsInIntSet(Var value)
 {
     Assert(this->kind == SetKind::IntSet);
-    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+    Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false /* allowNegOne */, true /* allowLossyConversion */>(value);
     if (!taggedInt)
     {
         return false;
@@ -520,7 +520,7 @@ bool
 JavascriptSet::DeleteFromSimpleVarSet(Var value)
 {
     Assert(this->kind == SetKind::SimpleVarSet);
-    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+    Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<true /* allowLossyConversion */>(value);
     if (!simpleVar)
     {
         return false;
@@ -553,7 +553,7 @@ bool JavascriptSet::Delete(Var value)
         return this->DeleteFromSimpleVarSet(value);
 
     case SetKind::ComplexVarSet:
-        return this->DeleteFromVarSet<true>(value);
+        return this->DeleteFromVarSet<true /* isComplex */>(value);
 
     default:
         Assume(UNREACHED);
@@ -571,7 +571,7 @@ bool JavascriptSet::Has(Var value)
 
     case SetKind::IntSet:
     {
-        Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false>(value);
+        Var taggedInt = JavascriptConversion::TryCanonicalizeAsTaggedInt<false /* allowNegOne */, true /* allowLossyConversion */ >(value);
         if (!taggedInt)
         {
             return false;
@@ -588,7 +588,7 @@ bool JavascriptSet::Has(Var value)
             return true;
         }
         // If the value isn't in the set, check if the canonical value is
-        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar(value);
+        Var simpleVar = JavascriptConversion::TryCanonicalizeAsSimpleVar<true /* allowLossyConversion */>(value);
         // If the simple value is the same as the original value, we know it isn't in the set
         if (!simpleVar || simpleVar == value)
         {

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -503,7 +503,7 @@ template <bool isComplex>
 bool
 JavascriptSet::DeleteFromVarSet(Var value)
 {
-    Assert(this->kind == isComplex ? SetKind::ComplexVarSet : SetKind::SimpleVarSet);
+    Assert(this->kind == (isComplex ? SetKind::ComplexVarSet : SetKind::SimpleVarSet));
     SetDataNode * node = nullptr;
     if (isComplex
         ? !this->u.complexVarSet->TryGetValueAndRemove(value, &node)

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -39,11 +39,12 @@ namespace Js
         };
 
         Field(SetDataList) list;
-        union
+        union SetUnion
         {
             Field(SimpleVarDataSet*) simpleVarSet;
             Field(ComplexVarDataSet*) complexVarSet;
             Field(BVSparse<Recycler>*) intSet;
+            SetUnion() {}
         } u;
 
         Field(SetKind) kind = SetKind::EmptySet;

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -29,7 +29,7 @@ namespace Js
             // Deleting any element will also cause the set to be promoted to a SimpleVarSet
             IntSet,
             // A SimpleVarSet is a set containing only Vars which are comparable by pointer, and don't require
-            // pointer comparison
+            // value comparison
             //
             // Addition of a Var that is not comparable by pointer value causes the set to be promoted to a ComplexVarSet
             SimpleVarSet,

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -11,15 +11,61 @@ namespace Js
     public:
         typedef MapOrSetDataNode<Var> SetDataNode;
         typedef MapOrSetDataList<Var> SetDataList;
-        typedef JsUtil::BaseDictionary<Var, SetDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> SetDataSet;
+        typedef JsUtil::BaseDictionary<Var, SetDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> ComplexVarDataSet;
+        typedef JsUtil::BaseDictionary<Var, SetDataNode*, Recycler> SimpleVarDataSet;
 
     private:
+        enum class SetKind : uint8
+        {
+            // An EmptySet is a set containing no elements
+            EmptySet,
+            // An IntSet is a set containing only int elements
+            //
+            // Adding any TaggedInt or JavascriptNumber that can be represented as a TaggedInt
+            // will succeed and be stored as an int32 in the set, EXCEPT for the value -1
+            // Adding any other value will cause the set to be promoted to a SimpleVarSet or ComplexVarSet,
+            // depending on the value being added
+            //
+            // Deleting any element will also cause the set to be promoted to a SimpleVarSet
+            IntSet,
+            // A SimpleVarSet is a set containing only Vars which are comparable by pointer, and don't require
+            // pointer comparison
+            //
+            // Addition of a Var that is not comparable by pointer value causes the set to be promoted to a ComplexVarSet
+            SimpleVarSet,
+            // A ComplexVarSet is a set containing Vars for which we must inspect the values to do a comparison
+            // This includes Strings, Symbols, and (sometimes) JavascriptNumbers
+            ComplexVarSet
+        };
+
         Field(SetDataList) list;
-        Field(SetDataSet*) set;
+        union
+        {
+            Field(SimpleVarDataSet*) simpleVarSet;
+            Field(ComplexVarDataSet*) complexVarSet;
+            Field(BVSparse<Recycler>*) intSet;
+        } u;
+
+        Field(SetKind) kind = SetKind::EmptySet;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptSet, DynamicObject, list);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptSet);
 
+        template <typename T>
+        T* CreateVarSetFromList(uint initialCapacity);
+        void PromoteToSimpleVarSet();
+        void PromoteToComplexVarSet();
+
+        void AddToEmptySet(Var value);
+        bool TryAddToIntSet(Var value);
+        bool TryAddToSimpleVarSet(Var value);
+        void AddToComplexVarSet(Var value);
+
+        bool IsInIntSet(Var value);
+
+        template <bool isComplex>
+        bool DeleteFromVarSet(Var value);
+        bool DeleteFromSimpleVarSet(Var value);
     public:
         JavascriptSet(DynamicType* type);
 
@@ -30,7 +76,9 @@ namespace Js
         static JavascriptSet* UnsafeFromVar(Var aValue);
 
         void Add(Var value);
+
         void Clear();
+
         bool Delete(Var value);
         bool Has(Var value);
         int Size();

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -45,7 +45,9 @@ namespace Js
             Field(ComplexVarDataSet*) complexVarSet;
             Field(BVSparse<Recycler>*) intSet;
             SetUnion() {}
-        } u;
+        };
+
+        Field(SetUnion) u;
 
         Field(SetKind) kind = SetKind::EmptySet;
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3041,7 +3041,7 @@ case_2:
         return result;
     }
 
-    bool JavascriptString::Equals(Var aLeft, Var aRight)
+    bool JavascriptString::Equals(JavascriptString* aLeft, JavascriptString* aRight)
     {
         return JavascriptStringHelpers<JavascriptString>::Equals(aLeft, aRight);
     }
@@ -3906,33 +3906,28 @@ case_2:
 
     /* static */
     template <typename T>
-    bool JavascriptStringHelpers<T>::Equals(Var aLeft, Var aRight)
+    bool JavascriptStringHelpers<T>::Equals(T* aLeft, T* aRight)
     {
-        AssertMsg(T::Is(aLeft) && T::Is(aRight), "string comparison");
-
         if (aLeft == aRight) return true;
 
-        T *leftString = T::UnsafeFromVar(aLeft);
-        T *rightString = T::UnsafeFromVar(aRight);
-
         // methods could get called a lot of times this can show up as regressions in benchmarks.
-        volatile T** keepAliveLeftString = (volatile T**)& leftString;
-        volatile T** keepAliveRightString = (volatile T**)& rightString;
+        volatile T** keepAliveLeftString = (volatile T**)& aLeft;
+        volatile T** keepAliveRightString = (volatile T**)& aRight;
         auto keepAliveLambda = [&]() {
             UNREFERENCED_PARAMETER(keepAliveLeftString);
             UNREFERENCED_PARAMETER(keepAliveRightString);
         };
 
-        if (leftString->GetLength() != rightString->GetLength())
+        if (aLeft->GetLength() != aRight->GetLength())
         {
             return false;
         }
 
-        return JsUtil::CharacterBuffer<char16>::StaticEquals(leftString->GetString(), rightString->GetString(), leftString->GetLength());
+        return JsUtil::CharacterBuffer<char16>::StaticEquals(aLeft->GetString(), aRight->GetString(), aLeft->GetLength());
     }
 
 #if ENABLE_NATIVE_CODEGEN
-    template bool JavascriptStringHelpers<JITJavascriptString>::Equals(Var aLeft, Var aRight);
+    template bool JavascriptStringHelpers<JITJavascriptString>::Equals(JITJavascriptString* aLeft, JITJavascriptString* aRight);
 #endif
 
 }

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -127,7 +127,7 @@ namespace Js
         static bool Is(Var aValue);
         static JavascriptString* FromVar(Var aValue);
         static JavascriptString* UnsafeFromVar(Var aValue);
-        static bool Equals(Var aLeft, Var aRight);
+        static bool Equals(JavascriptString* aLeft, JavascriptString* aRight);
         static bool LessThan(Var aLeft, Var aRight);
         static bool IsNegZero(JavascriptString *string);
 
@@ -396,7 +396,7 @@ namespace Js
     class JavascriptStringHelpers
     {
     public:
-        static bool Equals(Var aLeft, Var aRight);
+        static bool Equals(T* aLeft, T* aRight);
     };
 }
 

--- a/lib/Runtime/Library/MapOrSetDataList.h
+++ b/lib/Runtime/Library/MapOrSetDataList.h
@@ -124,6 +124,11 @@ namespace Js
             {
                 return current->data;
             }
+
+            Field(MapOrSetDataNode<TData>*) CurrentNode() const
+            {
+                return current;
+            }
         };
 
         void Clear()
@@ -188,5 +193,13 @@ namespace Js
         {
             return Iterator(this);
         }
+    };
+
+
+    template <typename TData>
+    class DelayedDeleteMapOrSetDataList : MapOrSetDataList<TData>
+    {
+        Field(SList<TData>*) deletedList;
+
     };
 }

--- a/lib/Runtime/Library/SameValueComparer.h
+++ b/lib/Runtime/Library/SameValueComparer.h
@@ -85,9 +85,15 @@ namespace Js
 
             case TypeIds_String:
                 {
-                    JavascriptString* v = JavascriptString::FromVar(i);
+                    JavascriptString* v = JavascriptString::UnsafeFromVar(i);
                     return JsUtil::CharacterBuffer<WCHAR>::StaticGetHashCode(v->GetString(), v->GetLength());
                 }
+
+            case TypeIds_Symbol:
+            {
+                JavascriptSymbol* sym = JavascriptSymbol::UnsafeFromVar(i);
+                return sym->GetValue()->GetHashCode();
+            }
 
             default:
                 return RecyclerPointerComparer<Var>::GetHashCode(i);

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -669,7 +669,8 @@ namespace Js
             case TypeIds_Symbol:
                 goto ReturnFalse;
             case TypeIds_String:
-                goto CompareStrings;
+                *value = JavascriptString::Equals(JavascriptString::UnsafeFromVar(aLeft), JavascriptString::UnsafeFromVar(aRight));
+                return TRUE;
             case TypeIds_Number:
             case TypeIds_Integer:
             case TypeIds_Boolean:
@@ -756,9 +757,6 @@ namespace Js
         rightType = JavascriptOperators::GetTypeId(aRight);
         redoCount++;
         goto Redo;
-    CompareStrings:
-        *value = JavascriptString::Equals(aLeft, aRight);
-        return TRUE;
     CompareDoubles:
         *value = dblLeft == dblRight;
         return TRUE;


### PR DESCRIPTION
This change separates sets into three different types: Int, Simple, and Complex.

Int sets are sets which contain only int values. They are represented with a bit vector.
Simple sets contain values that are comparable by pointer alone, and use a normal dictionary.
Complex sets are sets that need full value comparison, and use a dictionary with a custom comparator.

I also added two kinds of maps, Simple and Complex, which function the same as simple and complex sets.

Improves perf of ARES-6 by 6% and VueJS by about 4%.