### PR TITLE
Improve compatibility with Clang for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Build/swum-cache.txt
 Build/VCBuild.Lite/
 Build/VCBuild.NoJIT/
 Build/VCBuild.SWB/
+Build/VCBuild.ClangCL/
 Build/VCBuild/
 buildchk.*
 buildfre.*

--- a/Build/Chakra.Build.Clang.Default.props
+++ b/Build/Chakra.Build.Clang.Default.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Not officially supported! Configuration to build with clang on windows -->
-  <PropertyGroup Condition="'$(Clang)'=='ClangCL'">
+  <PropertyGroup Condition="'$(Clang)'=='ClangCL' And '$(ForceMSVC)'==''">
     <PlatformToolset>LLVM-vs2014</PlatformToolset>
   </PropertyGroup>
 </Project>

--- a/Build/Chakra.Build.Clang.props
+++ b/Build/Chakra.Build.Clang.props
@@ -61,7 +61,9 @@
         -Wno-microsoft-extra-qualification
         -Wno-microsoft-default-arg-redefinition
         -Wno-microsoft-exception-spec
-        -v
+        -Wno-clang-cl-pch
+        -Wno-unused-lambda-capture
+        -Wno-pragma-pack
       </AdditionalOptions>
       <!-- Clang doesn't support code view information, but will generate line number.  It only support /Z7 generation -->
       <DebugInformationFormat>OldStyle</DebugInformationFormat>

--- a/bin/NativeTests/stdafx.h
+++ b/bin/NativeTests/stdafx.h
@@ -40,7 +40,7 @@ if (!(exp)) \
 
 #define Assert(exp)             AssertMsg(exp, #exp)
 #define _JSRT_
-#include "chakracore.h"
+#include "ChakraCore.h"
 #include "Core/CommonTypedefs.h"
 
 #include <FileLoadHelpers.h>

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -103,13 +103,6 @@
 
 #define get_cpuid __cpuid
 
-#if defined(__clang__)
-__forceinline void  __int2c()
-{
-    __asm int 0x2c
-}
-#endif
-
 #else // !_WIN32
 
 #define USING_PAL_STDLIB 1
@@ -499,7 +492,7 @@ DWORD __cdecl CharUpperBuffW(const char16* lpsz, DWORD  cchLength);
 #endif
 
 // `typename QualifiedName` declarations outside of template code not supported before MSVC 2015 update 1
-#if defined(_MSC_VER) && _MSC_VER < 1910
+#if defined(_MSC_VER) && _MSC_VER < 1910 && !defined(__clang__)
 #define _TYPENAME
 #else
 #define _TYPENAME typename

--- a/lib/Common/Core/EtwTraceCore.h
+++ b/lib/Common/Core/EtwTraceCore.h
@@ -78,7 +78,7 @@ CompileAssert(false)
 #pragma prefast(push)
 #pragma prefast(disable:__WARNING_USING_UNINIT_VAR, "The ETW data generated from the manifest includes a default null function which uses unintialized memory.")
 
-#include <microsoft-scripting-chakra-instrumentationevents.h>
+#include <Microsoft-Scripting-Chakra-InstrumentationEvents.h>
 #ifdef NTBUILD
 #include <ieresp_mshtml.h>
 #include <microsoft-scripting-jscript9.internalevents.h>

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
-#ifdef __clang__
+#if defined(__clang__) && !defined(_MSC_VER)
 #include <cxxabi.h>
 #endif
 
@@ -882,7 +882,7 @@ void HeapBlock::PrintVerifyMarkFailure(Recycler* recycler, char* objectAddress, 
     if (Recycler::DoProfileAllocTracker())
     {
         // need CheckMemoryLeak or KeepRecyclerTrackData flag to have the tracker data and show following detailed info
-#ifdef __clang__
+#if  defined(__clang__) && !defined(_MSC_VER)
         auto getDemangledName = [](const type_info* typeinfo) ->const char*
         {
             int status;

--- a/lib/Common/Memory/HeapBucketStats.cpp
+++ b/lib/Common/Memory/HeapBucketStats.cpp
@@ -3,9 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
-#ifdef __clang__
-#include <cxxabi.h>
-#endif
 
 #if ENABLE_MEM_STATS
 MemStats::MemStats()

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -157,7 +157,7 @@ SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::SetAttributes(void * addre
     // but recycler visited block allows traced only objects; it also unconditionally bumps the heap info
     // live/new finalizable object counts which will become unbalance if FinalizeBit is not set).
     // We do want the grandparent class behavior though, which actually sets the ObjectInfo bits.
-    SmallFinalizableHeapBlockT<TBlockAttributes>::Base::SetAttributes(address, attributes);
+    SmallNormalHeapBlockT<TBlockAttributes>::SetAttributes(address, attributes);
 
     if (attributes & FinalizeBit)
     {

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -177,7 +177,7 @@ public:
         return block ? block->template AsRecyclerVisitedHostBlock<TBlockAttributes>() : nullptr;
     }
 
-    virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) override sealed
+    virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) sealed
     {
         return this->template FindHeapObjectImpl<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>>(objectAddress, recycler, flags, heapObject);
     }

--- a/lib/JITIDL/Chakra.JITIDL.vcxproj
+++ b/lib/JITIDL/Chakra.JITIDL.vcxproj
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This is a work-around for a bug in clang-cl. Clang-cl purports to support a /P option to preprocess to a file, but this does not work, so we have to find a different cl on the system. -->
+  <PropertyGroup>
+    <ForceMSVC>true</ForceMSVC>
+  </PropertyGroup>
   <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
   <PropertyGroup Label="Globals">

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -144,9 +144,11 @@ protected:
 
 #pragma warning(push)
 #pragma warning(error: 4440)
+CLANG_WNO_BEGIN("-Wignored-attributes")
 // MSVC will give warning C4440 in case of calling convention redefinition
 template<typename F> void EnsureStdcall(F*) { typedef F __stdcall* T; }
 template<typename F> void EnsureCdecl(F*) { typedef F __cdecl* T; }
+CLANG_WNO_END
 #pragma warning(pop)
 template<typename T>
 uintptr_t ShiftCdeclAddr(const ThreadContextInfo*const context, T* address)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3692,15 +3692,19 @@ namespace Js
         case AsmJsRetType::Uint8x16:
 #if _WIN32 //WASM.SIMD ToDo: Enable thunk for Xplat
 #if _M_X64
+#if !defined(__clang__)
             X86SIMDValue simdVal;
             simdVal.m128_value = JavascriptFunction::CallAsmJsFunction<__m128>(function, entrypointInfo->jsMethod, m_outParams, alignedArgsSize, reg);
             m_localSimdSlots[returnReg] = X86SIMDValue::ToSIMDValue(simdVal);
 #else
+            AssertOrFailFastMsg(false, "This particular path causes linking issues in clang on windows; potential difference in name mangling?");
+#endif // !defined(__clang__)
+#else
             m_localSimdSlots[returnReg] = JavascriptFunction::CallAsmJsFunction<AsmJsSIMDValue>(function, entrypointInfo->jsMethod, m_outParams, alignedArgsSize, reg);
-#endif
-#endif
+#endif // _M_X64
+#endif // _WIN32
             break;
-#endif
+#endif // ENABLE_WASM_SIMD
         default:
             Assume(UNREACHED);
         }

--- a/lib/Runtime/Library/MathLibrary.cpp
+++ b/lib/Runtime/Library/MathLibrary.cpp
@@ -8,10 +8,6 @@
 
 #include <math.h>
 
-#if defined(_M_IX86) || defined(_M_X64)
-#pragma intrinsic(_mm_round_sd)
-#endif
-
 const LPCWSTR UCrtC99MathApis::LibraryName = _u("api-ms-win-crt-math-l1-1-0.dll");
 
 void UCrtC99MathApis::Ensure()

--- a/lib/wabt/src/literal.cc
+++ b/lib/wabt/src/literal.cc
@@ -37,7 +37,6 @@ struct FloatTraitsBase<float> {
   typedef uint32_t Uint;
   static constexpr int kBits = sizeof(Uint) * 8;
   static constexpr int kSigBits = 23;
-  static constexpr float kHugeVal = HUGE_VALF;
   static constexpr int kMaxHexBufferSize = WABT_MAX_FLOAT_HEX;
 
   static float Strto(const char* s, char** endptr) { return strtof(s, endptr); }
@@ -48,7 +47,6 @@ struct FloatTraitsBase<double> {
   typedef uint64_t Uint;
   static constexpr int kBits = sizeof(Uint) * 8;
   static constexpr int kSigBits = 52;
-  static constexpr float kHugeVal = HUGE_VAL;
   static constexpr int kMaxHexBufferSize = WABT_MAX_DOUBLE_HEX;
 
   static double Strto(const char* s, char** endptr) {
@@ -163,7 +161,7 @@ Result FloatParser<T>::ParseFloat(const char* s,
   char* endptr;
   Float value = Traits::Strto(buffer, &endptr);
   if (endptr != buffer_end ||
-      (value == Traits::kHugeVal || value == -Traits::kHugeVal)) {
+      (value == (1.0e300 * 1.0e300) || value == -(1.0e300 * 1.0e300))) {
     return Result::Error;
   }
 


### PR DESCRIPTION
This changeset removes some of the impediments to building ChakraCore with clang on windows. This is still not a supported configuration, just a less buggy one. There's still known failures with the staticinterpreterthunk in this configuration, and building the jit idl takes manual configuration of the relevant project file due to a clang bug.