### PR TITLE
Speed up `in` operations with PropertyString or Symbol keys, part 1

### DIFF
--- a/lib/Runtime/Language/CacheOperators.h
+++ b/lib/Runtime/Language/CacheOperators.h
@@ -29,7 +29,8 @@ namespace Js
             bool CheckTypePropertyCache,
             bool IsInlineCacheAvailable,
             bool IsPolymorphicInlineCacheAvailable,
-            bool ReturnOperationInfo>
+            bool ReturnOperationInfo,
+            bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
         static bool TryGetProperty(Var const instance, const bool isRoot, RecyclableObject *const object, const PropertyId propertyId, Var *const propertyValue, ScriptContext *const requestContext, PropertyCacheOperationInfo * operationInfo, PropertyValueInfo *const propertyValueInfo);
         template<
             bool CheckLocal,

--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -15,7 +15,8 @@ namespace Js
         bool CheckTypePropertyCache,
         bool IsInlineCacheAvailable,
         bool IsPolymorphicInlineCacheAvailable,
-        bool ReturnOperationInfo>
+        bool ReturnOperationInfo,
+        bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
     inline bool CacheOperators::TryGetProperty(
         Var const instance,
         const bool isRoot,
@@ -38,7 +39,7 @@ namespace Js
             InlineCache *const inlineCache = IsInlineCacheAvailable ? propertyValueInfo->GetInlineCache() : nullptr;
             if(IsInlineCacheAvailable)
             {
-                if (inlineCache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo>(
+                if (inlineCache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo, OutputExistence>(
                         instance,
                         object,
                         propertyId,
@@ -73,7 +74,8 @@ namespace Js
                             CheckAccessor,
                             CheckMissing,
                             IsInlineCacheAvailable,
-                            ReturnOperationInfo
+                            ReturnOperationInfo,
+                            OutputExistence
                         >(
                             instance,
                             object,
@@ -96,7 +98,7 @@ namespace Js
 
         TypePropertyCache *const typePropertyCache = object->GetType()->GetPropertyCache();
         if(!typePropertyCache ||
-            !typePropertyCache->TryGetProperty(
+            !typePropertyCache->TryGetProperty<OutputExistence>(
                     CheckMissing,
                     object,
                     propertyId,
@@ -346,6 +348,9 @@ namespace Js
             {
                 return;
             }
+
+            // Before allowing proxies to cache, we would need to solve various issues (see JavascriptProxy::GetPropertyQuery).
+            Assert(!JavascriptProxy::Is(objectWithProperty));
         }
         else
         {

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -283,7 +283,8 @@ namespace Js
             bool CheckProto,
             bool CheckAccessor,
             bool CheckMissing,
-            bool ReturnOperationInfo>
+            bool ReturnOperationInfo,
+            bool OutputExistence /*When set, propertyValue is true or false, representing whether the property exists on the instance not its actual value*/>
         bool TryGetProperty(
             Var const instance,
             RecyclableObject *const propertyObject,
@@ -463,7 +464,8 @@ namespace Js
             bool CheckAccessor,
             bool CheckMissing,
             bool IsInlineCacheAvailable,
-            bool ReturnOperationInfo>
+            bool ReturnOperationInfo,
+            bool OutputExistence /*When set, propertyValue is true or false, representing whether the property exists on the instance not its actual value*/>
         bool TryGetProperty(
             Var const instance,
             RecyclableObject *const propertyObject,

--- a/lib/Runtime/Language/InlineCache.inl
+++ b/lib/Runtime/Language/InlineCache.inl
@@ -11,7 +11,8 @@ namespace Js
         bool CheckProto,
         bool CheckAccessor,
         bool CheckMissing,
-        bool ReturnOperationInfo>
+        bool ReturnOperationInfo,
+        bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
     bool InlineCache::TryGetProperty(
         Var const instance,
         RecyclableObject *const propertyObject,
@@ -35,9 +36,17 @@ namespace Js
         if (CheckLocal && type == u.local.type)
         {
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetInlineSlot(u.local.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetInlineSlot(u.local.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Local;
@@ -49,9 +58,17 @@ namespace Js
         if (CheckLocal && TypeWithAuxSlotTag(type) == u.local.type)
         {
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetAuxSlot(u.local.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetAuxSlot(u.local.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Local;
@@ -63,9 +80,17 @@ namespace Js
         if (CheckProto && type == u.proto.type && !this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetInlineSlot(u.proto.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = u.proto.prototypeObject->GetInlineSlot(u.proto.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Proto;
@@ -77,9 +102,17 @@ namespace Js
         if (CheckProto && TypeWithAuxSlotTag(type) == u.proto.type && !this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Proto;
@@ -93,22 +126,30 @@ namespace Js
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheGetterFlag);
 
-            RecyclableObject * function;
-            if (u.accessor.isOnProto)
+            if (OutputExistence)
             {
-                function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
             }
             else
             {
-                function = RecyclableObject::UnsafeFromVar(DynamicObject::UnsafeFromVar(propertyObject)->GetInlineSlot(u.accessor.slotIndex));
-            }
+                RecyclableObject * function;
+                if (u.accessor.isOnProto)
+                {
+                    function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
+                }
+                else
+                {
+                    function = RecyclableObject::UnsafeFromVar(DynamicObject::UnsafeFromVar(propertyObject)->GetInlineSlot(u.accessor.slotIndex));
+                }
 
-            *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
+                *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
 
-            // Can't assert because the getter could have a side effect
+                // Can't assert because the getter could have a side effect
 #ifdef CHKGETTER
-            Assert(JavascriptOperators::Equal(*propertyValue, JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext), requestContext));
+                Assert(JavascriptOperators::Equal(*propertyValue, JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext), requestContext));
 #endif
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Getter;
@@ -122,22 +163,30 @@ namespace Js
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheGetterFlag);
 
-            RecyclableObject * function;
-            if (u.accessor.isOnProto)
+            if (OutputExistence)
             {
-                function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+                *propertyValue = requestContext->GetLibrary()->GetTrue();
+                Assert(JavascriptOperators::HasProperty(propertyObject, propertyId));
             }
             else
             {
-                function = RecyclableObject::UnsafeFromVar(DynamicObject::FromVar(propertyObject)->GetAuxSlot(u.accessor.slotIndex));
-            }
+                RecyclableObject * function;
+                if (u.accessor.isOnProto)
+                {
+                    function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+                }
+                else
+                {
+                    function = RecyclableObject::UnsafeFromVar(DynamicObject::FromVar(propertyObject)->GetAuxSlot(u.accessor.slotIndex));
+                }
 
-            *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
+                *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
 
-            // Can't assert because the getter could have a side effect
+                // Can't assert because the getter could have a side effect
 #ifdef CHKGETTER
-            Assert(JavascriptOperators::Equal(*propertyValue, JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext), requestContext));
+                Assert(JavascriptOperators::Equal(*propertyValue, JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext), requestContext));
 #endif
+            }
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Getter;
@@ -149,9 +198,17 @@ namespace Js
         if (CheckMissing && type == u.proto.type && this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetInlineSlot(u.proto.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetFalse();
+                Assert(!JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = u.proto.prototypeObject->GetInlineSlot(u.proto.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
 
 #ifdef MISSING_PROPERTY_STATS
             if (PHASE_STATS1(MissingPropertyCachePhase))
@@ -171,9 +228,17 @@ namespace Js
         if (CheckMissing && TypeWithAuxSlotTag(type) == u.proto.type && this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
-            Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
-                (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            if (OutputExistence)
+            {
+                *propertyValue = requestContext->GetLibrary()->GetFalse();
+                Assert(!JavascriptOperators::HasProperty(propertyObject, propertyId));
+            }
+            else
+            {
+                *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
+                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
+                    (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
+            }
 
 #ifdef MISSING_PROPERTY_STATS
             if (PHASE_STATS1(MissingPropertyCachePhase))
@@ -540,7 +605,8 @@ namespace Js
         bool CheckAccessor,
         bool CheckMissing,
         bool IsInlineCacheAvailable,
-        bool ReturnOperationInfo>
+        bool ReturnOperationInfo,
+        bool OutputExistence /*When set, propertyValue is true or false, representing whether the property exists on the instance not its actual value*/>
     bool PolymorphicInlineCache::TryGetProperty(
         Var const instance,
         RecyclableObject *const propertyObject,
@@ -564,7 +630,7 @@ namespace Js
             isEmpty = cache->IsEmpty();
         }
 #endif
-        bool result = cache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo>(
+        bool result = cache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo, OutputExistence>(
             instance, propertyObject, propertyId, propertyValue, requestContext, operationInfo);
 
 #ifdef CLONE_INLINECACHE_TO_EMPTYSLOT
@@ -573,7 +639,7 @@ namespace Js
             result = CheckClonedInlineCache(inlineCacheIndex, [&](uint tryInlineCacheIndex) -> bool
             {
                 cache = &inlineCaches[tryInlineCacheIndex];
-                return cache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo>(
+                return cache->TryGetProperty<CheckLocal, CheckProto, CheckAccessor, CheckMissing, ReturnOperationInfo, OutputExistence>(
                     instance, propertyObject, propertyId, propertyValue, requestContext, operationInfo);
             });
         }

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3377,7 +3377,7 @@ namespace Js
         PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
         Var aValue;
         if (obj &&
-            CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false>(
+            CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false, false>(
                 obj, false, obj, propertyId, &aValue, GetScriptContext(), nullptr, &info))
         {
             SetReg(playout->Value, aValue);
@@ -3423,7 +3423,7 @@ namespace Js
         PropertyValueInfo info;
         PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
         Var aValue;
-        if (CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false>(
+        if (CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false, false>(
                 obj, true, obj, propertyId, &aValue, GetScriptContext(), nullptr, &info))
         {
             SetReg(playout->Value, aValue);
@@ -3481,7 +3481,7 @@ namespace Js
         PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
         Var aValue;
         if (obj &&
-            CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false>(
+            CacheOperators::TryGetProperty<true, true, false, false, false, false, true, false, false, false>(
                 obj, false, obj, propertyId, &aValue, GetScriptContext(), nullptr, &info))
         {
             threadContext->CheckAndResetImplicitCallAccessorFlag();
@@ -3810,7 +3810,7 @@ namespace Js
         PropertyValueInfo info;
         PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
         Var value;
-        if(CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false>(
+        if(CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false, false>(
                 obj, true, obj, propertyId, &value, GetScriptContext(), nullptr, &info))
         {
             SetReg(playout->Value, value);
@@ -4011,7 +4011,7 @@ namespace Js
             PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
 
             Var value;
-            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false>(
+            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false, false>(
                     obj, false, obj, propertyId, &value, GetScriptContext(), nullptr, &info))
             {
                 SetReg(playout->Value, value);
@@ -4037,7 +4037,7 @@ namespace Js
             PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->PropertyIdIndex, true);
 
             Var value;
-            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false>(
+            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false, false>(
                 thisObj, false, superObj, propertyId, &value, GetScriptContext(), nullptr, &info))
             {
                 SetReg(playout->Value, value);
@@ -4158,7 +4158,7 @@ namespace Js
             PropertyValueInfo info;
             PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
             Var value;
-            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false>(
+            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false, false>(
                     obj, false, obj, propertyId, &value, scriptContext, nullptr, &info))
             {
                 threadContext->CheckAndResetImplicitCallAccessorFlag();
@@ -4195,7 +4195,7 @@ namespace Js
             PropertyValueInfo info;
             PropertyValueInfo::SetCacheInfo(&info, GetFunctionBody(), inlineCache, playout->inlineCacheIndex, true);
             Var value;
-            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false>(
+            if (CacheOperators::TryGetProperty<true, false, false, false, false, false, true, false, false, false>(
                 obj, false, obj, propertyId, &value, scriptContext, nullptr, &info))
             {
                 threadContext->CheckAndResetImplicitCallAccessorFlag();

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -177,7 +177,7 @@ namespace Js
         static BOOL HasProperty(RecyclableObject* instance, PropertyId propertyId);
         static BOOL HasRootProperty(RecyclableObject* instance, PropertyId propertyId);
         static BOOL HasProxyOrPrototypeInlineCacheProperty(RecyclableObject* instance, PropertyId propertyId);
-        template<typename PropertyKeyType>
+        template<bool OutputExistence, typename PropertyKeyType>
         static BOOL GetPropertyWPCache(Var instance, RecyclableObject* propertyObject, PropertyKeyType propertyKey, Var* value, ScriptContext* requestContext, _Inout_ PropertyValueInfo * info);
         static BOOL GetPropertyUnscopable(Var instance, RecyclableObject* propertyObject, PropertyId propertyId, Var* value, ScriptContext* requestContext, PropertyValueInfo* info=NULL);
         static Var  GetProperty(RecyclableObject* instance, PropertyId propertyId, ScriptContext* requestContext, PropertyValueInfo* info = NULL);
@@ -710,6 +710,12 @@ namespace Js
         static BOOL ToPropertyDescriptorForGenericObjects(Var propertySpec, PropertyDescriptor* descriptor, ScriptContext* scriptContext);
 
         static BOOL IsRemoteArray(RecyclableObject* instance);
+
+        // Get the property record usage cache from the given index variable, if it has one.
+        // Adds a PropertyString to a LiteralStringWithPropertyStringPtr on second call with that string.
+        // Also outputs the object that owns the usage cache, since PropertyRecordUsageCache is an interior pointer.
+        // Returns whether a PropertyRecordUsageCache was found.
+        _Success_(return) static bool GetPropertyRecordUsageCache(Var index, ScriptContext* scriptContext, _Outptr_ PropertyRecordUsageCache** propertyRecordUsageCache, _Outptr_ RecyclableObject** cacheOwner);
     };
 
 } // namespace Js

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -145,13 +145,13 @@ namespace Js
         unambiguousNonLocalExports->AddNew(propertyId, *nonLocalExportNameRecord);
     }
 
-    PropertyQueryFlags ModuleNamespace::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags ModuleNamespace::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         SimpleDictionaryPropertyDescriptor<BigPropertyIndex> propertyDescriptor;
         const Js::PropertyRecord* propertyRecord = GetScriptContext()->GetThreadContext()->GetPropertyName(propertyId);
         if (propertyRecord->IsSymbol())
         {
-            return this->DynamicObject::HasPropertyQuery(propertyId);
+            return this->DynamicObject::HasPropertyQuery(propertyId, info);
         }
         if (propertyMap != nullptr && propertyMap->TryGetValue(propertyRecord, &propertyDescriptor))
         {

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -34,7 +34,7 @@ namespace Js
         static ModuleNamespace* FromVar(Var obj) { AssertOrFailFast(JavascriptOperators::GetTypeId(obj) == TypeIds_ModuleNamespace); return static_cast<ModuleNamespace*>(obj); }
 
         virtual PropertyId GetPropertyId(BigPropertyIndex index) override;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -894,7 +894,7 @@ namespace Js
             PropertyCacheOperationInfo operationInfo;
             PropertyValueInfo propertyValueInfo;
             PropertyValueInfo::SetCacheInfo(&propertyValueInfo, functionBody, inlineCache, inlineCacheIndex, true);
-            if (!CacheOperators::TryGetProperty<true, true, true, !Root && !Method, true, !Root, true, false, true>(
+            if (!CacheOperators::TryGetProperty<true, true, true, !Root && !Method, true, !Root, true, false, true, false>(
                     object,
                     Root,
                     object,

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -321,7 +321,7 @@ namespace Js
 
     }
 
-    PropertyQueryFlags HeapArgumentsObject::HasPropertyQuery(PropertyId id)
+    PropertyQueryFlags HeapArgumentsObject::HasPropertyQuery(PropertyId id, _Inout_opt_ PropertyValueInfo* info)
     {
         ScriptContext *scriptContext = GetScriptContext();
 
@@ -332,7 +332,7 @@ namespace Js
             return HeapArgumentsObject::HasItemQuery(index);
         }
 
-        return DynamicObject::HasPropertyQuery(id);
+        return DynamicObject::HasPropertyQuery(id, info);
     }
 
     PropertyQueryFlags HeapArgumentsObject::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -75,7 +75,7 @@ namespace Js
         virtual BOOL SetItemAt(uint32 index, Var value);
         virtual BOOL DeleteItemAt(uint32 index);
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -269,14 +269,14 @@ namespace Js
         return false;
     }
 
-    PropertyQueryFlags BoundFunction::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags BoundFunction::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {
             return PropertyQueryFlags::Property_Found;
         }
 
-        return JavascriptFunction::HasPropertyQuery(propertyId);
+        return JavascriptFunction::HasPropertyQuery(propertyId, info);
     }
 
     PropertyQueryFlags BoundFunction::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/BoundFunction.h
+++ b/lib/Runtime/Library/BoundFunction.h
@@ -26,7 +26,7 @@ namespace Js
         static bool Is(Var func){ return JavascriptFunction::Is(func) && JavascriptFunction::UnsafeFromVar(func)->IsBoundFunction(); }
         static Var NewInstance(RecyclableObject* function, CallInfo callInfo, ...);
         virtual JavascriptString* GetDisplayNameImpl() const override;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/ES5Array.cpp
+++ b/lib/Runtime/Library/ES5Array.cpp
@@ -40,7 +40,7 @@ namespace Js
         return GetTypeHandler()->IsLengthWritable();
     }
 
-    PropertyQueryFlags ES5Array::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags ES5Array::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {
@@ -48,7 +48,7 @@ namespace Js
         }
 
         // Skip JavascriptArray override
-        return DynamicObject::HasPropertyQuery(propertyId);
+        return DynamicObject::HasPropertyQuery(propertyId, info);
     }
 
     BOOL ES5Array::IsWritable(PropertyId propertyId)

--- a/lib/Runtime/Library/ES5Array.h
+++ b/lib/Runtime/Library/ES5Array.h
@@ -55,7 +55,7 @@ namespace Js
         //
         // To skip JavascriptArray overrides
         //
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL IsWritable(PropertyId propertyId) override;
         virtual BOOL SetEnumerable(PropertyId propertyId, BOOL value) override;
         virtual BOOL SetWritable(PropertyId propertyId, BOOL value) override;

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -125,7 +125,7 @@ namespace Js
 
     BOOL GlobalObject::ReserveGlobalProperty(PropertyId propertyId)
     {
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/)))
         {
             return false;
         }
@@ -1780,9 +1780,9 @@ LHexError:
         return FALSE;
     }
 
-    PropertyQueryFlags GlobalObject::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags GlobalObject::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
-        return JavascriptConversion::BooleanToPropertyQueryFlags(JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)) ||
+        return JavascriptConversion::BooleanToPropertyQueryFlags(JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, info)) ||
             (this->directHostObject && JavascriptOperators::HasProperty(this->directHostObject, propertyId)) ||
             (this->hostObject && JavascriptOperators::HasProperty(this->hostObject, propertyId)));
     }
@@ -1796,13 +1796,13 @@ LHexError:
 
     BOOL GlobalObject::HasOwnProperty(PropertyId propertyId)
     {
-        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)) ||
+        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/)) ||
             (this->directHostObject && this->directHostObject->HasProperty(propertyId));
     }
 
     BOOL GlobalObject::HasOwnPropertyNoHostObject(PropertyId propertyId)
     {
-        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId));
+        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/));
     }
 
     PropertyQueryFlags GlobalObject::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -1922,7 +1922,7 @@ LHexError:
 
     BOOL GlobalObject::SetExistingProperty(PropertyId propertyId, Var value, PropertyValueInfo* info, BOOL *setAttempted)
     {
-        BOOL hasOwnProperty = JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId));
+        BOOL hasOwnProperty = JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/));
         BOOL hasProperty = JavascriptOperators::HasProperty(this->GetPrototype(), propertyId);
         *setAttempted = TRUE;
 
@@ -2167,7 +2167,7 @@ LHexError:
 
     BOOL GlobalObject::DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags)
     {
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(__super::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(__super::HasPropertyQuery(propertyId, nullptr /*info*/)))
         {
             return __super::DeleteProperty(propertyId, flags);
         }

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -132,7 +132,7 @@ namespace Js
         static Var VEval(JavascriptLibrary* library, FrameDisplay* environment, ModuleID moduleID, bool isStrictMode, bool isIndirect,
             Arguments& args, bool isLibraryCode, bool registerDocument, uint32 additionalGrfscr, ScriptContext* debugEvalScriptContext = nullptr);
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual BOOL HasOwnPropertyNoHostObject(PropertyId propertyId) override;
         virtual BOOL UseDynamicObjectForNoHostObjectAccess() override { return TRUE; }

--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -226,7 +226,7 @@ JSONStringifier::ReadValue(_In_ JavascriptString* key, _In_opt_ const PropertyRe
     if (propertyString != nullptr)
     {
         PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), false);
-        if (propertyString->TryGetPropertyFromCache<false /* ownPropertyOnly */>(holder, holder, &value, this->scriptContext, &info))
+        if (propertyString->TryGetPropertyFromCache<false /* ownPropertyOnly */, false /* OutputExistence */>(holder, holder, &value, this->scriptContext, &info))
         {
             return value;
         }
@@ -280,7 +280,8 @@ JSONStringifier::ToJSON(_In_ JavascriptString* key, _In_ RecyclableObject* value
         true,   // CheckTypePropertyCache
         false,  // IsInlineCacheAvailable
         true,   // IsPolymorphicInlineCacheAvailable
-        false>  // ReturnOperationInfo
+        false,  // ReturnOperationInfo
+        false>  // OutputExistence
         (valueObject,
             false,
             valueObject,

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11973,7 +11973,7 @@ Case0:
         return DynamicObject::DeleteProperty(propertyNameString, flags);
     }
 
-    PropertyQueryFlags JavascriptArray::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptArray::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {
@@ -11987,7 +11987,7 @@ Case0:
             return JavascriptConversion::BooleanToPropertyQueryFlags(this->HasItem(index));
         }
 
-        return DynamicObject::HasPropertyQuery(propertyId);
+        return DynamicObject::HasPropertyQuery(propertyId, info);
     }
 
     BOOL JavascriptArray::IsEnumerable(PropertyId propertyId)

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -333,7 +333,7 @@ namespace Js
 #if DBG
         void DoTypeMutation();
 #endif
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2488,7 +2488,7 @@ LABEL1:
         return isJsBuiltInCode;
     }
 
-    PropertyQueryFlags JavascriptFunction::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptFunction::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         switch (propertyId)
         {
@@ -2506,7 +2506,7 @@ LABEL1:
             }
             break;
         }
-        return DynamicObject::HasPropertyQuery(propertyId);
+        return DynamicObject::HasPropertyQuery(propertyId, info);
     }
 
     BOOL JavascriptFunction::GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext)

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -202,7 +202,7 @@ namespace Js
 
         virtual bool HasReadOnlyPropertiesInvisibleToTypeHandler() override { return true; }
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -256,7 +256,7 @@ namespace Js
         return scriptFunction->EnsureSourceString();
     }
 
-    PropertyQueryFlags JavascriptGeneratorFunction::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptGeneratorFunction::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {
@@ -266,10 +266,10 @@ namespace Js
         if (propertyId == PropertyIds::caller || propertyId == PropertyIds::arguments)
         {
             // JavascriptFunction has special case for caller and arguments; call DynamicObject:: virtual directly to skip that.
-            return DynamicObject::HasPropertyQuery(propertyId);
+            return DynamicObject::HasPropertyQuery(propertyId, info);
         }
 
-        return JavascriptFunction::HasPropertyQuery(propertyId);
+        return JavascriptFunction::HasPropertyQuery(propertyId, info);
     }
 
     PropertyQueryFlags JavascriptGeneratorFunction::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -57,7 +57,7 @@ namespace Js
         virtual Var GetSourceString() const;
         virtual Var EnsureSourceString();
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -373,7 +373,8 @@ namespace Js
             true,                                       // CheckTypePropertyCache
             !PolymorphicInlineCache::IsPolymorphic,     // IsInlineCacheAvailable
             PolymorphicInlineCache::IsPolymorphic,      // IsPolymorphicInlineCacheAvailable
-            false>                                      // ReturnOperationInfo
+            false,                                      // ReturnOperationInfo
+            false>                                      // OutputExistence
             (thisArg, false, thisArg, toStringTagId, &value, scriptContext, nullptr, &info))
         {
             return value;
@@ -1596,7 +1597,7 @@ namespace Js
             //
             // Whenever possible, our enumerator populates the cache, so we should generally get a cache hit here
             PropertyValueInfo getPropertyInfo;
-            if (propertyString == nullptr || !propertyString->TryGetPropertyFromCache<true /* OwnPropertyOnly */>(from, from, &propValue, scriptContext, &getPropertyInfo))
+            if (propertyString == nullptr || !propertyString->TryGetPropertyFromCache<true /* OwnPropertyOnly */, false /* OutputExistence */>(from, from, &propValue, scriptContext, &getPropertyInfo))
             {
                 if (!JavascriptOperators::GetOwnProperty(from, nextKey, &propValue, scriptContext, &getPropertyInfo))
                 {

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -463,8 +463,14 @@ namespace Js
         return hasProperty;
     }
 
-    PropertyQueryFlags JavascriptProxy::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptProxy::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
+        if (info)
+        {
+            // Prevent caching. See comment in GetPropertyQuery for more detail.
+            PropertyValueInfo::SetNoCache(info, this);
+            PropertyValueInfo::DisablePrototypeCache(info, this);
+        }
         auto fn = [&](RecyclableObject* object)->BOOL {
             return JavascriptOperators::HasProperty(object, propertyId);
         };
@@ -527,6 +533,7 @@ namespace Js
     {
         // We can't cache the property at this time. both target and handler can be changed outside of the proxy, so the inline cache needs to be
         // invalidate when target, handler, or handler prototype has changed. We don't have a way to achieve this yet.
+        // Also, Get and Has operations share a cache, so a trap on either should prevent caching on both.
         PropertyValueInfo::SetNoCache(info, this);
         PropertyValueInfo::DisablePrototypeCache(info, this); // We can't cache prototype property either
         auto fn = [&](RecyclableObject* object)-> BOOL {
@@ -553,7 +560,7 @@ namespace Js
         PropertyValueInfo::SetNoCache(info, this);
         PropertyValueInfo::DisablePrototypeCache(info, this); // We can't cache prototype property either
         auto fn = [&](RecyclableObject* object)-> BOOL {
-            return JavascriptOperators::GetPropertyWPCache(originalInstance, object, propertyNameString, value, requestContext, info);
+            return JavascriptOperators::GetPropertyWPCache<false /* OutputExistence */>(originalInstance, object, propertyNameString, value, requestContext, info);
         };
         auto getPropertyId = [&]()->PropertyId{
             const PropertyRecord* propertyRecord;

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -73,7 +73,7 @@ namespace Js
 
         static DWORD GetOffsetOfTarget() { return offsetof(JavascriptProxy, target); }
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual BOOL HasOwnPropertyNoHostObject(PropertyId propertyId) override;
         virtual BOOL HasOwnPropertyCheckNoRedecl(PropertyId propertyId) override;

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -173,7 +173,7 @@ namespace Js
         PropertyIds::index,
     };
 
-    PropertyQueryFlags JavascriptRegExpConstructor::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptRegExpConstructor::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         switch (propertyId)
         {
@@ -199,7 +199,7 @@ namespace Js
         case PropertyIds::$9:
             return PropertyQueryFlags::Property_Found;
         default:
-            return JavascriptFunction::HasPropertyQuery(propertyId);
+            return JavascriptFunction::HasPropertyQuery(propertyId, info);
         }
     }
 

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -24,7 +24,7 @@ namespace Js
     public:
         JavascriptRegExpConstructor(DynamicType * type);
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -1098,12 +1098,12 @@ namespace Js
         PropertyIds::sticky
     };
 
-    PropertyQueryFlags JavascriptRegExp::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptRegExp::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         const ScriptConfiguration* scriptConfig = this->GetScriptContext()->GetConfig();
 
 #define HAS_PROPERTY(ownProperty) \
-        return (ownProperty ? PropertyQueryFlags::Property_Found : DynamicObject::HasPropertyQuery(propertyId));
+        return (ownProperty ? PropertyQueryFlags::Property_Found : DynamicObject::HasPropertyQuery(propertyId, info));
 
         switch (propertyId)
         {
@@ -1120,7 +1120,7 @@ namespace Js
         case PropertyIds::sticky:
             HAS_PROPERTY(scriptConfig->IsES6RegExStickyEnabled() && !scriptConfig->IsES6RegExPrototypePropertiesEnabled())
         default:
-            return DynamicObject::HasPropertyQuery(propertyId);
+            return DynamicObject::HasPropertyQuery(propertyId, info);
         }
 
 #undef HAS_PROPERTY

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -181,7 +181,7 @@ namespace Js
 
         virtual bool HasReadOnlyPropertiesInvisibleToTypeHandler() override { return true; }
 
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3637,7 +3637,7 @@ case_2:
         return concatString;
     }
 
-    PropertyQueryFlags JavascriptString::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptString::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -106,7 +106,7 @@ namespace Js
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
         virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
         virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags propertyOperationFlags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags propertyOperationFlags) override;

--- a/lib/Runtime/Library/JavascriptStringObject.cpp
+++ b/lib/Runtime/Library/JavascriptStringObject.cpp
@@ -94,14 +94,14 @@ namespace Js
         return !conditionMetBehavior;
     }
 
-    PropertyQueryFlags JavascriptStringObject::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags JavascriptStringObject::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         if (propertyId == PropertyIds::length)
         {
             return PropertyQueryFlags::Property_Found;
         }
 
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, info)))
         {
             return PropertyQueryFlags::Property_Found;
         }
@@ -171,7 +171,7 @@ namespace Js
 
         // From DynamicObject::IsConfigurable we can't tell if the result is from a property or just default
         // value. Call HasProperty to find out.
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/)))
         {
             return DynamicObject::IsConfigurable(propertyId);
         }
@@ -199,7 +199,7 @@ namespace Js
 
         // From DynamicObject::IsWritable we can't tell if the result is from a property or just default
         // value. Call HasProperty to find out.
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/)))
         {
             return DynamicObject::IsWritable(propertyId);
         }

--- a/lib/Runtime/Library/JavascriptStringObject.h
+++ b/lib/Runtime/Library/JavascriptStringObject.h
@@ -37,7 +37,7 @@ namespace Js
         virtual bool HasReadOnlyPropertiesInvisibleToTypeHandler() override { return true; }
 
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL IsConfigurable(PropertyId propertyId) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL IsWritable(PropertyId propertyId) override;

--- a/lib/Runtime/Library/JavascriptVariantDate.h
+++ b/lib/Runtime/Library/JavascriptVariantDate.h
@@ -35,7 +35,7 @@ namespace Js
         double GetValue() { return value; }
 
         virtual BOOL Equals(Var other, BOOL* value, ScriptContext * requestContext) override;
-        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId) override { return PropertyQueryFlags::Property_NotFound; };
+        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override { return PropertyQueryFlags::Property_NotFound; };
         virtual PropertyQueryFlags GetPropertyQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/ModuleRoot.cpp
+++ b/lib/Runtime/Library/ModuleRoot.cpp
@@ -17,9 +17,9 @@ namespace Js
         __super::SetHostObject(hostObject);
     }
 
-    PropertyQueryFlags ModuleRoot::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags ModuleRoot::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
-        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
+        if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, info)))
         {
             return PropertyQueryFlags::Property_Found;
         }
@@ -27,7 +27,7 @@ namespace Js
         {
             return PropertyQueryFlags::Property_Found;
         }
-        return this->GetLibrary()->GetGlobalObject()->GlobalObject::HasPropertyQuery(propertyId);
+        return this->GetLibrary()->GetGlobalObject()->GlobalObject::HasPropertyQuery(propertyId, info);
     }
 
     BOOL ModuleRoot::EnsureProperty(PropertyId propertyId)
@@ -56,7 +56,7 @@ namespace Js
 
     BOOL ModuleRoot::HasOwnProperty(PropertyId propertyId)
     {
-        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId));
+        return JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId, nullptr /*info*/));
     }
 
     PropertyQueryFlags ModuleRoot::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/ModuleRoot.h
+++ b/lib/Runtime/Library/ModuleRoot.h
@@ -21,7 +21,7 @@ namespace Js
 
         virtual BOOL InitPropertyScoped(PropertyId propertyId, Var value) override;
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value) override;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual BOOL UseDynamicObjectForNoHostObjectAccess() override { return TRUE; }
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/PropertyRecordUsageCache.h
+++ b/lib/Runtime/Library/PropertyRecordUsageCache.h
@@ -43,14 +43,70 @@ namespace Js
             RecyclableObject *const owner /* Object that this usage cache is part of */);
 
 
-        template <bool OwnPropertyOnly>
-        bool TryGetPropertyFromCache(
+        template <
+            bool OwnPropertyOnly,
+            bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
+        inline bool TryGetPropertyFromCache(
             Var const instance,
             RecyclableObject *const object,
             Var *const propertyValue,
             ScriptContext *const requestContext,
             PropertyValueInfo *const propertyValueInfo,
-            RecyclableObject *const owner /* Object that this usage cache is part of */);
+            RecyclableObject *const owner /* Object that this usage cache is part of */)
+        {
+            if (ShouldUseCache())
+            {
+                PropertyValueInfo::SetCacheInfo(propertyValueInfo, owner, this, GetLdElemInlineCache(), true /* allowResizing */);
+
+                // Some caches will look at prototype, so GetOwnProperty lookups must not check these
+                bool found = CacheOperators::TryGetProperty<
+                    true,               // CheckLocal
+                    !OwnPropertyOnly,   // CheckProto
+                    !OwnPropertyOnly,   // CheckAccessor
+                    !OwnPropertyOnly,   // CheckMissing
+                    true,               // CheckPolymorphicInlineCache
+                    !OwnPropertyOnly,   // CheckTypePropertyCache
+                    false,              // IsInlineCacheAvailable
+                    true,               // IsPolymorphicInlineCacheAvailable
+                    false,              // ReturnOperationInfo
+                    OutputExistence>    // OutputExistence
+                        (instance,
+                        false, // isRoot
+                        object,
+                        this->propertyRecord->GetPropertyId(),
+                        propertyValue,
+                        requestContext,
+                        nullptr, // operationInfo
+                        propertyValueInfo);
+
+                if (found)
+                {
+                    RegisterCacheHit();
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+                    if (PHASE_TRACE1(PropertyCachePhase))
+                    {
+                        Output::Print(_u("PropertyCache: GetElem cache hit for '%s': type %p\n"),
+                            GetString(),
+                            object->GetType());
+                    }
+#endif
+                    return true;
+                }
+            }
+
+            RegisterCacheMiss();
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+            if (PHASE_TRACE1(PropertyCachePhase))
+            {
+                Output::Print(_u("PropertyCache: GetElem cache miss for '%s': type %p, index %d\n"),
+                    GetString(),
+                    object->GetType(),
+                    GetLdElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
+                DumpCache(true);
+            }
+#endif
+            return false;
+        }
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
 
@@ -72,66 +128,4 @@ namespace Js
         }
 #endif
     };
-
-    template <bool OwnPropertyOnly> inline
-    bool PropertyRecordUsageCache::TryGetPropertyFromCache(
-        Var const instance,
-        RecyclableObject *const object,
-        Var *const propertyValue,
-        ScriptContext *const requestContext,
-        PropertyValueInfo *const propertyValueInfo,
-        RecyclableObject *const owner /* Object that this usage cache is part of */)
-    {
-        if (ShouldUseCache())
-        {
-            PropertyValueInfo::SetCacheInfo(propertyValueInfo, owner, this, GetLdElemInlineCache(), true /* allowResizing */);
-
-            // Some caches will look at prototype, so GetOwnProperty lookups must not check these
-            bool found = CacheOperators::TryGetProperty<
-                true,               // CheckLocal
-                !OwnPropertyOnly,   // CheckProto
-                !OwnPropertyOnly,   // CheckAccessor
-                !OwnPropertyOnly,   // CheckMissing
-                true,               // CheckPolymorphicInlineCache
-                !OwnPropertyOnly,   // CheckTypePropertyCache
-                false,              // IsInlineCacheAvailable
-                true,               // IsPolymorphicInlineCacheAvailable
-                false>              // ReturnOperationInfo
-                    (instance,
-                    false, // isRoot
-                    object,
-                    this->propertyRecord->GetPropertyId(),
-                    propertyValue,
-                    requestContext,
-                    nullptr, // operationInfo
-                    propertyValueInfo);
-
-            if (found)
-            {
-                RegisterCacheHit();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                if (PHASE_TRACE1(PropertyCachePhase))
-                {
-                    Output::Print(_u("PropertyCache: GetElem cache hit for '%s': type %p\n"),
-                        GetString(),
-                        object->GetType());
-                }
-#endif
-                return true;
-            }
-        }
-
-        RegisterCacheMiss();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-        if (PHASE_TRACE1(PropertyCachePhase))
-        {
-            Output::Print(_u("PropertyCache: GetElem cache miss for '%s': type %p, index %d\n"),
-                GetString(),
-                object->GetType(),
-                GetLdElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
-            DumpCache(true);
-        }
-#endif
-        return false;
-    }
 }

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -37,13 +37,18 @@ public:
         _Inout_ PropertyValueInfo *const propertyValueInfo);
 
 
-    template <bool OwnPropertyOnly>
-    bool TryGetPropertyFromCache(
+    template <
+        bool OwnPropertyOnly,
+        bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
+    inline bool TryGetPropertyFromCache(
         Var const instance,
         RecyclableObject *const object,
         Var *const propertyValue,
         ScriptContext *const requestContext,
-        PropertyValueInfo *const propertyValueInfo);
+        PropertyValueInfo *const propertyValueInfo)
+    {
+        return this->propertyRecordUsageCache.TryGetPropertyFromCache<OwnPropertyOnly, OutputExistence>(instance, object, propertyValue, requestContext, propertyValueInfo, this);
+    }
 
     static PropertyString* New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler);
 
@@ -80,17 +85,6 @@ PropertyString * PropertyString::TryFromVar(T var)
     return PropertyString::Is(var)
         ? reinterpret_cast<PropertyString*>(var)
         : nullptr;
-}
-
-template <bool OwnPropertyOnly> inline
-bool PropertyString::TryGetPropertyFromCache(
-    Var const instance,
-    RecyclableObject *const object,
-    Var *const propertyValue,
-    ScriptContext *const requestContext,
-    PropertyValueInfo *const propertyValueInfo)
-{
-    return this->propertyRecordUsageCache.TryGetPropertyFromCache<OwnPropertyOnly>(instance, object, propertyValue, requestContext, propertyValueInfo, this);
 }
 
 } // namespace Js

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -740,7 +740,7 @@ namespace Js
 
     BOOL TypedArrayBase::HasOwnProperty(PropertyId propertyId)
     {
-        return JavascriptConversion::PropertyQueryFlagsToBoolean(HasPropertyQuery(propertyId));
+        return JavascriptConversion::PropertyQueryFlagsToBoolean(HasPropertyQuery(propertyId, nullptr /*info*/));
     }
 
     inline BOOL TypedArrayBase::CanonicalNumericIndexString(PropertyId propertyId, ScriptContext *scriptContext)
@@ -755,7 +755,7 @@ namespace Js
         return JavascriptConversion::CanonicalNumericIndexString(propertyString, &result, scriptContext);
     }
 
-    PropertyQueryFlags TypedArrayBase::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags TypedArrayBase::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         uint32 index = 0;
         ScriptContext *scriptContext = GetScriptContext();
@@ -770,7 +770,7 @@ namespace Js
             return PropertyQueryFlags::Property_NotFound_NoProto;
         }
 
-        return DynamicObject::HasPropertyQuery(propertyId);
+        return DynamicObject::HasPropertyQuery(propertyId, info);
     }
 
     BOOL TypedArrayBase::DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags)

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -102,7 +102,7 @@ namespace Js
         virtual DescriptorFlags GetSetter(PropertyId propertyId, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override;
-        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(Js::PropertyId propertyId) override;
         virtual PropertyQueryFlags GetPropertyQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Js::Var originalInstance, Js::JavascriptString* propertyNameString, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/DeferredTypeHandler.h
+++ b/lib/Runtime/Types/DeferredTypeHandler.h
@@ -93,7 +93,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
         virtual bool EnsureObjectReady(DynamicObject* instance) override;
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -247,7 +247,7 @@ namespace Js
     }
 
     template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 _inlineSlotCapacity, uint16 _offsetOfInlineSlots>
-    BOOL DeferredTypeHandler<initializer, DeferredTypeFilter, isPrototypeTemplate, _inlineSlotCapacity, _offsetOfInlineSlots>::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
+    BOOL DeferredTypeHandler<initializer, DeferredTypeFilter, isPrototypeTemplate, _inlineSlotCapacity, _offsetOfInlineSlots>::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
         if (noRedecl != nullptr)
         {
@@ -264,7 +264,7 @@ namespace Js
             return TRUE;
         }
 
-        return GetCurrentTypeHandler(instance)->HasProperty(instance, propertyId, noRedecl);
+        return GetCurrentTypeHandler(instance)->HasProperty(instance, propertyId, noRedecl, info);
     }
 
     template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 _inlineSlotCapacity, uint16 _offsetOfInlineSlots>

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -136,16 +136,7 @@ namespace Js
                 if (dataSlot != NoSlots && (attribs & PropertyWritable))
                 {
                     PropertyValueInfo::SetCacheInfo(info, propertyString, propertyString->GetLdElemInlineCache(), false);
-                    SetPropertyValueInfo(info, instance, dataSlot, descriptor.Attributes);
-                    if (descriptor.IsOrMayBecomeFixed())
-                    {
-                        PropertyValueInfo::DisableStoreFieldCache(info);
-                    }
-                    if (descriptor.Attributes & PropertyDeleted)
-                    {
-                        // letconst shadowing a deleted property. don't bother to cache
-                        PropertyValueInfo::SetNoCache(info, instance);
-                    }
+                    SetPropertyValueInfo(info, instance, dataSlot, &descriptor);
                 }
                 else
                 {
@@ -407,20 +398,20 @@ namespace Js
     }
 
     template <typename T>
-    BOOL DictionaryTypeHandlerBase<T>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl)
+    BOOL DictionaryTypeHandlerBase<T>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
-        return HasProperty_Internal<false>(instance, propertyId, noRedecl, nullptr, nullptr);
+        return HasProperty_Internal<false>(instance, propertyId, noRedecl, info, nullptr, nullptr);
     }
 
     template <typename T>
     BOOL DictionaryTypeHandlerBase<T>::HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
-        return HasProperty_Internal<true>(instance, propertyId, noRedecl, pDeclaredProperty, pNonconfigurableProperty);
+        return HasProperty_Internal<true>(instance, propertyId, noRedecl, nullptr /*info*/, pDeclaredProperty, pNonconfigurableProperty);
     }
 
     template <typename T>
     template <bool allowLetConstGlobal>
-    BOOL DictionaryTypeHandlerBase<T>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
+    BOOL DictionaryTypeHandlerBase<T>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, _Inout_opt_ PropertyValueInfo* info, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
         // HasProperty is called with NoProperty in JavascriptDispatch.cpp to for undeferral of the
         // deferred type system that DOM objects use.  Allow NoProperty for this reason, but only
@@ -450,6 +441,23 @@ namespace Js
             if (pNonconfigurableProperty && !(descriptor->Attributes & PropertyConfigurable))
             {
                 *pNonconfigurableProperty = true;
+            }
+            if (info)
+            {
+                T dataSlot = descriptor->template GetDataPropertyIndex<allowLetConstGlobal>();
+                if (dataSlot != NoSlots)
+                {
+                    SetPropertyValueInfo(info, instance, dataSlot, descriptor);
+                }
+                else if (descriptor->GetGetterPropertyIndex() != NoSlots)
+                {
+                    // PropertyAttributes is only one byte so it can't carry out data about whether this is an accessor.
+                    // Accessors must be cached differently than normal properties, so if we want to cache this we must
+                    // do so here rather than in the caller. However, caching here would require passing originalInstance and 
+                    // requestContext through a wide variety of call paths to this point (like we do for GetProperty), for
+                    // very little improvement. For now, just block caching this case.
+                    PropertyValueInfo::SetNoCache(info, instance);
+                }
             }
             return true;
         }
@@ -526,21 +534,12 @@ namespace Js
         if (dataSlot != NoSlots)
         {
             *value = instance->GetSlot(dataSlot);
-            SetPropertyValueInfo(info, instance, dataSlot, descriptor->Attributes);
-            if (descriptor->IsOrMayBecomeFixed())
-            {
-                PropertyValueInfo::DisableStoreFieldCache(info);
-            }
-            if (descriptor->Attributes & PropertyDeleted)
-            {
-                // letconst shadowing a deleted property. don't bother to cache
-                PropertyValueInfo::SetNoCache(info, instance);
-            }
+            SetPropertyValueInfo(info, instance, dataSlot, descriptor);
         }
         else if (descriptor->GetGetterPropertyIndex() != NoSlots)
         {
             // We must update cache before calling a getter, because it can invalidate something. Bug# 593815
-            SetPropertyValueInfo(info, instance, descriptor->GetGetterPropertyIndex(), descriptor->Attributes);
+            SetPropertyValueInfoNonFixed(info, instance, descriptor->GetGetterPropertyIndex(), descriptor->Attributes);
             CacheOperators::CachePropertyReadForGetter(info, originalInstance, propertyT, requestContext);
             PropertyValueInfo::SetNoCache(info, instance); // we already cached getter, so we don't have to do it once more
 
@@ -598,14 +597,28 @@ namespace Js
     }
 
     template <typename T>
-    void DictionaryTypeHandlerBase<T>::SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, PropertyAttributes attributes, InlineCacheFlags flags)
+    void DictionaryTypeHandlerBase<T>::SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, DictionaryPropertyDescriptor<T>* descriptor)
+    {
+        SetPropertyValueInfoNonFixed(info, instance, propIndex, descriptor->Attributes);
+        if (descriptor->IsOrMayBecomeFixed())
+        {
+            PropertyValueInfo::DisableStoreFieldCache(info);
+        }
+        if (descriptor->Attributes & PropertyDeleted)
+        {
+            // letconst shadowing a deleted property. don't bother to cache
+            PropertyValueInfo::SetNoCache(info, instance);
+        }
+    }
+
+    template <typename T>
+    void DictionaryTypeHandlerBase<T>::SetPropertyValueInfoNonFixed(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, PropertyAttributes attributes, InlineCacheFlags flags)
     {
         PropertyValueInfo::Set(info, instance, propIndex, attributes, flags);
     }
 
-
     template <>
-    void DictionaryTypeHandlerBase<BigPropertyIndex>::SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, BigPropertyIndex propIndex, PropertyAttributes attributes, InlineCacheFlags flags)
+    void DictionaryTypeHandlerBase<BigPropertyIndex>::SetPropertyValueInfoNonFixed(PropertyValueInfo* info, RecyclableObject* instance, BigPropertyIndex propIndex, PropertyAttributes attributes, InlineCacheFlags flags)
     {
         PropertyValueInfo::SetNoCache(info, instance);
     }
@@ -673,7 +686,7 @@ namespace Js
         else if (descriptor->GetSetterPropertyIndex() != NoSlots)
         {
             *setterValue=((DynamicObject*)instance)->GetSlot(descriptor->GetSetterPropertyIndex());
-            SetPropertyValueInfo(info, instance, descriptor->GetSetterPropertyIndex(), descriptor->Attributes, InlineCacheSetterFlag);
+            SetPropertyValueInfoNonFixed(info, instance, descriptor->GetSetterPropertyIndex(), descriptor->Attributes, InlineCacheSetterFlag);
             return Accessor;
         }
         return None;
@@ -770,7 +783,7 @@ namespace Js
             // when overwriting this property and correctly invalidate any JIT-ed code that hard-coded this method.
             if (!descriptor->IsOrMayBecomeFixed())
             {
-                SetPropertyValueInfo(info, instance, dataSlotAllowLetConstGlobal, GetLetConstGlobalPropertyAttributes<allowLetConstGlobal>(descriptor->Attributes));
+                SetPropertyValueInfoNonFixed(info, instance, dataSlotAllowLetConstGlobal, GetLetConstGlobalPropertyAttributes<allowLetConstGlobal>(descriptor->Attributes));
             }
             else
             {
@@ -787,11 +800,11 @@ namespace Js
             T dataSlot = descriptor->template GetDataPropertyIndex<false>();
             if (dataSlot != NoSlots)
             {
-                SetPropertyValueInfo(info, instance, dataSlot, descriptor->Attributes);
+                SetPropertyValueInfoNonFixed(info, instance, dataSlot, descriptor->Attributes);
             }
             else if (descriptor->GetSetterPropertyIndex() != NoSlots)
             {
-                SetPropertyValueInfo(info, instance, descriptor->GetSetterPropertyIndex(), descriptor->Attributes, InlineCacheSetterFlag);
+                SetPropertyValueInfoNonFixed(info, instance, descriptor->GetSetterPropertyIndex(), descriptor->Attributes, InlineCacheSetterFlag);
             }
         }
         SetPropertyUpdateSideEffect(instance, propertyId, value, SideEffects_Any);
@@ -2192,7 +2205,7 @@ namespace Js
         else
 #endif
         {
-            SetPropertyValueInfo(info, instance, index, attributes);
+            SetPropertyValueInfoNonFixed(info, instance, index, attributes);
         }
 
         // Always invalidate prototype caches when we add a property.  Previously, we only did this if the current

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -85,7 +85,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
 
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -225,10 +225,11 @@ namespace Js
 
         BigDictionaryTypeHandler* ConvertToBigDictionaryTypeHandler(DynamicObject* instance);
 
-        void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, PropertyAttributes attributes, InlineCacheFlags flags = InlineCacheNoFlags);
+        void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, DictionaryPropertyDescriptor<T>* descriptor);
+        void SetPropertyValueInfoNonFixed(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, PropertyAttributes attributes, InlineCacheFlags flags = InlineCacheNoFlags);
 
         template<bool allowLetConstGlobal>
-        inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
+        inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, _Inout_opt_ PropertyValueInfo* info, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
         template<bool allowLetConstGlobal>
         inline PropertyIndex GetPropertyIndex_Internal(PropertyRecord const* propertyRecord);
         template<bool allowLetConstGlobal>

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -227,7 +227,7 @@ namespace Js
         virtual PropertyId GetPropertyId(PropertyIndex index) override;
         virtual PropertyId GetPropertyId(BigPropertyIndex index) override;
         PropertyIndex GetPropertyIndex(PropertyId propertyId) sealed;
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -243,12 +243,12 @@ namespace Js
         return GetTypeHandler()->GetPropertyIndex(this->GetScriptContext()->GetPropertyName(propertyId));
     }
 
-    PropertyQueryFlags DynamicObject::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags DynamicObject::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         // HasProperty can be invoked with propertyId = NoProperty in some cases, namely cross-thread and DOM
         // This is done to force creation of a type handler in case the type handler is deferred
         Assert(!Js::IsInternalPropertyId(propertyId) || propertyId == Js::Constants::NoProperty);
-        return JavascriptConversion::BooleanToPropertyQueryFlags(GetTypeHandler()->HasProperty(this, propertyId));
+        return JavascriptConversion::BooleanToPropertyQueryFlags(GetTypeHandler()->HasProperty(this, propertyId, nullptr /*pNoRedecl*/, info));
     }
 
     // HasOwnProperty and HasProperty is the same for most objects except globalobject (moduleroot as well in legacy)

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -725,7 +725,7 @@ namespace Js
     }
 
     template <class T>
-    BOOL ES5ArrayTypeHandlerBase<T>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl)
+    BOOL ES5ArrayTypeHandlerBase<T>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
         ScriptContext* scriptContext = instance->GetScriptContext();
         uint32 index;
@@ -741,7 +741,7 @@ namespace Js
             return ES5ArrayTypeHandlerBase<T>::HasItem(instance, index);
         }
 
-        return __super::HasProperty(instance, propertyId, noRedecl);
+        return __super::HasProperty(instance, propertyId, noRedecl, info);
     }
 
     template <class T>

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
@@ -158,7 +158,7 @@ namespace Js
         BOOL GetItemAccessors(ES5Array* arr, DynamicObject* instance, uint32 index, Var* getter, Var* setter);
 
     public:
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -56,7 +56,7 @@ namespace Js
     }
 #endif
 
-    BOOL MissingPropertyTypeHandler::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
+    BOOL MissingPropertyTypeHandler::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
         if (noRedecl != nullptr)
         {

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.h
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.h
@@ -31,7 +31,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -72,7 +72,7 @@ namespace Js
     }
 #endif
 
-    BOOL NullTypeHandlerBase::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
+    BOOL NullTypeHandlerBase::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
         // Check numeric propertyId only if objectArray is available
         uint32 indexVal;

--- a/lib/Runtime/Types/NullTypeHandler.h
+++ b/lib/Runtime/Types/NullTypeHandler.h
@@ -35,7 +35,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -140,7 +140,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -316,6 +316,7 @@ namespace Js
         PropertyIndex GetPropertyIndex(PropertyId propertyId);
 
         void SetSlotAndCache(DynamicObject* instance, PropertyId propertyId, PropertyRecord const * record, PropertyIndex index, Var value, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects);
+
     protected:
         bool GetSuccessor(const PathTypeSuccessorKey successorKey, RecyclerWeakReference<DynamicType> ** typeWeakRef) const;
         void SetSuccessor(DynamicType * type, const PathTypeSuccessorKey successorKey, RecyclerWeakReference<DynamicType> * typeWeakRef, ScriptContext * scriptContext);
@@ -337,6 +338,8 @@ namespace Js
         virtual PathTypeSetterSlotIndex GetSetterCount() const { return 0; }
         virtual void SetSetterSlots(PathTypeSetterSlotIndex * setters) { Assert(false); }
         virtual void SetSetterSlot(PropertyIndex propertyIndex, PathTypeSetterSlotIndex setterSlot) { Assert(false); }
+
+        void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, PropertyIndex index, ObjectSlotAttributes attributes = ObjectSlotAttr_Writable);
 
 #if ENABLE_FIXED_FIELDS
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
@@ -485,6 +488,7 @@ namespace Js
         virtual BOOL SetConfigurable(DynamicObject* instance, PropertyId propertyId, BOOL value) override;
 
         virtual int GetPropertyCountForEnum() override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetAttributesWithPropertyIndex(DynamicObject * instance, PropertyId propertyId, BigPropertyIndex index, PropertyAttributes * attributes) override;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -334,7 +334,7 @@ namespace Js
             /* TODO-ERROR: args.Info.Count > 0? args[0] : nullptr); */);
     }
 
-    PropertyQueryFlags RecyclableObject::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags RecyclableObject::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         return PropertyQueryFlags::Property_NotFound;
     }

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -292,7 +292,7 @@ namespace Js {
         virtual PropertyId GetPropertyId(BigPropertyIndex index) { return Constants::NoProperty; }
         virtual PropertyIndex GetPropertyIndex(PropertyId propertyId) { return Constants::NoSlot; }
         virtual int GetPropertyCount() { return 0; }
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId);
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info);
         virtual BOOL HasOwnProperty( PropertyId propertyId);
         virtual BOOL HasOwnPropertyNoHostObject( PropertyId propertyId);
         virtual BOOL HasOwnPropertyCheckNoRedecl( PropertyId propertyId) { Assert(FALSE); return FALSE; }

--- a/lib/Runtime/Types/RecyclableObject.inl
+++ b/lib/Runtime/Types/RecyclableObject.inl
@@ -69,7 +69,7 @@ namespace Js
 
     inline BOOL RecyclableObject::HasProperty(PropertyId propertyId)
     {
-        return JavascriptConversion::PropertyQueryFlagsToBoolean(HasPropertyQuery(propertyId));
+        return JavascriptConversion::PropertyQueryFlagsToBoolean(HasPropertyQuery(propertyId, nullptr /*info*/));
     }
 
     inline BOOL RecyclableObject::GetProperty(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -125,7 +125,7 @@ namespace Js
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, BigPropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
 
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -270,7 +270,7 @@ namespace Js
         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
 
         template <bool allowLetConstGlobal>
-        inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
+        inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, _Inout_opt_ PropertyValueInfo* info, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
         template <bool allowLetConstGlobal>
         inline PropertyIndex GetPropertyIndex_Internal(const PropertyRecord* propertyRecord);
         template <bool allowLetConstGlobal>
@@ -293,7 +293,8 @@ namespace Js
         BOOL SetProperty_JavascriptString(DynamicObject* instance, JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info, TemplateParameter::Box<JavascriptString*>);
 
         BigSimpleDictionaryTypeHandler* ConvertToBigSimpleDictionaryTypeHandler(DynamicObject* instance);
-        void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, TPropertyIndex propIndex, PropertyAttributes attributes, InlineCacheFlags flags = InlineCacheNoFlags);
+        void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, SimpleDictionaryPropertyDescriptor<TPropertyIndex>* descriptor);
+        void SetPropertyValueInfoNonFixed(PropertyValueInfo* info, RecyclableObject* instance, TPropertyIndex propIndex, PropertyAttributes attributes, InlineCacheFlags flags = InlineCacheNoFlags);
 
         BOOL PreventExtensionsInternal(DynamicObject* instance);
         BOOL SealInternal(DynamicObject* instance);

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -371,7 +371,7 @@ namespace Js
 #endif
 
     template<size_t size>
-    BOOL SimpleTypeHandler<size>::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
+    BOOL SimpleTypeHandler<size>::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl, _Inout_opt_ PropertyValueInfo* info)
     {
         if (noRedecl != nullptr)
         {
@@ -389,6 +389,11 @@ namespace Js
                 if (noRedecl && descriptors[i].Attributes & PropertyNoRedecl)
                 {
                     *noRedecl = true;
+                }
+
+                if (info)
+                {
+                    PropertyValueInfo::Set(info, instance, static_cast<PropertyIndex>(i), descriptors[i].Attributes);
                 }
                 return true;
             }

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -41,7 +41,7 @@ namespace Js
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
 #endif
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -26,7 +26,7 @@ namespace Js
         uint GetArgumentSpreadCount()  const { return iteratorIndices ? iteratorIndices->Count() : 0; }
 
         // A SpreadArgument should never call the Functions defined below this comment
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override { AssertAndFailFast();  return PropertyQueryFlags::Property_NotFound; };
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override { AssertAndFailFast();  return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL HasOwnProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -441,7 +441,7 @@ namespace Js
 #endif
 
         virtual bool EnsureObjectReady(DynamicObject* instance) { return true; }
-        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *pNoRedecl = nullptr) = 0;
+        virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *pNoRedecl = nullptr, _Inout_opt_ PropertyValueInfo* info = nullptr) = 0;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) = 0;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) = 0;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) = 0;

--- a/lib/Runtime/Types/TypePropertyCache.h
+++ b/lib/Runtime/Types/TypePropertyCache.h
@@ -58,6 +58,7 @@ namespace Js
         bool TryGetIndexForStore(const PropertyId id, PropertyIndex *const index, bool *const isInlineSlot) const;
 
     public:
+        template <bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
         bool TryGetProperty(const bool checkMissing, RecyclableObject *const propertyObject, const PropertyId propertyId, Var *const propertyValue, ScriptContext *const requestContext, PropertyCacheOperationInfo *const operationInfo, PropertyValueInfo *const propertyValueInfo);
         bool TrySetProperty(RecyclableObject *const object, const PropertyId propertyId, Var propertyValue, ScriptContext *const requestContext, PropertyCacheOperationInfo *const operationInfo, PropertyValueInfo *const propertyValueInfo);
 

--- a/lib/Runtime/Types/WithScopeObject.cpp
+++ b/lib/Runtime/Types/WithScopeObject.cpp
@@ -23,7 +23,7 @@ namespace Js
         return static_cast<WithScopeObject*>(aValue);
     }
 
-    PropertyQueryFlags WithScopeObject::HasPropertyQuery(PropertyId propertyId)
+    PropertyQueryFlags WithScopeObject::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)
     {
         return JavascriptConversion::BooleanToPropertyQueryFlags(JavascriptOperators::HasPropertyUnscopables(wrappedObject, propertyId));
     }

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -29,7 +29,7 @@ namespace Js
             static WithScopeObject* FromVar(Var value);
             static WithScopeObject* UnsafeFromVar(Var value);
             RecyclableObject *GetWrappedObject() { return wrappedObject; }
-            virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+            virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
             virtual BOOL HasOwnProperty(PropertyId propertyId) override;
             virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
             virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;


### PR DESCRIPTION
This change allows the runtime call for `str in obj` to use the same property record cache that we use for loading `obj[str]`. This makes the `in` operator faster in some common cases, and also populates the cache for an upcoming change which will lower fast-path code for `in` on PropertyStrings and Symbols.

With this change, the Elm test in Speedometer improves about 3%, and time for the following microbenchmark drops from about 440 ms to about 240 ms:

```javascript
function compare(a, b) {
    let diffs = 0;
    for (const aKey in a) {
        if (!(aKey in b)) {
            ++diffs;
            continue;
        }
        if (a[aKey] !== b[aKey]) {
            ++diffs;
            continue;
        }
    }
    for (const bKey in b) {
        if (!(bKey in a)) {
            ++diffs;
            continue;
        }
    }
    return diffs;
}

const before = {
    a: 1,
    b: "hello",
    c: 6e60,
    d: {},
    e: []
};

const after = {
    a: 1,
    b: "goodbye",
    d: before.d,
    e: [],
    f: 3
};

const now = Date.now();
let total = 0;
for (let i = 0; i < 1e6; ++i) {
    total += compare(before, after);
}
print(Date.now() - now);
```