### PR TITLE
Make HashTbl and Scanner an inline instance of the Parser or a stack instance instead of allocating it in the heap

### DIFF
--- a/lib/Parser/BackgroundParser.cpp
+++ b/lib/Parser/BackgroundParser.cpp
@@ -32,7 +32,8 @@ BackgroundParser::~BackgroundParser()
         static_cast<JsUtil::BackgroundJobProcessor*>(processor)->IterateBackgroundThreads([&](JsUtil::ParallelThreadData *threadData)->bool {
             if (threadData->parser)
             {
-                threadData->parser->Release();
+                // Adelete to make sure dtor are called (since the HashTbl has its NoReleaseAllocator)
+                Adelete(threadData->threadArena, threadData->parser);
                 threadData->parser = nullptr;
             }
             return false;
@@ -79,7 +80,6 @@ bool BackgroundParser::Process(JsUtil::Job *const job, JsUtil::ParallelThreadDat
         // the background thread to decommit its pages.
         threadData->parser = Anew(threadData->threadArena, Parser, this->scriptContext, backgroundItem->IsStrictMode(), &threadData->backgroundPageAllocator, true);
         threadData->pse = Anew(threadData->threadArena, CompileScriptException);
-        threadData->parser->PrepareScanner(backgroundItem->GetParseContext()->fromExternal);
     }
 
     Parser *parser = threadData->parser;
@@ -143,7 +143,8 @@ void BackgroundParser::OnDecommit(JsUtil::ParallelThreadData *threadData)
 {
     if (threadData->parser)
     {
-        threadData->parser->Release();
+        // Adelete to make sure dtor are called (since the HashTbl has its NoReleaseAllocator)
+        Adelete(threadData->threadArena, threadData->parser);
         threadData->parser = nullptr;
     }
 }

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -26,22 +26,6 @@ const HashTbl::ReservedWordInfo HashTbl::s_reservedWordInfo[tkID] =
 #include "keywords.h"
 };
 
-HashTbl * HashTbl::Create(uint cidHash)
-{
-    HashTbl * phtbl;
-
-    if (nullptr == (phtbl = HeapNewNoThrow(HashTbl)))
-        return nullptr;
-    if (!phtbl->Init(cidHash))
-    {
-        delete phtbl;  // invokes overridden operator delete
-        return nullptr;
-    }
-
-    return phtbl;
-}
-
-
 BOOL HashTbl::Init(uint cidHash)
 {
     // cidHash must be a power of two
@@ -368,11 +352,9 @@ IdentPtr HashTbl::FindExistingPid(
 {
     int32 bucketCount;
     IdentPtr pid;
-    IdentPtr *ppid = &m_prgpidName[luHash & m_luMask];
 
     /* Search the hash table for an existing match */
-    ppid = &m_prgpidName[luHash & m_luMask];
-
+    IdentPtr *ppid = &m_prgpidName[luHash & m_luMask];
     for (bucketCount = 0; nullptr != (pid = *ppid); ppid = &pid->m_pidNext, bucketCount++)
     {
         if (pid->m_luHash == luHash && (int)pid->m_cch == cch &&

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -316,13 +316,17 @@ public:
 class HashTbl
 {
 public:
-    static HashTbl * Create(uint cidHash);
-
-    void Release(void)
+    HashTbl(uint cidHash = DEFAULT_HASH_TABLE_SIZE)
     {
-        delete this;  // invokes overridden operator delete
+        AssertCanHandleOutOfMemory();
+        m_prgpidName = nullptr;
+        memset(&m_rpid, 0, sizeof(m_rpid));
+        if (!Init(cidHash))
+        {
+            Js::Throw::OutOfMemory();
+        }
     }
-
+    ~HashTbl(void) {}
 
     BOOL TokIsBinop(tokens tk, int *popl, OpCode *pnop)
     {
@@ -392,24 +396,14 @@ public:
     }
 
 private:
+    static const uint DEFAULT_HASH_TABLE_SIZE = 256;
+
     NoReleaseAllocator m_noReleaseAllocator;            // to allocate identifiers
     Ident ** m_prgpidName;        // hash table for names
 
     uint32 m_luMask;                // hash mask
     uint32 m_luCount;              // count of the number of entires in the hash table    
     IdentPtr m_rpid[tkLimKwd];
-
-    HashTbl()
-    {
-        m_prgpidName = nullptr;
-        memset(&m_rpid, 0, sizeof(m_rpid));
-    }
-    ~HashTbl(void) {}
-
-    void operator delete(void* p, size_t size)
-    {
-        HeapFree(p, size);
-    }
 
     // Called to grow the number of buckets in the table to reduce the table density.
     void Grow();

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -118,7 +118,7 @@ namespace UnifiedRegex
         , ArenaAllocator* ctAllocator
         , StandardChars<EncodedChar>* standardEncodedChars
         , StandardChars<Char>* standardChars
-        , bool isFromExternalSource
+        , bool isUtf8
 #if ENABLE_REGEX_CONFIG_OPTIONS
         , DebugWriter* w
 #endif
@@ -151,8 +151,7 @@ namespace UnifiedRegex
         , deferredIfNotUnicodeError(nullptr)
         , deferredIfUnicodeError(nullptr)
     {
-        if (isFromExternalSource)
-            this->FromExternalSource();
+        this->SetIsUtf8(isUtf8);
     }
 
     //

--- a/lib/Parser/RegexParser.h
+++ b/lib/Parser/RegexParser.h
@@ -216,7 +216,7 @@ namespace UnifiedRegex
             , ArenaAllocator* ctAllocator
             , StandardChars<EncodedChar>* standardEncodedChars
             , StandardChars<Char>* standardChars
-            , bool isFromExternalSource
+            , bool isUtf8
 #if ENABLE_REGEX_CONFIG_OPTIONS
             , DebugWriter* w
 #endif

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -180,8 +180,9 @@ protected:
     }
 
 public:
-    void FromExternalSource() { }
-    bool IsFromExternalSource() { return false; }
+    void Clear() {}
+    void SetIsUtf8(bool isUtf8) { }
+    bool IsUtf8() const { return false; }
 };
 
 template <bool nullTerminated>
@@ -197,11 +198,11 @@ protected:
     size_t m_cMultiUnits;
     utf8::DecodeOptions m_decodeOptions;
 
-    UTF8EncodingPolicyBase(): m_cMultiUnits(0), m_decodeOptions(utf8::doAllowThreeByteSurrogates) { }
+    UTF8EncodingPolicyBase() { Clear(); }
 
     static BOOL IsMultiUnitChar(OLECHAR ch) { return ch > 0x7f; }
     // Note when nullTerminated is false we still need to increment the character pointer because the scanner "puts back" this virtual null character by decrementing the pointer
-    static OLECHAR ReadFirst(EncodedCharPtr &p, EncodedCharPtr last) { return (nullTerminated || p < last) ? static_cast< OLECHAR >(*p++) : (p++, 0); }
+    static OLECHAR ReadFirst(EncodedCharPtr &p, EncodedCharPtr last) { return (nullTerminated || p < last) ? static_cast<OLECHAR>(*p++) : (p++, 0); }
 
     // "bScan" indicates if this ReadFull is part of scanning. Pass true during scanning and ReadFull will update
     // related Scanner state. The caller is supposed to sync result "p" to Scanner's current position. Pass false
@@ -210,7 +211,7 @@ protected:
     OLECHAR ReadFull(EncodedCharPtr &p, EncodedCharPtr last)
     {
         EncodedChar ch = (nullTerminated || p < last) ? *p++ : (p++, 0);
-        return !IsMultiUnitChar(ch) ? static_cast< OLECHAR >(ch) : ReadRest<bScan>(ch, p, last);
+        return !IsMultiUnitChar(ch) ? static_cast<OLECHAR>(ch) : ReadRest<bScan>(ch, p, last);
     }
 
     OLECHAR ReadSurrogatePairUpper(EncodedCharPtr &p, EncodedCharPtr last)
@@ -221,7 +222,7 @@ protected:
         return ReadRest<true>(ch, p, last);
     }
 
-    static OLECHAR PeekFirst(EncodedCharPtr p, EncodedCharPtr last) { return (nullTerminated || p < last) ? static_cast< OLECHAR >(*p) : 0; }
+    static OLECHAR PeekFirst(EncodedCharPtr p, EncodedCharPtr last) { return (nullTerminated || p < last) ? static_cast<OLECHAR>(*p) : 0; }
 
     OLECHAR PeekFull(EncodedCharPtr p, EncodedCharPtr last)
     {
@@ -273,7 +274,7 @@ protected:
         if (m_cMultiUnits == 0 && offset <= currentCharacterOffset) return offset;
 
         // Use local decode options
-        utf8::DecodeOptions decodeOptions = IsFromExternalSource() ? utf8::doDefault : utf8::doAllowThreeByteSurrogates;
+        utf8::DecodeOptions decodeOptions = IsUtf8() ? utf8::doDefault : utf8::doAllowThreeByteSurrogates;
 
         if (offset > currentCharacterOffset)
         {
@@ -297,11 +298,26 @@ protected:
         utf8::DecodeUnitsInto(pch, start, end, m_decodeOptions);
     }
 
-
 public:
+    void Clear()
+    {
+        m_cMultiUnits = 0;
+        m_decodeOptions = utf8::doAllowThreeByteSurrogates;
+    }
+
     // If we get UTF8 source buffer, turn off doAllowThreeByteSurrogates but allow invalid WCHARs without replacing them with replacement 'g_chUnknown'.
-    void FromExternalSource() { m_decodeOptions = (utf8::DecodeOptions)(m_decodeOptions & ~utf8::doAllowThreeByteSurrogates | utf8::doAllowInvalidWCHARs); }
-    bool IsFromExternalSource() { return (m_decodeOptions & utf8::doAllowThreeByteSurrogates) == 0; }
+    void SetIsUtf8(bool isUtf8)
+    {
+        if (isUtf8)
+        {
+            m_decodeOptions = (utf8::DecodeOptions)(m_decodeOptions & ~utf8::doAllowThreeByteSurrogates | utf8::doAllowInvalidWCHARs);
+        }
+        else
+        {
+            m_decodeOptions = (utf8::DecodeOptions)(m_decodeOptions & ~utf8::doAllowInvalidWCHARs | utf8::doAllowThreeByteSurrogates);
+        }
+    }
+    bool IsUtf8() const { return (m_decodeOptions & utf8::doAllowThreeByteSurrogates) == 0; }
 };
 
 typedef UTF8EncodingPolicyBase<false> NotNullTerminatedUTF8EncodingPolicy;
@@ -362,19 +378,13 @@ class Scanner : public IScanner, public EncodingPolicy
     typedef typename EncodingPolicy::EncodedCharPtr EncodedCharPtr;
 
 public:
-    static Scanner * Create(Parser* parser, HashTbl *phtbl, Token *ptoken, Js::ScriptContext *scriptContext)
-    {
-        return HeapNewNoThrow(Scanner, parser, phtbl, ptoken, scriptContext);
-    }
-    void Release(void)
-    {
-        delete this;  // invokes overridden operator delete
-    }
+    Scanner(Parser* parser, Token *ptoken, Js::ScriptContext *scriptContext);
+    ~Scanner(void);
 
     tokens Scan();
     tokens ScanNoKeywords();
     tokens ScanForcingPid();
-    void SetText(EncodedCharPtr psz, size_t offset, size_t length, charcount_t characterOffset, ULONG grfscr, ULONG lineNumber = 0);
+    void SetText(EncodedCharPtr psz, size_t offset, size_t length, charcount_t characterOffset, bool isUtf8, ULONG grfscr, ULONG lineNumber = 0);
 #if ENABLE_BACKGROUND_PARSING
     void PrepareForBackgroundParse(Js::ScriptContext *scriptContext);
 #endif
@@ -480,7 +490,6 @@ public:
     // have if the entire file was converted to Unicode (UTF16-LE).
     charcount_t IchMinTok(void) const
     {
-
         Assert(m_pchMinTok - m_pchBase >= 0);
         Assert(m_pchMinTok - m_pchBase <= LONG_MAX);
         Assert(static_cast<charcount_t>(m_pchMinTok - m_pchBase) >= m_cMinTokMultiUnits);
@@ -546,7 +555,6 @@ public:
     // Returns the character offset within the stream of the first character on the current line.
     charcount_t IchMinLine(void) const
     {
-
         Assert(m_pchMinLine - m_pchBase >= 0);
         Assert(m_pchMinLine - m_pchBase <= LONG_MAX);
         Assert(static_cast<charcount_t>(m_pchMinLine - m_pchBase) >= m_cMinLineMultiUnits);
@@ -554,9 +562,7 @@ public:
     }
 
     // Returns the current line number
-    charcount_t LineCur(void) { return m_line; }
-
-    tokens ErrorToken() { return m_errorToken; }
+    charcount_t LineCur(void) const { return m_line; }
 
     void SetCurrentCharacter(charcount_t offset, ULONG lineNumber = 0)
     {
@@ -586,7 +592,7 @@ public:
     }
 
     virtual HRESULT SysAllocErrorLine(int32 ichMinLine, __out BSTR* pbstrLine);
-    charcount_t UpdateLine(int32 &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd);
+
     class TemporaryBuffer
     {
         friend Scanner<EncodingPolicy>;
@@ -608,7 +614,7 @@ public:
             m_cchMax = _countof(m_rgbInit) / sizeof(OLECHAR);
             m_ichCur = 0;
         }
-
+        
         ~TemporaryBuffer()
         {
             if (m_prgch != (OLECHAR*)m_rgbInit)
@@ -617,9 +623,20 @@ public:
             }
         }
 
-        void Init()
+        void Reset()
         {
             m_ichCur = 0;
+        }
+
+        void Clear()
+        {
+            if (m_prgch != (OLECHAR*)m_rgbInit)
+            {
+                free(m_prgch);
+                m_prgch = (OLECHAR*)m_rgbInit;
+                m_cchMax = _countof(m_rgbInit) / sizeof(OLECHAR);
+            }
+            Reset();
         }
 
         void AppendCh(uint ch)
@@ -643,6 +660,7 @@ public:
             }
         }
 
+    private:
         void Grow()
         {
             Assert(m_pscanner != nullptr);
@@ -678,14 +696,12 @@ public:
     void Capture(_Out_ RestorePoint* restorePoint, uint functionIdIncrement, size_t lengthDecr);
     void SeekTo(const RestorePoint& restorePoint, uint *nextFunctionId);
 
-    void SetNextStringTemplateIsTagged(BOOL value)
-    {
-        this->m_fNextStringTemplateIsTagged = value;
-    }
+    void Clear();
 
+    HashTbl * GetHashTbl() { return &m_htbl; }
 private:
     Parser *m_parser;
-    HashTbl *m_phtbl;
+    HashTbl m_htbl;
     Token *m_ptoken;
     EncodedCharPtr m_pchBase;          // beginning of source
     EncodedCharPtr m_pchLast;          // The end of source
@@ -702,8 +718,7 @@ private:
     bool m_OctOrLeadingZeroOnLastTKNumber :1;
     bool m_EscapeOnLastTkStrCon:1;
     BOOL m_fNextStringTemplateIsTagged:1;   // the next string template scanned has a tag (must create raw strings)
-    BYTE m_DeferredParseFlags:2;            // suppressStrPid and suppressIdPid
-    charcount_t m_ichCheck;             // character at which completion is to be computed.
+    BYTE m_DeferredParseFlags:2;            // suppressStrPid and suppressIdPid    
     bool es6UnicodeMode;                // True if ES6Unicode Extensions are enabled.
     bool m_fYieldIsKeywordRegion;       // Whether to treat 'yield' as an identifier or keyword
     bool m_fAwaitIsKeywordRegion;       // Whether to treat 'await' as an identifier or keyword
@@ -714,7 +729,6 @@ private:
 
     charcount_t m_line;
     ScanState m_scanState;
-    tokens m_errorToken;
 
     charcount_t m_ichMinError;
     charcount_t m_ichLimError;
@@ -728,13 +742,7 @@ private:
     size_t m_iecpLimTokPrevious;
     charcount_t m_ichLimTokPrevious;
 
-    Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, Js::ScriptContext *scriptContext);
-    ~Scanner(void);
-
-    void operator delete(void* p, size_t size)
-    {
-        HeapFree(p, size);
-    }
+    void ClearStates();
 
     template <bool forcePid>
     void SeekAndScan(const RestorePoint& restorePoint);
@@ -745,7 +753,6 @@ private:
     tokens ScanError(EncodedCharPtr pchCur, tokens errorToken)
     {
         m_currentCharacter = pchCur;
-        m_errorToken = errorToken;
         return m_ptoken->tk = tkScanError;
     }
 
@@ -756,7 +763,7 @@ private:
         throw ParseExceptionObject(hr);
     }
 
-    const EncodedCharPtr PchBase(void)
+    const EncodedCharPtr PchBase(void) const
     {
         return m_pchBase;
     }
@@ -837,4 +844,5 @@ private:
         return false;
     }
 
+    charcount_t UpdateLine(int32 &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd);
 };


### PR DESCRIPTION
Parser will never have a NULL HashTbl or Scanner.
