### PR TITLE
Refactoring Chakra's Telemetry code

### DIFF
--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -527,11 +527,6 @@
       <Project>{0db5ecbc-9385-4a65-be2c-4ef7c65cb719}</Project>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="CRC.h">
-      <FileType>CppCode</FileType>
-    </ClInclude>
-  </ItemGroup>
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -367,7 +367,6 @@
     <ClInclude Include="FunctionCodeGenJitTimeData.h" />
     <ClInclude Include="FixedFieldInfo.h" />
     <ClInclude Include="ObjTypeSpecFldInfo.h" />
-    <ClInclude Include="CRC.h" />
     <ClInclude Include="PageAllocatorPool.h" />
     <ClInclude Include="GlobOptBlockData.h" />
     <ClInclude Include="ValueInfo.h" />

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "Backend.h"
-#include "CRC.h"
+#include "Core/CRC.h"
 
 ///----------------------------------------------------------------------------
 ///

--- a/lib/Common/Core/CMakeLists.txt
+++ b/lib/Common/Core/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library (Chakra.Common.Core OBJECT
     CommonCorePch.cpp
     ConfigFlagsTable.cpp
     ConfigParser.cpp
+    CRC.cpp
     DbgHelpSymbolManager.cpp
     DelayLoadLibrary.cpp
     EtwTraceCore.cpp

--- a/lib/Common/Core/CRC.cpp
+++ b/lib/Common/Core/CRC.cpp
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "CommonCorePch.h"
+#include "Core/CRC.h"
+
+unsigned int CalculateCRC32(unsigned int bufferCRC, size_t data)
+{
+    /* update running CRC calculation with contents of a buffer */
+
+    bufferCRC = bufferCRC ^ 0xffffffffL;
+    bufferCRC = crc_32_tab[(bufferCRC ^ data) & 0xFF] ^ (bufferCRC >> 8);
+    return (bufferCRC ^ 0xffffffffL);
+}
+
+unsigned int CalculateCRC32(const char* in)
+{
+    unsigned int crc = (unsigned int)-1;
+    while (*in != '\0')
+    {
+        crc = (crc >> 8) ^ crc_32_tab[(crc ^ *in) & 0xFF];
+        in++;
+    }
+    return crc ^ (unsigned int)-1;
+}

--- a/lib/Common/Core/CRC.h
+++ b/lib/Common/Core/CRC.h
@@ -1,6 +1,13 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
 /*
 *   CRC32 code derived from work by Gary S. Brown.
 */
+
+#pragma once
 
 /*
 * Pre-populated Table used for calculating CRC32.
@@ -41,11 +48,6 @@ static const unsigned int crc_32_tab[] =
     0xB3667A2EL, 0xC4614AB8L, 0x5D681B02L, 0x2A6F2B94L, 0xB40BBE37L, 0xC30C8EA1L, 0x5A05DF1BL, 0x2D02EF8DL
 };
 
-static unsigned int CalculateCRC32(unsigned int bufferCRC, size_t data)
-{
-    /* update running CRC calculation with contents of a buffer */
+unsigned int CalculateCRC32(unsigned int bufferCRC, size_t data);
 
-    bufferCRC = bufferCRC ^ 0xffffffffL;
-    bufferCRC = crc_32_tab[(bufferCRC ^ data) & 0xFF] ^ (bufferCRC >> 8);
-    return (bufferCRC ^ 0xffffffffL);
-}
+unsigned int CalculateCRC32(const char* in);

--- a/lib/Common/Core/Chakra.Common.Core.vcxproj
+++ b/lib/Common/Core/Chakra.Common.Core.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)GlobalSecurityPolicy.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Output.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PerfCounter.cpp" />
+    <ClCompile Include="CRC.cpp" />
     <None Include="PerfCounterImpl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PerfCounterSet.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ProfileInstrument.cpp" />
@@ -67,6 +68,7 @@
     <ClInclude Include="CommonTypedefs.h" />
     <ClInclude Include="ConfigFlagsTable.h" />
     <ClInclude Include="ConfigParser.h" />
+    <ClInclude Include="CRC.h" />
     <ClInclude Include="CriticalSection.h" />
     <ClInclude Include="DbgHelpSymbolManager.h" />
     <ClInclude Include="DelayLoadLibrary.h" />

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4058,7 +4058,7 @@ ParseNodePtr Parser::ParseArgList( bool *pCallOfConstants, uint16 *pSpreadArgCou
     }
 
     if (pSpreadArgCount!=nullptr && (*pSpreadArgCount) > 0){
-        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(SpreadFeature, m_scriptContext);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, SpreadFeature, m_scriptContext);
     }
 
     *pCount = static_cast<uint16>(count);
@@ -4230,7 +4230,7 @@ ParseNodePtr Parser::ParseArrayList(bool *pArrayOfTaggedInts, bool *pArrayOfInts
     }
 
     if (spreadCount != nullptr && *spreadCount > 0){
-        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(SpreadFeature, m_scriptContext);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, SpreadFeature, m_scriptContext);
     }
 
     if (buildAST)
@@ -5256,7 +5256,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
     if (pnodeFnc && pnodeFnc->AsParseNodeFnc()->IsGenerator())
     {
-        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Generator, m_scriptContext);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Generator, m_scriptContext);
     }
 
     if (fncExprScope && !*pHasName)
@@ -5288,7 +5288,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
     if (fLambda)
     {
-        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Lambda, m_scriptContext);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Lambda, m_scriptContext);
     }
 
     uint uDeferSave = m_grfscr & fscrDeferFncParse;
@@ -5736,7 +5736,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
             }
 
             this->m_fUseStrictMode = oldStrictMode;
-            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(StrictModeFunction, m_scriptContext);
+            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, StrictModeFunction, m_scriptContext);
         }
 
         if (fDeferred)
@@ -6779,7 +6779,7 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
                     {
                         if (!m_currentNodeFunc->AsParseNodeFnc()->HasDefaultArguments())
                         {
-                            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(DefaultArgFunction, m_scriptContext);
+                            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, DefaultArgFunction, m_scriptContext);
                         }
                         pnodeT->AsParseNodeVar()->pnodeInit = pnodeInit;
                         pnodeT->ichLim = m_pscan->IchLimTok();
@@ -6816,7 +6816,7 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
 
         if (seenRestParameter)
         {
-            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Rest, m_scriptContext);
+            CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Rest, m_scriptContext);
         }
 
         if (m_token.tk != tkRParen)
@@ -7586,7 +7586,7 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, uin
     {
         pnodeClass = CreateNode(knopClassDecl);
 
-        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Class, m_scriptContext);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Class, m_scriptContext);
 
         cbMinConstructor = m_pscan->IecpMinTok();
     }
@@ -7996,7 +7996,7 @@ ParseNodePtr Parser::ParseStringTemplateDecl(ParseNodePtr pnodeTagFnc)
         }
 
     }
-    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(StringTemplates, m_scriptContext);
+    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, StringTemplates, m_scriptContext);
 
     OUTPUT_TRACE_DEBUGONLY(
         Js::StringTemplateParsePhase,
@@ -9309,12 +9309,12 @@ ParseNodePtr Parser::ParseVariableDeclaration(
             else if (declarationType == tkCONST)
             {
                 pnodeThis = CreateBlockScopedDeclNode(pid, knopConstDecl);
-                CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Const, m_scriptContext);
+                CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Const, m_scriptContext);
             }
             else
             {
                 pnodeThis = CreateBlockScopedDeclNode(pid, knopLetDecl);
-                CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Let, m_scriptContext);
+                CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Let, m_scriptContext);
             }
 
             if (pid == wellKnownPropertyPids.arguments)
@@ -10994,7 +10994,7 @@ void Parser::ParseStmtList(ParseNodePtr *ppnodeList, ParseNodePtr **pppnodeLast,
                         m_currentNodeFunc->AsParseNodeFnc()->SetCanBeDeferred(false);
                         m_InAsmMode = true;
 
-                        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(AsmJSFunction, m_scriptContext);
+                        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, AsmJSFunction, m_scriptContext);
                     }
                 }
                 else if (isOctalInString)
@@ -12550,7 +12550,7 @@ IdentPtr Parser::ParseSuper(bool fAllowCall)
     }
 
     currentNodeFunc->AsParseNodeFnc()->SetHasSuperReference(TRUE);
-    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(Super, m_scriptContext);
+    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Super, m_scriptContext);
 
     // If we are defer parsing, we can skip verifying that the super reference is valid.
     // If it wasn't the parser would have thrown during upfront parsing and we wouldn't be defer parsing the function.

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -2715,7 +2715,7 @@ namespace UnifiedRegex
                     }
                     flags = (RegexFlags)(flags | UnicodeRegexFlag);
                     // For telemetry
-                    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(UnicodeRegexFlag, scriptContext);
+                    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, UnicodeRegexFlag, scriptContext);
 
                     break;
                 }
@@ -2728,7 +2728,7 @@ namespace UnifiedRegex
                     }
                     flags = (RegexFlags)(flags | StickyRegexFlag);
                     // For telemetry
-                    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(StickyRegexFlag, scriptContext);
+                    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, StickyRegexFlag, scriptContext);
 
                     break;
                 }

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #ifdef ENABLE_BASIC_TELEMETRY
-#include "ScriptContextTelemetry.h"
+#include "ScriptContext/ScriptContextTelemetry.h"
 #endif
 
 namespace Js
@@ -176,7 +176,7 @@ namespace Js
         , rejitReasonCountsCap(nullptr)
 #endif
 #ifdef ENABLE_BASIC_TELEMETRY
-        , telemetry(nullptr)
+        , telemetry()
 #endif
 #ifdef INLINE_CACHE_STATS
         , cacheDataMap(nullptr)
@@ -336,7 +336,7 @@ namespace Js
 #endif
 
 #ifdef ENABLE_BASIC_TELEMETRY
-        this->telemetry = Anew(this->TelemetryAllocator(), ScriptContextTelemetry, *this);
+        this->telemetry = Anew(this->TelemetryAllocator(), Js::ScriptContextTelemetry, this);
 #endif
 
 #ifdef PROFILE_STRINGS
@@ -5981,7 +5981,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 #endif
 
 #ifdef ENABLE_BASIC_TELEMETRY
-    ScriptContextTelemetry& ScriptContext::GetTelemetry()
+    Js::ScriptContextTelemetry& ScriptContext::GetTelemetry()
     {
         return *this->telemetry;
     }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -19,11 +19,12 @@ using namespace PlatformAgnostic;
 class NativeCodeGenerator;
 class BackgroundParser;
 struct IActiveScriptDirect;
-#ifdef ENABLE_BASIC_TELEMETRY
-class ScriptContextTelemetry;
-#endif
 namespace Js
 {
+#ifdef ENABLE_BASIC_TELEMETRY
+    class ScriptContextTelemetry;
+#endif
+
     class ScriptContext;
     class ScriptEditQuery;
     class MutationBreakpoint;
@@ -737,9 +738,9 @@ public:
 #ifdef ENABLE_BASIC_TELEMETRY
 
     private:
-        ScriptContextTelemetry* telemetry;
+        Js::ScriptContextTelemetry * telemetry;
     public:
-        ScriptContextTelemetry& GetTelemetry();
+        Js::ScriptContextTelemetry& GetTelemetry();
         bool HasTelemetry();
 
 #endif

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -382,18 +382,6 @@ public:
 
     virtual bool IsNumericProperty(Js::PropertyId propertyId) override;
 
-#ifdef ENABLE_BASIC_TELEMETRY
-    Js::LanguageStats* GetLanguageStats()
-    {
-        return langTel.GetLanguageStats();
-    }
-
-    void ResetLangStats()
-    {
-        this->langTel.Reset();
-    }
-#endif
-    
 #ifdef ENABLE_WASM_SIMD
 #if _M_IX86 || _M_AMD64
     // auxiliary SIMD values in memory to help JIT'ed code. E.g. used for Int8x16 shuffle.
@@ -441,10 +429,6 @@ private:
 
     // The current heap enumeration object being used during enumeration.
     IActiveScriptProfilerHeapEnum* heapEnum;
-
-#ifdef ENABLE_BASIC_TELEMETRY
-    Js::LanguageTelemetry langTel;
-#endif
 
     struct PropertyGuardEntry
     {

--- a/lib/Runtime/Language/InterpreterLoop.inl
+++ b/lib/Runtime/Language/InterpreterLoop.inl
@@ -200,15 +200,6 @@ Js::Var Js::InterpreterStackFrame::INTERPRETERLOOPNAME()
 #endif
 #endif
 
-#ifdef ENABLE_BASIC_TELEMETRY
-        if( TELEMETRY_OPCODE_OFFSET_ENABLED )
-        {
-            OpcodeTelemetry& opcodeTelemetry = this->scriptContext->GetTelemetry().GetOpcodeTelemetry();
-            opcodeTelemetry.ProgramLocationFunctionId    ( this->function->GetFunctionInfo()->GetLocalFunctionId() );
-            opcodeTelemetry.ProgramLocationBytecodeOffset( this->m_reader.GetCurrentOffset() );
-        }
-#endif
-
 #if DEBUGGING_LOOP
         if (this->scriptContext->GetThreadContext()->GetDebugManager()->stepController.IsActive() &&
             this->scriptContext->GetThreadContext()->GetDebugManager()->stepController.IsStepComplete_AllowingFalsePositives(this))

--- a/lib/Runtime/Language/RuntimeLanguagePch.h
+++ b/lib/Runtime/Language/RuntimeLanguagePch.h
@@ -57,10 +57,6 @@
 #include "Debug/DebugContext.h"
 #endif
 
-#ifdef ENABLE_BASIC_TELEMETRY
-#include "ScriptContextTelemetry.h"
-#endif
-
 // .inl files
 #include "Language/CacheOperators.inl"
 #include "Language/JavascriptMathOperators.inl"

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -5,9 +5,6 @@
 #include "RuntimeLibraryPch.h"
 #include "Library/EngineInterfaceObject.h"
 #include "Library/IntlEngineInterfaceExtensionObject.h"
-#ifdef ENABLE_BASIC_TELEMETRY
-#include "ScriptContextTelemetry.h"
-#endif
 
 namespace Js
 {

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -53,7 +53,7 @@ Var JavascriptMap::NewInstance(RecyclableObject* function, CallInfo callInfo, ..
 
     Var newTarget = args.GetNewTarget();
     bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
-    CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Map);
+    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Map, scriptContext);
 
     JavascriptMap* mapObject = nullptr;
 

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -28,7 +28,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
         JavascriptLibrary* library = scriptContext->GetLibrary();
 
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Promise);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Promise, scriptContext);
 
         // SkipDefaultNewObject function flag should have prevented the default object from
         // being created, except when call true a host dispatch

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -48,7 +48,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Proxy);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Proxy, scriptContext);
 
         if (!(args.Info.Flags & CallFlags_New))
         {

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -705,7 +705,7 @@ namespace Js
 
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_RegexSymbolMatch);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, RegexSymbolMatch, scriptContext);
 
         PCWSTR const varName = _u("RegExp.prototype[Symbol.match]");
 
@@ -775,7 +775,7 @@ namespace Js
 
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_RegexSymbolReplace);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, RegexSymbolReplace, scriptContext);
 
         PCWSTR varName = _u("RegExp.prototype[Symbol.replace]");
 
@@ -809,7 +809,7 @@ namespace Js
 
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_RegexSymbolSearch);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, RegexSymbolSearch, scriptContext);
 
         PCWSTR const varName = _u("RegExp.prototype[Symbol.search]");
 
@@ -838,7 +838,7 @@ namespace Js
 
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_RegexSymbolSplit);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, RegexSymbolSplit, scriptContext);
 
         RecyclableObject *thisObj = GetThisObject(args, _u("RegExp.prototype[Symbol.match]"), scriptContext);
         JavascriptString* string = GetFirstStringArg(args, scriptContext);

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -53,7 +53,7 @@ Var JavascriptSet::NewInstance(RecyclableObject* function, CallInfo callInfo, ..
 
     Var newTarget = args.GetNewTarget();
     bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
-    CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Set);
+    CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Set, scriptContext);
 
     JavascriptSet* setObject = nullptr;
 

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -38,7 +38,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
 
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_Symbol);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, Symbol, scriptContext);
 
         // SkipDefaultNewObject function flag should have prevented the default object from
         // being created, except when call true a host dispatch.

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -87,7 +87,7 @@ namespace Js
 
         Var newTarget = args.GetNewTarget();
         bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_WeakMap);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, WeakMap, scriptContext);
 
         JavascriptWeakMap* weakMapObject = nullptr;
 

--- a/lib/Runtime/Library/JavascriptWeakSet.cpp
+++ b/lib/Runtime/Library/JavascriptWeakSet.cpp
@@ -41,7 +41,7 @@ namespace Js
 
         Var newTarget = args.GetNewTarget();
         bool isCtorSuperCall = JavascriptOperators::GetAndAssertIsConstructorSuperCall(args);
-        CHAKRATEL_LANGSTATS_INC_DATACOUNT(ES6_WeakSet);
+        CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(ES6, WeakSet, scriptContext);
 
         JavascriptWeakSet* weakSetObject = nullptr;
 

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -460,11 +460,10 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Base/Entropy.h"
 #ifdef ENABLE_BASIC_TELEMETRY
 #include "DirectCall.h"
-#include "LanguageTelemetry.h"
+#include "ScriptContext/ScriptContextTelemetry.h"
 #else
 #define CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(builtin)
-#define CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(feature, m_scriptContext)
-#define CHAKRATEL_LANGSTATS_INC_DATACOUNT(feature)
+#define CHAKRATEL_LANGSTATS_INC_LANGFEATURECOUNT(esVersion, feature, m_scriptContext)
 #endif
 #include "Base/ThreadContext.h"
 


### PR DESCRIPTION
  - simplified abstractions related to telemetry reporting (e.g., deleting concept of "telemetry provider" & "ESBuiltInsDatabase"
  - cleaned up code so there was a single obvious place where script telemetry being tracked/reported
  - cleaned up reporting code to use the publically documented telemetry reporting macros
  - simplified macros used to code gen supporting telemetry fields.  should be easier to understand now.
  - deleted any code I didn't understand. :)