### PR TITLE
Optimize In operator (OpCode::IsIn) for int indices in arrays

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -686,7 +686,7 @@ private:
     IR::Instr*              CreateBoundsCheckInstr(IR::Opnd* lowerBound, IR::Opnd* upperBound, int offset, Func* func);
     IR::Instr*              CreateBoundsCheckInstr(IR::Opnd* lowerBound, IR::Opnd* upperBound, int offset, IR::BailOutKind bailoutkind, BailOutInfo* bailoutInfo, Func* func);
     IR::Instr*              AttachBoundsCheckData(IR::Instr* instr, IR::Opnd* lowerBound, IR::Opnd* upperBound, int offset);
-    void                    OptArraySrc(IR::Instr * *const instrRef);
+    void                    OptArraySrc(IR::Instr **const instrRef, Value ** src1Val, Value ** src2Val);
 
 private:
     void                    TrackIntSpecializedAddSubConstant(IR::Instr *const instr, const AddSubConstantInfo *const addSubConstantInfo, Value *const dstValue, const bool updateSourceBounds);
@@ -742,6 +742,7 @@ private:
     IR::Instr *             ToFloat64(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Value *val, IR::IndirOpnd *indir, IR::BailOutKind bailOutKind);
     IR::Instr *             ToTypeSpecUse(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Value *val, IR::IndirOpnd *indir,
         IRType toType, IR::BailOutKind bailOutKind, bool lossy = false, IR::Instr *insertBeforeInstr = nullptr);
+    IR::Instr *             ToTypeSpecIndex(IR::Instr * instr, IR::RegOpnd * opnd, IR::IndirOpnd * indir);
     void                    ToVarRegOpnd(IR::RegOpnd *dst, BasicBlock *block);
     void                    ToVarStackSym(StackSym *varSym, BasicBlock *block);
     void                    ToInt32Dst(IR::Instr *instr, IR::RegOpnd *dst, BasicBlock *block);

--- a/lib/Backend/GlobOptArrays.cpp
+++ b/lib/Backend/GlobOptArrays.cpp
@@ -316,7 +316,7 @@ void GlobOpt::ArraySrcOpt::CheckVirtualArrayBounds()
 #endif
 }
 
-void GlobOpt::ArraySrcOpt::TryEleminiteBoundsCheck()
+void GlobOpt::ArraySrcOpt::TryEliminiteBoundsCheck()
 {
     AnalysisAssert(indexOpnd != nullptr || baseOwnerIndir != nullptr);
     Assert(needsHeadSegmentLength);
@@ -1822,7 +1822,7 @@ void GlobOpt::ArraySrcOpt::Optimize()
 
     if (needsBoundChecks && globOpt->DoBoundCheckElimination())
     {
-        TryEleminiteBoundsCheck();
+        TryEliminiteBoundsCheck();
     }
 
     if (doArrayChecks || doHeadSegmentLoad || doHeadSegmentLengthLoad || doLengthLoad || doExtractBoundChecks)
@@ -1898,7 +1898,7 @@ void GlobOpt::ArraySrcOpt::Optimize()
             else
             {
                 Assert(baseOwnerInstr->GetSrc2() == baseOpnd);
-                baseOwnerInstr->ReplaceSrc1(baseArrayOpnd);
+                baseOwnerInstr->ReplaceSrc2(baseArrayOpnd);
             }
         }
         else

--- a/lib/Backend/GlobOptArrays.cpp
+++ b/lib/Backend/GlobOptArrays.cpp
@@ -37,6 +37,15 @@
 
 #endif
 
+GlobOpt::ArraySrcOpt::~ArraySrcOpt()
+{
+    if (originalIndexOpnd != nullptr)
+    {
+        Assert(instr->m_opcode == Js::OpCode::IsIn);
+        instr->ReplaceSrc1(originalIndexOpnd);
+    }
+}
+
 
 bool GlobOpt::ArraySrcOpt::CheckOpCode()
 {
@@ -136,11 +145,72 @@ bool GlobOpt::ArraySrcOpt::CheckOpCode()
             needsLength = true;
             break;
 
+        case Js::OpCode::IsIn:
+            if (!instr->GetSrc1()->IsRegOpnd() || !instr->GetSrc2()->IsRegOpnd())
+            {
+                return false;
+            }
+
+            baseOpnd = instr->GetSrc2()->AsRegOpnd();
+            if (baseOpnd->GetValueType().IsLikelyObject() && baseOpnd->GetValueType().GetObjectType() == ObjectType::ObjectWithArray)
+            {
+                return false;
+            }
+
+            baseOwnerInstr = instr;
+
+            needsBoundChecks = true;
+            needsHeadSegmentLength = true;
+            needsHeadSegment = true;
+            break;
+
         default:
             return false;
     }
 
     return true;
+}
+
+void GlobOpt::ArraySrcOpt::TypeSpecIndex()
+{
+    // Since this happens before type specialization, make sure that any necessary conversions are done, and that the index is int-specialized if possible such that the const flags are correct.
+    if (!globOpt->IsLoopPrePass())
+    {
+        if (baseOwnerIndir)
+        {
+            globOpt->ToVarUses(instr, baseOwnerIndir, baseOwnerIndir == instr->GetDst(), nullptr);
+        }
+        else if (instr->m_opcode == Js::OpCode::IsIn)
+        {
+            // If the optimization is unable to eliminate the bounds checks, we need to restore the original var sym.
+            originalIndexOpnd = instr->GetSrc1()->Copy(func)->AsRegOpnd();
+            globOpt->ToTypeSpecIndex(instr, instr->GetSrc1()->AsRegOpnd(), nullptr);
+        }
+    }
+
+    if (baseOwnerIndir != nullptr)
+    {
+        indexOpnd = baseOwnerIndir->GetIndexOpnd();
+    }
+    else if (instr->m_opcode == Js::OpCode::IsIn)
+    {
+        indexOpnd = instr->GetSrc1()->AsRegOpnd();
+    }
+
+    if (indexOpnd != nullptr)
+    {
+        if (indexOpnd->m_sym->IsTypeSpec())
+        {
+            Assert(indexOpnd->m_sym->IsInt32());
+            indexVarSym = indexOpnd->m_sym->GetVarEquivSym(nullptr);
+        }
+        else
+        {
+            indexVarSym = indexOpnd->m_sym;
+        }
+
+        indexValue = globOpt->CurrentBlockData()->FindValue(indexVarSym);
+    }
 }
 
 void GlobOpt::ArraySrcOpt::UpdateValue(StackSym * newHeadSegmentSym, StackSym * newHeadSegmentLengthSym, StackSym * newLengthSym)
@@ -210,13 +280,10 @@ void GlobOpt::ArraySrcOpt::CheckVirtualArrayBounds()
             // checks in jitted code.
             if (!globOpt->GetIsAsmJSFunc() && baseOwnerIndir)
             {
-                IR::RegOpnd * idxOpnd = baseOwnerIndir->GetIndexOpnd();
-                if (idxOpnd)
+                if (indexOpnd)
                 {
-                    StackSym * idxSym = idxOpnd->m_sym->IsTypeSpec() ? idxOpnd->m_sym->GetVarEquivSym(nullptr) : idxOpnd->m_sym;
-                    Value * idxValue = globOpt->CurrentBlockData()->FindValue(idxSym);
                     IntConstantBounds idxConstantBounds;
-                    if (idxValue && idxValue->GetValueInfo()->TryGetIntConstantBounds(&idxConstantBounds))
+                    if (indexValue && indexValue->GetValueInfo()->TryGetIntConstantBounds(&idxConstantBounds))
                     {
                         BYTE indirScale = Lowerer::GetArrayIndirScale(baseValueType);
                         int32 upperBound = idxConstantBounds.UpperBound();
@@ -232,7 +299,7 @@ void GlobOpt::ArraySrcOpt::CheckVirtualArrayBounds()
             }
             else
             {
-                if (!baseOwnerIndir)
+                if (baseOwnerIndir == nullptr)
                 {
                     Assert(instr->m_opcode == Js::OpCode::InlineArrayPush ||
                         instr->m_opcode == Js::OpCode::InlineArrayPop ||
@@ -250,7 +317,7 @@ void GlobOpt::ArraySrcOpt::CheckVirtualArrayBounds()
 
 void GlobOpt::ArraySrcOpt::TryEleminiteBoundsCheck()
 {
-    AnalysisAssert(baseOwnerIndir);
+    AnalysisAssert(indexOpnd != nullptr || baseOwnerIndir != nullptr);
     Assert(needsHeadSegmentLength);
 
     // Bound checks can be separated from the instruction only if it can bail out instead of making a helper call when a
@@ -259,16 +326,11 @@ void GlobOpt::ArraySrcOpt::TryEleminiteBoundsCheck()
     doExtractBoundChecks = (headSegmentLengthIsAvailable || doHeadSegmentLengthLoad) && canBailOutOnArrayAccessHelperCall;
 
     // Get the index value
-    IR::RegOpnd * const indexOpnd = baseOwnerIndir->GetIndexOpnd();
     if (indexOpnd != nullptr)
     {
-        StackSym * const indexSym = indexOpnd->m_sym;
-        if (indexSym->IsTypeSpec())
+        if (indexOpnd->m_sym->IsTypeSpec())
         {
-            Assert(indexSym->IsInt32());
-            indexVarSym = indexSym->GetVarEquivSym(nullptr);
             Assert(indexVarSym);
-            indexValue = globOpt->CurrentBlockData()->FindValue(indexVarSym);
             Assert(indexValue);
             AssertVerify(indexValue->GetValueInfo()->TryGetIntConstantBounds(&indexConstantBounds));
             Assert(indexOpnd->GetType() == TyInt32 || indexOpnd->GetType() == TyUint32);
@@ -290,7 +352,6 @@ void GlobOpt::ArraySrcOpt::TryEleminiteBoundsCheck()
         else
         {
             doExtractBoundChecks = false; // Bound check instruction operates only on int-specialized operands
-            indexValue = globOpt->CurrentBlockData()->FindValue(indexSym);
             if (!indexValue || !indexValue->GetValueInfo()->TryGetIntConstantBounds(&indexConstantBounds))
             {
                 return;
@@ -569,11 +630,11 @@ void GlobOpt::ArraySrcOpt::DoLengthLoad()
 
         // Hoist the length value
         for (InvariantBlockBackwardIterator it(
-            globOpt,
-            globOpt->currentBlock,
-            hoistLengthLoadOutOfLoop->landingPad,
-            baseOpnd->m_sym,
-            baseValue->GetValueNumber());
+                globOpt,
+                globOpt->currentBlock,
+                hoistLengthLoadOutOfLoop->landingPad,
+                baseOpnd->m_sym,
+                baseValue->GetValueNumber());
             it.IsValid();
             it.MoveNext())
         {
@@ -664,11 +725,11 @@ void GlobOpt::ArraySrcOpt::DoHeadSegmentLengthLoad()
 
         // Hoist the head segment length value
         for (InvariantBlockBackwardIterator it(
-            globOpt,
-            globOpt->currentBlock,
-            hoistHeadSegmentLengthLoadOutOfLoop->landingPad,
-            baseOpnd->m_sym,
-            baseValue->GetValueNumber());
+                globOpt,
+                globOpt->currentBlock,
+                hoistHeadSegmentLengthLoadOutOfLoop->landingPad,
+                baseOpnd->m_sym,
+                baseValue->GetValueNumber());
             it.IsValid();
             it.MoveNext())
         {
@@ -691,8 +752,8 @@ void GlobOpt::ArraySrcOpt::DoHeadSegmentLengthLoad()
 void GlobOpt::ArraySrcOpt::DoExtractBoundChecks()
 {
     Assert(!(eliminatedLowerBoundCheck && eliminatedUpperBoundCheck));
-    Assert(baseOwnerIndir);
-    Assert(!baseOwnerIndir->GetIndexOpnd() || baseOwnerIndir->GetIndexOpnd()->m_sym->IsTypeSpec());
+    Assert(baseOwnerIndir != nullptr || indexOpnd != nullptr);
+    Assert(indexOpnd == nullptr || indexOpnd->m_sym->IsTypeSpec());
     Assert(doHeadSegmentLengthLoad || headSegmentLengthIsAvailable);
     Assert(canBailOutOnArrayAccessHelperCall);
     Assert(!isStore || instr->m_opcode == Js::OpCode::StElemI_A || instr->m_opcode == Js::OpCode::StElemI_A_Strict || Js::IsSimd128LoadStore(instr->m_opcode));
@@ -753,7 +814,7 @@ void GlobOpt::ArraySrcOpt::DoLowerBoundCheck()
     eliminatedLowerBoundCheck = true;
 
     Assert(indexVarSym);
-    Assert(baseOwnerIndir->GetIndexOpnd());
+    Assert(indexOpnd);
     Assert(indexValue);
 
     GlobOpt::ArrayLowerBoundCheckHoistInfo &hoistInfo = lowerBoundCheckHoistInfo;
@@ -904,11 +965,11 @@ void GlobOpt::ArraySrcOpt::DoLowerBoundCheck()
         if (hoistBlock != globOpt->currentBlock && hoistInfo.IndexSym() && hoistInfo.Offset() != INT32_MIN)
         {
             for (InvariantBlockBackwardIterator it(
-                globOpt,
-                globOpt->currentBlock->next,
-                hoistBlock,
-                hoistInfo.IndexSym(),
-                hoistInfo.IndexValueNumber());
+                    globOpt,
+                    globOpt->currentBlock->next,
+                    hoistBlock,
+                    hoistInfo.IndexSym(),
+                    hoistInfo.IndexValueNumber());
                 it.IsValid();
                 it.MoveNext())
             {
@@ -938,7 +999,7 @@ void GlobOpt::ArraySrcOpt::DoLowerBoundCheck()
     else
     {
         IR::Opnd* lowerBound = IR::IntConstOpnd::New(0, TyInt32, instr->m_func, true);
-        IR::Opnd* upperBound = baseOwnerIndir->GetIndexOpnd();
+        IR::Opnd* upperBound = indexOpnd;
         upperBound->SetIsJITOptimizedReg(true);
         const int offset = 0;
 
@@ -1262,8 +1323,8 @@ void GlobOpt::ArraySrcOpt::DoUpperBoundCheck()
     }
     else
     {
-        IR::Opnd* lowerBound = baseOwnerIndir->GetIndexOpnd()
-            ? static_cast<IR::Opnd *>(baseOwnerIndir->GetIndexOpnd())
+        IR::Opnd* lowerBound = indexOpnd
+            ? static_cast<IR::Opnd *>(indexOpnd)
             : IR::IntConstOpnd::New(baseOwnerIndir->GetOffset(), TyInt32, instr->m_func);
 
         lowerBound->SetIsJITOptimizedReg(true);
@@ -1304,7 +1365,7 @@ void GlobOpt::ArraySrcOpt::DoUpperBoundCheck()
 
         instr->extractedUpperBoundCheckWithoutHoisting = true;
 
-        if (baseOwnerIndir->GetIndexOpnd())
+        if (indexOpnd != nullptr)
         {
             TRACE_PHASE_INSTR(
                 Js::Phase::BoundCheckEliminationPhase,
@@ -1408,11 +1469,11 @@ void GlobOpt::ArraySrcOpt::UpdateHoistedValueInfo()
     }
 
     for (InvariantBlockBackwardIterator it(
-        globOpt,
-        globOpt->currentBlock,
-        rootLoop->landingPad,
-        baseOpnd->m_sym,
-        baseValue->GetValueNumber());
+            globOpt,
+            globOpt->currentBlock,
+            rootLoop->landingPad,
+            baseOpnd->m_sym,
+            baseValue->GetValueNumber());
         it.IsValid();
         it.MoveNext())
     {
@@ -1600,12 +1661,7 @@ void GlobOpt::ArraySrcOpt::Optimize()
     Assert(!(baseOwnerInstr && baseOwnerIndir));
     Assert(!needsHeadSegmentLength || needsHeadSegment);
 
-    if (baseOwnerIndir && !globOpt->IsLoopPrePass())
-    {
-        // Since this happens before type specialization, make sure that any necessary conversions are done, and that the index
-        // is int-specialized if possible such that the const flags are correct.
-        globOpt->ToVarUses(instr, baseOwnerIndir, baseOwnerIndir == instr->GetDst(), nullptr);
-    }
+    TypeSpecIndex();
 
     if (isProfilableStElem && !globOpt->IsLoopPrePass())
     {
@@ -1740,7 +1796,7 @@ void GlobOpt::ArraySrcOpt::Optimize()
     newHeadSegmentLengthSym = doHeadSegmentLengthLoad ? StackSym::New(TyUint32, instr->m_func) : nullptr;
     newLengthSym = doLengthLoad ? StackSym::New(TyUint32, instr->m_func) : nullptr;
 
-    if (Js::IsSimd128LoadStore(instr->m_opcode))
+    if (Js::IsSimd128LoadStore(instr->m_opcode) || instr->m_opcode == Js::OpCode::IsIn)
     {
         // SIMD_JS
         // simd load/store never call helper
@@ -1818,8 +1874,8 @@ void GlobOpt::ArraySrcOpt::Optimize()
         }
     }
 
-    IR::ArrayRegOpnd *baseArrayOpnd;
-    if (baseArrayValueInfo)
+    IR::ArrayRegOpnd * baseArrayOpnd;
+    if (baseArrayValueInfo != nullptr)
     {
         // Update the opnd to include the associated syms
         baseArrayOpnd =
@@ -1832,10 +1888,17 @@ void GlobOpt::ArraySrcOpt::Optimize()
                 eliminatedUpperBoundCheck,
                 instr->m_func);
 
-        if (baseOwnerInstr)
+        if (baseOwnerInstr != nullptr)
         {
-            Assert(baseOwnerInstr->GetSrc1() == baseOpnd);
-            baseOwnerInstr->ReplaceSrc1(baseArrayOpnd);
+            if (baseOwnerInstr->GetSrc1() == baseOpnd)
+            {
+                baseOwnerInstr->ReplaceSrc1(baseArrayOpnd);
+            }
+            else
+            {
+                Assert(baseOwnerInstr->GetSrc2() == baseOpnd);
+                baseOwnerInstr->ReplaceSrc1(baseArrayOpnd);
+            }
         }
         else
         {
@@ -1910,6 +1973,26 @@ void GlobOpt::ArraySrcOpt::Optimize()
         {
             OnEliminated(Js::Phase::BoundCheckEliminationPhase, "upper bound check");
         }
+    }
+
+    if (instr->m_opcode == Js::OpCode::IsIn)
+    {
+        if (eliminatedLowerBoundCheck && eliminatedUpperBoundCheck)
+        {
+            instr->m_opcode = Js::OpCode::Ld_A;
+
+            IR::AddrOpnd * addrOpnd = IR::AddrOpnd::New(func->GetScriptContextInfo()->GetTrueAddr(), IR::AddrOpndKindDynamicVar, func, true);
+            addrOpnd->SetValueType(ValueType::Boolean);
+            instr->ReplaceSrc1(addrOpnd);
+            instr->FreeSrc2();
+            originalIndexOpnd->Free(func);
+            originalIndexOpnd = nullptr;
+
+            src1Val = globOpt->GetVarConstantValue(instr->GetSrc1()->AsAddrOpnd());
+            src2Val = nullptr;
+        }
+
+        return;
     }
 
     if (!canBailOutOnArrayAccessHelperCall)

--- a/lib/Backend/GlobOptArrays.cpp
+++ b/lib/Backend/GlobOptArrays.cpp
@@ -183,6 +183,7 @@ void GlobOpt::ArraySrcOpt::TypeSpecIndex()
         else if (instr->m_opcode == Js::OpCode::IsIn)
         {
             // If the optimization is unable to eliminate the bounds checks, we need to restore the original var sym.
+            Assert(originalIndexOpnd == nullptr);
             originalIndexOpnd = instr->GetSrc1()->Copy(func)->AsRegOpnd();
             globOpt->ToTypeSpecIndex(instr, instr->GetSrc1()->AsRegOpnd(), nullptr);
         }
@@ -1979,6 +1980,8 @@ void GlobOpt::ArraySrcOpt::Optimize()
     {
         if (eliminatedLowerBoundCheck && eliminatedUpperBoundCheck)
         {
+            TRACE_TESTTRACE_PHASE_INSTR(Js::Phase::BoundCheckEliminationPhase, instr, _u("Eliminating IsIn\n"));
+
             instr->m_opcode = Js::OpCode::Ld_A;
 
             IR::AddrOpnd * addrOpnd = IR::AddrOpnd::New(func->GetScriptContextInfo()->GetTrueAddr(), IR::AddrOpndKindDynamicVar, func, true);

--- a/lib/Backend/GlobOptArrays.h
+++ b/lib/Backend/GlobOptArrays.h
@@ -27,7 +27,7 @@ private:
     void TypeSpecIndex();
     void UpdateValue(StackSym * newHeadSegmentSym, StackSym * newHeadSegmentLengthSym, StackSym * newLengthSym);
     void CheckVirtualArrayBounds();
-    void TryEleminiteBoundsCheck();
+    void TryEliminiteBoundsCheck();
     void CheckLoops();
     void DoArrayChecks();
     void DoLengthLoad();

--- a/lib/Backend/GlobOptArrays.h
+++ b/lib/Backend/GlobOptArrays.h
@@ -7,19 +7,24 @@
 class GlobOpt::ArraySrcOpt
 {
 public:
-    ArraySrcOpt(GlobOpt * glob, IR::Instr ** instrRef) :
+    ArraySrcOpt(GlobOpt * glob, IR::Instr ** instrRef, Value ** _src1Val, Value ** _src2Val) :
         globOpt(glob),
         func(glob->func),
-        instr(*instrRef)
+        instr(*instrRef),
+        src1Val(*_src1Val),
+        src2Val(*_src2Val)
     {
         Assert(instr != nullptr);
     }
+
+    ~ArraySrcOpt();
 
     void Optimize();
 
 private:
     bool CheckOpCode();
 
+    void TypeSpecIndex();
     void UpdateValue(StackSym * newHeadSegmentSym, StackSym * newHeadSegmentLengthSym, StackSym * newLengthSym);
     void CheckVirtualArrayBounds();
     void TryEleminiteBoundsCheck();
@@ -40,10 +45,14 @@ private:
     Func * func;
     GlobOpt * globOpt;
     IR::Instr *& instr;
+    Value *& src1Val;
+    Value *& src2Val;
+
     IR::Instr * baseOwnerInstr = nullptr;
     IR::IndirOpnd * baseOwnerIndir = nullptr;
     IR::RegOpnd * baseOpnd = nullptr;
     IR::RegOpnd * indexOpnd = nullptr;
+    IR::RegOpnd * originalIndexOpnd = nullptr;
     bool isProfilableLdElem = false;
     bool isProfilableStElem = false;
     bool isLoad = false;

--- a/test/Optimizer/IsIn_ArrayNoMissingValues.baseline
+++ b/test/Optimizer/IsIn_ArrayNoMissingValues.baseline
@@ -1,0 +1,3 @@
+Testtrace: BoundCheckElimination function foo ( (#1.1), #2): Eliminating array lower bound check
+Testtrace: BoundCheckElimination function foo ( (#1.1), #2): Eliminating array upper bound check
+Testtrace: BoundCheckElimination function foo ( (#1.1), #2): Eliminating IsIn

--- a/test/Optimizer/IsIn_ArrayNoMissingValues.js
+++ b/test/Optimizer/IsIn_ArrayNoMissingValues.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var a = [1,2,3,4,5];
+
+function foo(ary)
+{
+    var filled = 0;
+    for (var ii = 0; ii < ary.length; ++ii)
+    {
+        if (ii in ary)
+        {
+            ++filled;
+        }
+    }
+    return filled;
+}
+
+foo(a);
+foo(a);
+foo(a);

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1471,4 +1471,12 @@
       <compile-flags>-off:aggressiveinttypespec</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>IsIn_ArrayNoMissingValues.js</files>
+      <baseline>IsIn_ArrayNoMissingValues.baseline</baseline>
+      <compile-flags>-testtrace:BoundCheckElimination</compile-flags>
+      <tags>exclude_dynapogo,exclude_serialized,exclude_nonative</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
This commit adds a globopt optimization path to turn IsIn into a LdTrue for arrays when the the index is an int, the array has no missing values, and the index can be guaranteed to be within bounds. It leverages the existing bounds check elimination code for LdElemI/StElemI. 

The motivation for this optimization is to improve efficiency for JavaScript implementations of built-in functions. 