### PR TITLE
Don't do memcmp if buffers are same

### DIFF
--- a/lib/Common/DataStructures/CharacterBuffer.h
+++ b/lib/Common/DataStructures/CharacterBuffer.h
@@ -81,13 +81,13 @@ namespace JsUtil
     inline bool
     CharacterBuffer<WCHAR>::StaticEquals(__in_z WCHAR const * s1, __in_z WCHAR const * s2, __in charcount_t length)
     {
-        return wmemcmp(s1, s2, length) == 0;
+        return (s1 == s2) || wmemcmp(s1, s2, length) == 0;
     }
 
     template<>
     inline bool
     CharacterBuffer<unsigned char>::StaticEquals(__in_z unsigned char const * s1, __in_z unsigned char const *s2, __in charcount_t length)
     {
-        return memcmp(s1, s2, length) == 0;
+        return (s1 == s2) || memcmp(s1, s2, length) == 0;
     }
 }

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3928,12 +3928,7 @@ case_2:
             return false;
         }
 
-        if (wmemcmp(leftString->GetString(), rightString->GetString(), leftString->GetLength()) == 0)
-        {
-            return true;
-        }
-
-        return false;
+        return JsUtil::CharacterBuffer<char16>::StaticEquals(leftString->GetString(), rightString->GetString(), leftString->GetLength());
     }
 
 #if ENABLE_NATIVE_CODEGEN


### PR DESCRIPTION
Happens frequently during FindPropertyRecord
