### PR TITLE
Speed up `in` operations with PropertyString or Symbol keys, part 2

### DIFF
--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -156,7 +156,8 @@ private:
     bool            GenerateLdThisCheck(IR::Instr * instr);
     bool            GenerateLdThisStrict(IR::Instr * instr);
     bool            GenerateFastIsInst(IR::Instr * instr);
-    void            GenerateFastInlineIsIn(IR::Instr * instr);
+    void            GenerateFastArrayIsIn(IR::Instr * instr);
+    void            GenerateFastObjectIsIn(IR::Instr * instr);
 
     void GenerateProtoLdFldFromFlagInlineCache(
         IR::Instr * insertBeforeInstr,
@@ -339,9 +340,11 @@ private:
     void            GenerateIsEnabledFloatArraySetElementFastPathCheck(IR::LabelInstr * isDisabledLabel, IR::Instr * const insertBeforeInstr);
     void            GenerateStringTest(IR::RegOpnd *srcReg, IR::Instr *instrInsert, IR::LabelInstr * failLabel, IR::LabelInstr * succeedLabel = nullptr, bool generateObjectCheck = true);
     void            GenerateSymbolTest(IR::RegOpnd *srcReg, IR::Instr *instrInsert, IR::LabelInstr * failLabel, IR::LabelInstr * succeedLabel = nullptr, bool generateObjectCheck = true);
+    void            GeneratePropertyStringTest(IR::RegOpnd *srcReg, IR::Instr *instrInsert, IR::LabelInstr *labelHelper, bool usePoison);
     IR::RegOpnd *   GenerateUntagVar(IR::RegOpnd * opnd, IR::LabelInstr * labelFail, IR::Instr * insertBeforeInstr, bool generateTagCheck = true);
     void            GenerateNotZeroTest( IR::Opnd * opndSrc, IR::LabelInstr * labelZero, IR::Instr * instrInsert);
     IR::Opnd *      CreateOpndForSlotAccess(IR::Opnd * opnd);
+    IR::RegOpnd *   GetRegOpnd(IR::Opnd * opnd, IR::Instr * insertInstr, Func * func, IRType type);
 
     void            GenerateSwitchStringLookup(IR::Instr * instr);
     void            GenerateSingleCharStrJumpTableLookup(IR::Instr * instr);
@@ -443,7 +446,9 @@ private:
 
     IR::IndirOpnd * GenerateFastElemIStringIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
     IR::IndirOpnd * GenerateFastElemISymbolIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
+    void            GenerateFastIsInSymbolOrStringIndex(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, IR::Opnd *dest, uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone);
     IR::IndirOpnd * GenerateFastElemISymbolOrStringIndexCommon(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, const uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper);
+    void            GenerateLookUpInIndexCache(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, IR::RegOpnd *opndSlotArray, IR::RegOpnd *opndSlotIndex, const uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper);
     bool            GenerateFastLdElemI(IR::Instr *& ldElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastStElemI(IR::Instr *& StElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastLdLen(IR::Instr *ldLen, bool *instrIsInHelperBlockRef);


### PR DESCRIPTION
This change lowers code for the `in` operator that attempts to look up properties in the cache on a PropertyString or Symbol.

With this change, time for the following microbenchmark drops from about 440 ms to about 200 ms:

```javascript
function compare(a, b) {
    let diffs = 0;
    for (const aKey in a) {
        if (!(aKey in b)) {
            ++diffs;
            continue;
        }
        if (a[aKey] !== b[aKey]) {
            ++diffs;
            continue;
        }
    }
    for (const bKey in b) {
        if (!(bKey in a)) {
            ++diffs;
            continue;
        }
    }
    return diffs;
}

const before = {
    a: 1,
    b: "hello",
    c: 6e60,
    d: {},
    e: []
};

const after = {
    a: 1,
    b: "goodbye",
    d: before.d,
    e: [],
    f: 3
};

const now = Date.now();
let total = 0;
for (let i = 0; i < 1e6; ++i) {
    total += compare(before, after);
}
print(Date.now() - now);
```

If combined together with [part 1](https://github.com/Microsoft/ChakraCore/pull/4834), time decreases further to 130 ms because the properties that miss the local cache in the lowered code hit the missing-property cache in the IsIn runtime call.

The Elm Speedometer test improves by about 9% with these two changes together (though I suspect that part 2 alone would have nearly the same impact, since that test usually compares very similar objects and likely has cached all relevant properties through ordinary loads).