### PR TITLE
When we delete prototype property, clear HasKnownSlot0 flag

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -3081,6 +3081,10 @@ LABEL1:
         {
             InvalidateConstructorCacheOnPrototypeChange();
             this->GetScriptContext()->GetThreadContext()->InvalidateIsInstInlineCachesForFunction(this);
+            if (propertyId == PropertyIds::prototype)
+            {
+                this->GetTypeHandler()->ClearHasKnownSlot0();
+            }
         }
 
         return result;
@@ -3111,6 +3115,10 @@ LABEL1:
         {
             InvalidateConstructorCacheOnPrototypeChange();
             this->GetScriptContext()->GetThreadContext()->InvalidateIsInstInlineCachesForFunction(this);
+            if (BuiltInPropertyRecords::prototype.Equals(propertyNameString))
+            {
+                this->GetTypeHandler()->ClearHasKnownSlot0();
+            }
         }
 
         return result;

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -379,6 +379,11 @@ namespace Js
             SetFlags(HasKnownSlot0Flag);
         }
 
+        void ClearHasKnownSlot0()
+        {
+            ClearFlags(HasKnownSlot0Flag);
+        }
+
         void SetIsInlineSlotCapacityLocked()
         {
             Assert(!GetIsInlineSlotCapacityLocked());

--- a/test/Bugs/instancebug.js
+++ b/test/Bugs/instancebug.js
@@ -1,0 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+for (var pgjslh = 0; '' instanceof [].values; 0) {
+}
+print("Passed");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -451,4 +451,9 @@
       <files>inbug.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>instancebug.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Intl and JsBuiltins do the following at multiple places :

functionObj->SetConfigurable(Js::PropertyIds::prototype, true);
functionObj->DeleteProperty(Js::PropertyIds::prototype, Js::PropertyOperationFlags::PropertyOperation_None);

Currently HasKnownSlot0 doesnt get reset, and this causes an assertion when we do an instanceof on such ctor functions.

This is not an issue for user js functions because the prototype property is not configurable.

Fixes OS#16145313
