### PR TITLE
[MSFT 16280281]: Fix errors when switching between data and accessor property with PathTypeHandler

### DIFF
--- a/test/es5/objlitgetset2.js
+++ b/test/es5/objlitgetset2.js
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function __getProperties(obj) {
+  let properties = [];
+  for (let name of Object.getOwnPropertyNames(obj)) {
+ properties.push(name);
+  }
+  return properties;
+}
+function __getRandomObject() {
+}
+function __getRandomProperty(obj, seed) {
+  let properties = __getProperties(obj);
+  return properties[seed % properties.length];
+}
+  (function __f_2672() {
+      __v_13851 = {
+        get p() {
+        }
+      }
+      __v_13862 = {
+        get p() {
+        },
+        p: 2,
+        set p(__v_13863) { WScript.Echo('pass'); this.q = __v_13863},
+        p:9,
+        q:3,
+        set p(__v_13863) { WScript.Echo('pass'); this.q = __v_13863},        
+      };
+      __v_13862.p = 0;
+      if (__v_13862.q !== 0) WScript.Echo(__v_13862.q);
+  })();
+  __v_13851[__getRandomProperty(__v_13851, 483779)] = __getRandomObject();

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -79,6 +79,11 @@
   </test>
   <test>
     <default>
+      <files>ObjLitGetSet2.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>ObjLitGetSetParseOnly.js</files>
       <baseline>ObjLitGetSetParseOnly.baseline</baseline>
     </default>


### PR DESCRIPTION
1. Don't cache the result of an InitFld that converts an accessor property to a data property, as this transition doesn't match the behavior of a normal set. It must always go to the runtime. 2. Re-use the existing setter slot when we go from accessor property to data and back to accessor.