### PR TITLE
Improve JSON.stringify perf for TypedArrays

### DIFF
--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -402,6 +402,8 @@ JSONStringifier::AppendObjectElement(
             // If gap is specified, a space is appended
             UInt32Math::Inc(this->totalStringLength);
         }
+
+        jsonObject->Push(*prop);
     }
 }
 
@@ -421,8 +423,6 @@ JSONStringifier::ReadObjectElement(
     this->ReadProperty(propertyName, obj, &prop.propertyValue, value, objectStack);
 
     this->AppendObjectElement(propertyName, jsonObject, &prop);
-
-    jsonObject->Push(prop);
 }
 
 void
@@ -441,8 +441,6 @@ JSONStringifier::ReadObjectElement(
     this->ReadProperty(propertyName, obj, &prop.propertyValue, value, objectStack);
 
     this->AppendObjectElement(propertyName, jsonObject, &prop);
-
-    jsonObject->Push(prop);
 }
 
 // Calculates how many additional characters are needed for printing the Object/Array structure

--- a/lib/Runtime/Library/JSONStringifier.h
+++ b/lib/Runtime/Library/JSONStringifier.h
@@ -63,6 +63,18 @@ private:
     uint32 ReadArrayLength(_In_ RecyclableObject* value);
     JSONArray* ReadArray(_In_ RecyclableObject* arr, _In_ JSONObjectStack* objectStack);
 
+    void AppendObjectElement(
+        _In_ JavascriptString* propertyName,
+        _In_ JSONObject* jsonObject,
+        _In_ JSONObjectProperty* prop);
+
+    void ReadObjectElement(
+        _In_ JavascriptString* propertyName,
+        _In_ uint32 numericIndex,
+        _In_ RecyclableObject* obj,
+        _In_ JSONObject* jsonObject,
+        _In_ JSONObjectStack* objectStack);
+
     void ReadObjectElement(
         _In_ JavascriptString* propertyName,
         _In_opt_ PropertyRecord const* propertyRecord,
@@ -95,8 +107,7 @@ public:
         _In_ JavascriptString* key,
         _In_opt_ RecyclableObject* holder,
         _Out_ JSONProperty* prop,
-        _In_opt_ Var value,
-        _In_opt_ const PropertyRecord* propertyRecord,
+        _In_ Var value,
         _In_ JSONObjectStack* objectStack);
 
     const char16* GetGap() const { return this->gap; };

--- a/lib/Runtime/Library/JavascriptStringEnumerator.h
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.h
@@ -18,5 +18,6 @@ namespace Js
         JavascriptStringEnumerator(JavascriptString* stringObject, ScriptContext * requestContext);
         virtual void Reset() override;
         virtual JavascriptString * MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual uint32 GetCurrentItemIndex()  override { return index; }
     };
 }

--- a/lib/Runtime/Library/TypedArrayIndexEnumerator.h
+++ b/lib/Runtime/Library/TypedArrayIndexEnumerator.h
@@ -21,5 +21,6 @@ namespace Js
         TypedArrayIndexEnumerator(TypedArrayBase* typeArrayBase, EnumeratorFlags flags, ScriptContext* scriptContext);
         virtual JavascriptString * MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
+        virtual uint32 GetCurrentItemIndex()  override { return index; }
     };
 }

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
@@ -46,7 +46,6 @@ namespace Js
         bool GetSnapShotSemantics() const;
         bool GetUseCache() const;
         ScriptContext * GetScriptContext() const { return scriptContext; }
-        BigPropertyIndex GetInitialPropertyCount() const { return this->initialPropertyCount; }
 
         bool Initialize(DynamicObject * object, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache);
         bool IsNullEnumerator() const;

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.h
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.h
@@ -39,7 +39,6 @@ namespace Js
         void Reset();
         uint32 GetCurrentItemIndex();
         JavascriptString * MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
-        BigPropertyIndex GetInitialPropertyCount() const { return this->propertyEnumerator.GetInitialPropertyCount(); }
 
         static uint32 GetOffsetOfCurrentEnumerator() { return offsetof(JavascriptStaticEnumerator, currentEnumerator); }
         static uint32 GetOffsetOfPrefixEnumerator() { return offsetof(JavascriptStaticEnumerator, prefixEnumerator); }


### PR DESCRIPTION
During enumeration, we can (and should) avoid creating PropertyRecords for TypedArrays. Instead we can use the numeric index.

In the below micro-benchmark, this improves our perf by about 45%.

````
const view = new Int8Array(1 << 24);
for (let i = 0; i < view.length; ++i) {
  view[i] = i|0;
}
var start = Date.now();
const str = JSON.stringify(view);
console.log(Date.now() - start);
````

OS: 16385822