### PR TITLE
OS#16078067: Handle LdLen_A in IRBuilder:BuildElementCP

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -4335,6 +4335,7 @@ IRBuilder::BuildElementCP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot insta
     {
     case Js::OpCode::LdFldForTypeOf:
     case Js::OpCode::LdFld:
+    case Js::OpCode::LdLen_A:
         if (fieldSymOpnd->IsPropertySymOpnd())
         {
             fieldSymOpnd->AsPropertySymOpnd()->TryDisableRuntimePolymorphicCache();


### PR DESCRIPTION
BuildProfiledElementCP handles ProfiledLdLen_A, but the non-profiled variant was not being handled when it occured.
