### PR TITLE
use ForInCache for enumerator in Object.assign

### DIFF
--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -1092,10 +1092,10 @@ JITTimeFunctionBody::GetFormalsPropIdArray() const
     return  (Js::PropertyIdArray *)m_bodyData.formalsPropIdArray;
 }
 
-Js::ForInCache *
+Js::EnumeratorCache *
 JITTimeFunctionBody::GetForInCache(uint profileId) const
 {
-    return  &((Js::ForInCache *)m_bodyData.forInCacheArrayAddr)[profileId];
+    return  &((Js::EnumeratorCache *)m_bodyData.forInCacheArrayAddr)[profileId];
 }
 
 bool

--- a/lib/Backend/JITTimeFunctionBody.h
+++ b/lib/Backend/JITTimeFunctionBody.h
@@ -183,7 +183,7 @@ public:
     const Js::PropertyIdArray * ReadPropertyIdArrayFromAuxData(uint offset) const;
     Js::PropertyIdArray * GetFormalsPropIdArray() const;
 
-    Js::ForInCache * GetForInCache(uint profileId) const;
+    Js::EnumeratorCache * GetForInCache(uint profileId) const;
     bool InitializeStatementMap(Js::SmallSpanSequence * statementMap, ArenaAllocator* alloc) const;
 private:
     Js::FunctionInfo::Attributes GetAttributes() const;

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -27159,7 +27159,7 @@ Lowerer::GenerateHasObjectArrayCheck(IR::RegOpnd * objectOpnd, IR::RegOpnd * typ
 }
 
 void
-Lowerer::GenerateInitForInEnumeratorFastPath(IR::Instr * instr, Js::ForInCache * forInCache)
+Lowerer::GenerateInitForInEnumeratorFastPath(IR::Instr * instr, Js::EnumeratorCache * forInCache)
 {
     Func * func = this->m_func;
 
@@ -27292,7 +27292,7 @@ Lowerer::GenerateInitForInEnumeratorFastPath(IR::Instr * instr, Js::ForInCache *
 void
 Lowerer::LowerInitForInEnumerator(IR::Instr * instr)
 {
-    Js::ForInCache * forInCache = nullptr;
+    Js::EnumeratorCache * forInCache = nullptr;
     Func * func = instr->m_func;
     if (instr->IsProfiledInstr())
     {

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -714,7 +714,7 @@ private:
     IR::RegOpnd *   GenerateForInEnumeratorLoad(IR::Opnd * forInEnumeratorOpnd, IR::Instr * insertBeforeInstr);
     IR::Opnd *      GetForInEnumeratorFieldOpnd(IR::Opnd * forInEnumeratorOpnd, uint fieldOffset, IRType type);
 
-    void            GenerateInitForInEnumeratorFastPath(IR::Instr * instr, Js::ForInCache * forInCache);
+    void            GenerateInitForInEnumeratorFastPath(IR::Instr * instr, Js::EnumeratorCache * forInCache);
     void            GenerateHasObjectArrayCheck(IR::RegOpnd * objectOpnd, IR::RegOpnd * typeOpnd, IR::LabelInstr * hasObjectArray, IR::Instr * insertBeforeInstr);
 
     IR::LabelInstr* InsertLoopTopLabel(IR::Instr * insertBeforeInstr);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -3906,15 +3906,15 @@ Opnd::GetAddrDescription(__out_ecount(count) char16 *const description, const si
             break;
         case AddrOpndKindForInCache:
             DumpAddress(address, printToConsole, skipMaskedAddress);
-            WriteToBuffer(&buffer, &n, _u(" (ForInCache)"));
+            WriteToBuffer(&buffer, &n, _u(" (EnumeratorCache)"));
             break;
         case AddrOpndKindForInCacheType:
             DumpAddress(address, printToConsole, skipMaskedAddress);
-            WriteToBuffer(&buffer, &n, _u(" (&ForInCache->type)"));
+            WriteToBuffer(&buffer, &n, _u(" (&EnumeratorCache->type)"));
             break;
         case AddrOpndKindForInCacheData:
             DumpAddress(address, printToConsole, skipMaskedAddress);
-            WriteToBuffer(&buffer, &n, _u(" (&ForInCache->data)"));
+            WriteToBuffer(&buffer, &n, _u(" (&EnumeratorCache->data)"));
             break;
         case AddrOpndKindDynamicNativeCodeDataRef:
             DumpAddress(address, printToConsole, skipMaskedAddress);

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6032,18 +6032,18 @@ namespace Js
         {
             return;
         }
-        this->SetAuxPtr(AuxPointerType::ForInCacheArray, AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->ForInCacheAllocator(), ForInCache, profiledForInLoopCount));
+        this->SetAuxPtr(AuxPointerType::ForInCacheArray, AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->ForInCacheAllocator(), EnumeratorCache, profiledForInLoopCount));
     }
 
-    ForInCache * FunctionBody::GetForInCache(uint index)
+    EnumeratorCache * FunctionBody::GetForInCache(uint index)
     {
         Assert(index < this->GetProfiledForInLoopCount());
-        return &((ForInCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray))[index];
+        return &((EnumeratorCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray))[index];
     }
 
-    ForInCache * FunctionBody::GetForInCacheArray()
+    EnumeratorCache * FunctionBody::GetForInCacheArray()
     {
-        return ((ForInCache *)this->GetAuxPtrWithLock(AuxPointerType::ForInCacheArray));
+        return ((EnumeratorCache *)this->GetAuxPtrWithLock(AuxPointerType::ForInCacheArray));
     }
 
     void FunctionBody::CleanUpForInCache(bool isShutdown)
@@ -6053,12 +6053,12 @@ namespace Js
         {
             return;
         }
-        ForInCache * forInCacheArray = (ForInCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray);
+        EnumeratorCache * forInCacheArray = (EnumeratorCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray);
         if (forInCacheArray)
         {
             if (isShutdown)
             {
-                memset(forInCacheArray, 0, sizeof(ForInCache) * profiledForInLoopCount);
+                memset(forInCacheArray, 0, sizeof(EnumeratorCache) * profiledForInLoopCount);
             }
             else
             {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6032,7 +6032,7 @@ namespace Js
         {
             return;
         }
-        this->SetAuxPtr(AuxPointerType::ForInCacheArray, AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->ForInCacheAllocator(), EnumeratorCache, profiledForInLoopCount));
+        this->SetAuxPtr(AuxPointerType::ForInCacheArray, AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->GetEnumeratorAllocator(), EnumeratorCache, profiledForInLoopCount));
     }
 
     EnumeratorCache * FunctionBody::GetForInCache(uint index)
@@ -6062,7 +6062,7 @@ namespace Js
             }
             else
             {
-                AllocatorDeleteArray(CacheAllocator, this->GetScriptContext()->ForInCacheAllocator(), profiledForInLoopCount, forInCacheArray);
+                AllocatorDeleteArray(CacheAllocator, this->GetScriptContext()->GetEnumeratorAllocator(), profiledForInLoopCount, forInCacheArray);
                 this->SetAuxPtr(AuxPointerType::ForInCacheArray, nullptr);
             }
         }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -77,7 +77,7 @@ namespace Js
         DiagParamScopeInObject,     // The scope represents symbols at formals and formal scope in activation object
     };
 
-    struct ForInCache
+    struct EnumeratorCache
     {
         Type * type;
         void * data;
@@ -3229,8 +3229,8 @@ namespace Js
         uint IncLiteralRegexCount() { return IncreaseCountField(CounterFields::LiteralRegexCount); }
 
         void AllocateForInCache();
-        ForInCache * GetForInCache(uint index);
-        ForInCache * GetForInCacheArray();
+        EnumeratorCache * GetForInCache(uint index);
+        EnumeratorCache * GetForInCacheArray();
         void CleanUpForInCache(bool isShutdown);
 
         void AllocateInlineCache();

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -135,7 +135,7 @@ namespace Js
 #endif
         inlineCacheAllocator(_u("SC-InlineCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
         isInstInlineCacheAllocator(_u("SC-IsInstInlineCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
-        forInCacheAllocator(_u("SC-ForInCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
+        enumeratorCacheAllocator(_u("SC-EnumeratorCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
         hasUsedInlineCache(false),
         hasProtoOrStoreFieldInlineCache(false),
         hasIsInstInlineCache(false),
@@ -4726,18 +4726,10 @@ void ScriptContext::ClearIsInstInlineCaches()
     DebugOnly(isInstInlineCacheAllocator.CheckIsAllZero(true));
 }
 
-void ScriptContext::ClearForInCaches()
+void ScriptContext::ClearEnumeratorCaches()
 {
-    forInCacheAllocator.ZeroAll();
-    DebugOnly(forInCacheAllocator.CheckIsAllZero(false));
-}
-
-void ScriptContext::ClearAssignCache()
-{
-    if (Cache()->assignCache)
-    {
-        memset(Cache()->assignCache, 0, Js::Cache::AssignCacheSize);
-    }
+    enumeratorCacheAllocator.ZeroAll();
+    DebugOnly(enumeratorCacheAllocator.CheckIsAllZero(false));
 }
 
 #ifdef PERSISTENT_INLINE_CACHES

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4732,6 +4732,13 @@ void ScriptContext::ClearForInCaches()
     DebugOnly(forInCacheAllocator.CheckIsAllZero(false));
 }
 
+void ScriptContext::ClearAssignCache()
+{
+    if (Cache()->assignCache)
+    {
+        memset(Cache()->assignCache, 0, Js::Cache::AssignCacheSize);
+    }
+}
 
 #ifdef PERSISTENT_INLINE_CACHES
 void ScriptContext::ClearInlineCachesWithDeadWeakRefs()

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1481,6 +1481,7 @@ private:
         void ClearInlineCaches();
         void ClearIsInstInlineCaches();
         void ClearForInCaches();
+        void ClearAssignCache();
 #ifdef PERSISTENT_INLINE_CACHES
         void ClearInlineCachesWithDeadWeakRefs();
 #endif

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -570,7 +570,7 @@ namespace Js
         ArenaAllocator dynamicProfileInfoAllocator;
         InlineCacheAllocator inlineCacheAllocator;
         CacheAllocator isInstInlineCacheAllocator;
-        CacheAllocator forInCacheAllocator;
+        CacheAllocator enumeratorCacheAllocator;
 
         ArenaAllocator* interpreterArena;
         ArenaAllocator* guestArena;
@@ -1290,7 +1290,7 @@ private:
 #endif
         InlineCacheAllocator* GetInlineCacheAllocator() { return &inlineCacheAllocator; }
         CacheAllocator* GetIsInstInlineCacheAllocator() { return &isInstInlineCacheAllocator; }
-        CacheAllocator * ForInCacheAllocator() { return &forInCacheAllocator; }
+        CacheAllocator * GetEnumeratorAllocator() { return &enumeratorCacheAllocator; }
         ArenaAllocator* DynamicProfileInfoAllocator() { return &dynamicProfileInfoAllocator; }
 
 #ifdef ENABLE_SCRIPT_DEBUGGING
@@ -1480,8 +1480,7 @@ private:
 #endif
         void ClearInlineCaches();
         void ClearIsInstInlineCaches();
-        void ClearForInCaches();
-        void ClearAssignCache();
+        void ClearEnumeratorCaches();
 #ifdef PERSISTENT_INLINE_CACHES
         void ClearInlineCachesWithDeadWeakRefs();
 #endif

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3121,8 +3121,7 @@ ThreadContext::ClearEnumeratorCaches()
     Js::ScriptContext *scriptContext = this->scriptContextList;
     while (scriptContext != nullptr)
     {
-        scriptContext->ClearForInCaches();
-        scriptContext->ClearAssignCache();
+        scriptContext->ClearEnumeratorCaches();
         scriptContext = scriptContext->next;
     }
 }

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2529,7 +2529,7 @@ ThreadContext::PreSweepCallback()
 
     ClearEquivalentTypeCaches();
 
-    ClearForInCaches();
+    ClearEnumeratorCaches();
 
     this->dynamicObjectEnumeratorCacheMap.Clear();
 }
@@ -3116,12 +3116,13 @@ ThreadContext::ClearIsInstInlineCaches()
 }
 
 void
-ThreadContext::ClearForInCaches()
+ThreadContext::ClearEnumeratorCaches()
 {
     Js::ScriptContext *scriptContext = this->scriptContextList;
     while (scriptContext != nullptr)
     {
         scriptContext->ClearForInCaches();
+        scriptContext->ClearAssignCache();
         scriptContext = scriptContext->next;
     }
 }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1380,7 +1380,7 @@ public:
     void ClearInvalidatedUniqueGuards();
     void ClearInlineCaches();
     void ClearIsInstInlineCaches();
-    void ClearForInCaches();
+    void ClearEnumeratorCaches();
     void ClearEquivalentTypeCaches();
     void ClearScriptContextCaches();
 

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5199,7 +5199,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
         return aEnumerator->MoveAndGetNext(id);
     }
 
-    void JavascriptOperators::OP_InitForInEnumerator(Var enumerable, ForInObjectEnumerator * enumerator, ScriptContext* scriptContext, ForInCache * forInCache)
+    void JavascriptOperators::OP_InitForInEnumerator(Var enumerable, ForInObjectEnumerator * enumerator, ScriptContext* scriptContext, EnumeratorCache * forInCache)
     {
         RecyclableObject* enumerableObject;
 #if ENABLE_COPYONACCESS_ARRAY

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -390,7 +390,7 @@ namespace Js
         static void OP_InitComputedProperty(Var object, Var elementName, Var value, ScriptContext* scriptContext, PropertyOperationFlags flags = PropertyOperation_None);
         static void OP_InitProto(Var object, PropertyId propertyId, Var value);
 
-        static void OP_InitForInEnumerator(Var enumerable, ForInObjectEnumerator * enumerator, ScriptContext* scriptContext, ForInCache * forInCache = nullptr);
+        static void OP_InitForInEnumerator(Var enumerable, ForInObjectEnumerator * enumerator, ScriptContext* scriptContext, EnumeratorCache * forInCache = nullptr);
         static Var OP_BrOnEmpty(ForInObjectEnumerator * enumerator);
         static BOOL OP_BrHasSideEffects(int se,ScriptContext* scriptContext);
         static BOOL OP_BrNotHasSideEffects(int se,ScriptContext* scriptContext);

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -295,9 +295,9 @@ namespace Js
         return JavascriptConversion::BooleanToPropertyQueryFlags(GetProperty(originalInstance, propertyId, value, info, requestContext));
     }
 
-    BOOL ModuleNamespace::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL ModuleNamespace::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
-        ModuleNamespaceEnumerator* moduleEnumerator = ModuleNamespaceEnumerator::New(this, flags, requestContext, forInCache);
+        ModuleNamespaceEnumerator* moduleEnumerator = ModuleNamespaceEnumerator::New(this, flags, requestContext, enumeratorCache);
         if (moduleEnumerator == nullptr)
         {
             return FALSE;

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -59,7 +59,7 @@ namespace Js
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { *setterValue = nullptr; return DescriptorFlags::None; }
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { return false; }
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { return true; }
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr);
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr);
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { return false; }
         virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { return false; }
         virtual BOOL IsWritable(PropertyId propertyId) override;

--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
@@ -18,19 +18,19 @@ namespace Js
     {
     }
 
-    ModuleNamespaceEnumerator* ModuleNamespaceEnumerator::New(ModuleNamespace* nsObject, EnumeratorFlags flags, ScriptContext* scriptContext, ForInCache * forInCache)
+    ModuleNamespaceEnumerator* ModuleNamespaceEnumerator::New(ModuleNamespace* nsObject, EnumeratorFlags flags, ScriptContext* scriptContext, EnumeratorCache * enumeratorCache)
     {
         ModuleNamespaceEnumerator* enumerator = RecyclerNew(scriptContext->GetRecycler(), ModuleNamespaceEnumerator, nsObject, flags, scriptContext);
-        if (enumerator->Init(forInCache))
+        if (enumerator->Init(enumeratorCache))
         {
             return enumerator;
         }
         return nullptr;
     }
 
-    BOOL ModuleNamespaceEnumerator::Init(ForInCache * forInCache)
+    BOOL ModuleNamespaceEnumerator::Init(EnumeratorCache * enumeratorCache)
     {
-        if (!nsObject->DynamicObject::GetEnumerator(&symbolEnumerator, flags, GetScriptContext(), forInCache))
+        if (!nsObject->DynamicObject::GetEnumerator(&symbolEnumerator, flags, GetScriptContext(), enumeratorCache))
         {
             return FALSE;
         }

--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.h
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.h
@@ -11,10 +11,10 @@ namespace Js
     protected:
         DEFINE_VTABLE_CTOR(ModuleNamespaceEnumerator, JavascriptEnumerator);
         ModuleNamespaceEnumerator(ModuleNamespace* nsObject, EnumeratorFlags flags, ScriptContext* scriptContext);
-        BOOL Init(ForInCache * forInCache);
+        BOOL Init(EnumeratorCache * enumeratorCache);
 
     public:
-        static ModuleNamespaceEnumerator* New(ModuleNamespace* nsObject, EnumeratorFlags flags, ScriptContext* scriptContext, ForInCache * forInCache);        
+        static ModuleNamespaceEnumerator* New(ModuleNamespace* nsObject, EnumeratorFlags flags, ScriptContext* scriptContext, EnumeratorCache * enumeratorCache);
         virtual void Reset() override;
         virtual JavascriptString * MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual Var GetCurrentValue() { Assert(false); return nullptr; }

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -8,11 +8,11 @@
 
 namespace Js
 {
-    BOOL ArgumentsObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL ArgumentsObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         return GetEnumeratorWithPrefix(
             RecyclerNew(GetScriptContext()->GetRecycler(), ArgumentsObjectPrefixEnumerator, this, flags, requestContext),
-            enumerator, flags, requestContext, forInCache);
+            enumerator, flags, requestContext, enumeratorCache);
     }
 
     BOOL ArgumentsObject::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
@@ -593,9 +593,9 @@ namespace Js
         return this->DynamicObject::SetPropertyWithAttributes(propertyId, value, attributes, info, flags, possibleSideEffects);
     }
 
-    BOOL ES5HeapArgumentsObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL ES5HeapArgumentsObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
-        ES5ArgumentsObjectEnumerator * es5HeapArgumentsObjectEnumerator = ES5ArgumentsObjectEnumerator::New(this, flags, requestContext, forInCache);
+        ES5ArgumentsObjectEnumerator * es5HeapArgumentsObjectEnumerator = ES5ArgumentsObjectEnumerator::New(this, flags, requestContext, enumeratorCache);
         if (es5HeapArgumentsObjectEnumerator == nullptr)
         {
             return false;

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -23,7 +23,7 @@ namespace Js
 
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
 
         virtual uint32 GetNumberOfArguments() const = 0;
         virtual uint32 GetNextFormalArgIndex(uint32 index, BOOL enumNonEnumerable = FALSE, PropertyAttributes* attributes = nullptr) const = 0;
@@ -190,7 +190,7 @@ namespace Js
         virtual BOOL SetWritable(PropertyId propertyId, BOOL value) override;
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags) override;
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual BOOL PreventExtensions() override;
         virtual BOOL Seal() override;
         virtual BOOL Freeze() override;

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
@@ -40,10 +40,10 @@ namespace Js
     }
 
     //---------------------- ES5ArgumentsObjectEnumerator -------------------------------
-    ES5ArgumentsObjectEnumerator * ES5ArgumentsObjectEnumerator::New(ArgumentsObject* argumentsObject, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    ES5ArgumentsObjectEnumerator * ES5ArgumentsObjectEnumerator::New(ArgumentsObject* argumentsObject, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         ES5ArgumentsObjectEnumerator * enumerator = RecyclerNew(requestContext->GetRecycler(), ES5ArgumentsObjectEnumerator, argumentsObject, flags, requestContext);
-        if (!enumerator->Init(forInCache))
+        if (!enumerator->Init(enumeratorCache))
         {
             return nullptr;
         }
@@ -56,11 +56,11 @@ namespace Js
     {
     }
 
-    BOOL ES5ArgumentsObjectEnumerator::Init(ForInCache * forInCache)
+    BOOL ES5ArgumentsObjectEnumerator::Init(EnumeratorCache * enumeratorCache)
     {
         __super::Reset();
         this->enumeratedFormalsInObjectArrayCount = 0;
-        return argumentsObject->DynamicObject::GetEnumerator(&objectEnumerator, flags, GetScriptContext(), forInCache);
+        return argumentsObject->DynamicObject::GetEnumerator(&objectEnumerator, flags, GetScriptContext(), enumeratorCache);
     }
 
     JavascriptString * ES5ArgumentsObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.h
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.h
@@ -28,9 +28,9 @@ namespace Js
     protected:
         DEFINE_VTABLE_CTOR(ES5ArgumentsObjectEnumerator, ArgumentsObjectPrefixEnumerator);
         ES5ArgumentsObjectEnumerator(ArgumentsObject* argumentsObject, EnumeratorFlags flags, ScriptContext* requestContext);
-        BOOL Init(ForInCache * forInCache);
+        BOOL Init(EnumeratorCache * enumeratorCache);
     public:
-        static ES5ArgumentsObjectEnumerator * New(ArgumentsObject* argumentsObject, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache);
+        static ES5ArgumentsObjectEnumerator * New(ArgumentsObject* argumentsObject, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache);
         virtual void Reset() override;
         virtual JavascriptString * MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     private:

--- a/lib/Runtime/Library/ES5Array.cpp
+++ b/lib/Runtime/Library/ES5Array.cpp
@@ -314,9 +314,9 @@ namespace Js
         return DynamicObject::Freeze();
     }
 
-    BOOL ES5Array::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL ES5Array::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
-        return enumerator->Initialize(nullptr, this, this, flags, requestContext, forInCache);
+        return enumerator->Initialize(nullptr, this, this, flags, requestContext, enumeratorCache);
     }
 
     JavascriptEnumerator * ES5Array::GetIndexEnumerator(EnumeratorFlags flags, ScriptContext* requestContext)

--- a/lib/Runtime/Library/ES5Array.h
+++ b/lib/Runtime/Library/ES5Array.h
@@ -84,7 +84,7 @@ namespace Js
         virtual BOOL Seal() override;
         virtual BOOL Freeze() override;
 
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
 
         // objectArray support
         virtual BOOL SetItemWithAttributes(uint32 index, Var value, PropertyAttributes attributes) override;

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -29,7 +29,7 @@ namespace Js
         shadowData = nullptr;
     }
 
-    void ForInObjectEnumerator::Initialize(RecyclableObject* initObject, ScriptContext * requestContext, bool enumSymbols, ForInCache * forInCache)
+    void ForInObjectEnumerator::Initialize(RecyclableObject* initObject, ScriptContext * requestContext, bool enumSymbols, EnumeratorCache * forInCache)
     {
         this->enumeratingPrototype = false;
 
@@ -117,7 +117,7 @@ namespace Js
         return firstPrototypeWithEnumerableProperties;
     }
 
-    BOOL ForInObjectEnumerator::InitializeCurrentEnumerator(RecyclableObject * object, ForInCache * forInCache)
+    BOOL ForInObjectEnumerator::InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorCache * forInCache)
     {
         EnumeratorFlags flags = enumerator.GetFlags();
         RecyclableObject * prototype = object->GetPrototype();
@@ -129,7 +129,7 @@ namespace Js
         return InitializeCurrentEnumerator(object, flags, GetScriptContext(), forInCache);
     }
 
-    BOOL ForInObjectEnumerator::InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorFlags flags,  ScriptContext * scriptContext, ForInCache * forInCache)
+    BOOL ForInObjectEnumerator::InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorFlags flags,  ScriptContext * scriptContext, EnumeratorCache * forInCache)
     {
         Assert(object);
         Assert(scriptContext);

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -25,15 +25,15 @@ namespace Js
         bool enumeratingPrototype;
 
         BOOL TestAndSetEnumerated(PropertyId propertyId);
-        BOOL InitializeCurrentEnumerator(RecyclableObject * object, ForInCache * forInCache = nullptr);
-        BOOL InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache);
+        BOOL InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorCache * forInCache = nullptr);
+        BOOL InitializeCurrentEnumerator(RecyclableObject * object, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * forInCache);
 
     public:
         ForInObjectEnumerator(RecyclableObject* currentObject, ScriptContext * requestContext, bool enumSymbols = false);
         ~ForInObjectEnumerator() { Clear(); }
 
         ScriptContext * GetScriptContext() const { return enumerator.GetScriptContext(); }
-        void Initialize(RecyclableObject* currentObject, ScriptContext * requestContext, bool enumSymbols = false, ForInCache * forInCache = nullptr);
+        void Initialize(RecyclableObject* currentObject, ScriptContext * requestContext, bool enumSymbols = false, EnumeratorCache * forInCache = nullptr);
         void Clear();
         JavascriptString * MoveAndGetNext(PropertyId& propertyId);
 

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -12575,12 +12575,12 @@ Case0:
         return this->DirectDeleteItemAt<double>(index);
     }
 
-    BOOL JavascriptArray::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL JavascriptArray::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
 #endif
-        return enumerator->Initialize(nullptr, this, this, flags, requestContext, forInCache);
+        return enumerator->Initialize(nullptr, this, this, flags, requestContext, enumeratorCache);
     }
 
     BOOL JavascriptArray::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -361,7 +361,7 @@ namespace Js
         virtual BOOL Seal() override;
         virtual BOOL Freeze() override;
 
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetSpecialPropertyName(uint32 index, JavascriptString ** propertyName, ScriptContext * requestContext) override;

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6354,11 +6354,11 @@ namespace Js
         return this->propertyStringMap;
     }
 
-    ForInCache* JavascriptLibrary::GetObjectAssignCache(Type* type)
+    EnumeratorCache* JavascriptLibrary::GetObjectAssignCache(Type* type)
     {
         if (this->cache.assignCache == nullptr)
         {
-            this->cache.assignCache = RecyclerNewArrayZ(scriptContext->GetRecycler(), ForInCache, Cache::AssignCacheSize);
+            this->cache.assignCache = RecyclerNewArrayZ(scriptContext->GetRecycler(), EnumeratorCache, Cache::AssignCacheSize);
         }
 
         return &this->cache.assignCache[(((size_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6354,6 +6354,16 @@ namespace Js
         return this->propertyStringMap;
     }
 
+    ForInCache* JavascriptLibrary::GetObjectAssignCache(Type* type)
+    {
+        if (this->cache.assignCache == nullptr)
+        {
+            this->cache.assignCache = RecyclerNewArrayZ(scriptContext->GetRecycler(), ForInCache, Cache::AssignCacheSize);
+        }
+
+        return &this->cache.assignCache[(((size_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];
+    }
+
     SymbolCacheMap* JavascriptLibrary::EnsureSymbolMap()
     {
         if (this->symbolMap == nullptr)

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6356,12 +6356,14 @@ namespace Js
 
     EnumeratorCache* JavascriptLibrary::GetObjectAssignCache(Type* type)
     {
+        // Size must be power of 2 for cache indexing to work
+        CompileAssert((Cache::AssignCacheSize & (Cache::AssignCacheSize - 1)) == 0);
+
         if (this->cache.assignCache == nullptr)
         {
             this->cache.assignCache = AllocatorNewArrayZ(CacheAllocator, scriptContext->GetEnumeratorAllocator(), EnumeratorCache, Cache::AssignCacheSize);
         }
-
-        return &this->cache.assignCache[(((size_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];
+        return &this->cache.assignCache[(((uintptr_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];
     }
 
     SymbolCacheMap* JavascriptLibrary::EnsureSymbolMap()

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6358,7 +6358,7 @@ namespace Js
     {
         if (this->cache.assignCache == nullptr)
         {
-            this->cache.assignCache = RecyclerNewArrayZ(scriptContext->GetRecycler(), EnumeratorCache, Cache::AssignCacheSize);
+            this->cache.assignCache = AllocatorNewArrayZ(CacheAllocator, scriptContext->GetEnumeratorAllocator(), EnumeratorCache, Cache::AssignCacheSize);
         }
 
         return &this->cache.assignCache[(((size_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -88,7 +88,7 @@ namespace Js
         Field(BuiltInLibraryFunctionMap*) builtInLibraryFunctions;
         Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
         Field(ScriptContextPolymorphicInlineCache*) toJSONCache;
-        Field(ForInCache*) assignCache;
+        Field(EnumeratorCache*) assignCache;
 #if ENABLE_PROFILE_INFO
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
         Field(DynamicProfileInfoList*) profileInfoList;
@@ -1174,7 +1174,7 @@ namespace Js
             return (JavascriptLibrary *)((uintptr_t)cache - offsetof(JavascriptLibrary, charStringCache));
         }
 
-        ForInCache* GetObjectAssignCache(Type* type);
+        EnumeratorCache* GetObjectAssignCache(Type* type);
 
         bool GetArrayObjectHasUserDefinedSpecies() const { return arrayObjectHasUserDefinedSpecies; }
         void SetArrayObjectHasUserDefinedSpecies(bool val) { arrayObjectHasUserDefinedSpecies = val; }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -69,6 +69,8 @@ namespace Js
 
     struct Cache
     {
+        static const uint AssignCacheSize = 16;
+
         Field(PropertyStringMap*) propertyStrings[80];
         Field(JavascriptString *) lastNumberToStringRadix10String;
         Field(EnumeratedObjectCache) enumObjCache;
@@ -86,6 +88,7 @@ namespace Js
         Field(BuiltInLibraryFunctionMap*) builtInLibraryFunctions;
         Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
         Field(ScriptContextPolymorphicInlineCache*) toJSONCache;
+        Field(ForInCache*) assignCache;
 #if ENABLE_PROFILE_INFO
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
         Field(DynamicProfileInfoList*) profileInfoList;
@@ -1170,6 +1173,8 @@ namespace Js
         {
             return (JavascriptLibrary *)((uintptr_t)cache - offsetof(JavascriptLibrary, charStringCache));
         }
+
+        ForInCache* GetObjectAssignCache(Type* type);
 
         bool GetArrayObjectHasUserDefinedSpecies() const { return arrayObjectHasUserDefinedSpecies; }
         void SetArrayObjectHasUserDefinedSpecies(bool val) { arrayObjectHasUserDefinedSpecies = val; }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -94,7 +94,7 @@ namespace Js
         Field(DynamicProfileInfoList*) profileInfoList;
 #endif
 #endif
-        Cache() : toStringTagCache(nullptr), toJSONCache(nullptr) { }
+        Cache() : toStringTagCache(nullptr), toJSONCache(nullptr), assignCache(nullptr) { }
     };
 
     class MissingPropertyTypeHandler;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1569,8 +1569,9 @@ namespace Js
 
     void JavascriptObject::AssignForGenericObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext)
     {
+        ForInCache* cache = scriptContext->GetLibrary()->GetObjectAssignCache(from->GetType());
         JavascriptStaticEnumerator enumerator;
-        if (!from->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EnumSymbols, scriptContext))
+        if (!from->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EnumSymbols | EnumeratorFlags::UseCache, scriptContext, cache))
         {
             // Nothing to enumerate, continue with the nextSource.
             return;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1569,7 +1569,7 @@ namespace Js
 
     void JavascriptObject::AssignForGenericObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext)
     {
-        ForInCache* cache = scriptContext->GetLibrary()->GetObjectAssignCache(from->GetType());
+        EnumeratorCache* cache = scriptContext->GetLibrary()->GetObjectAssignCache(from->GetType());
         JavascriptStaticEnumerator enumerator;
         if (!from->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EnumSymbols | EnumeratorFlags::UseCache, scriptContext, cache))
         {

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -958,7 +958,7 @@ namespace Js
     }
 
     // No change to foreign enumerator, just forward
-    BOOL JavascriptProxy::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL JavascriptProxy::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         // Reject implicit call
         ThreadContext* threadContext = requestContext->GetThreadContext();
@@ -1044,7 +1044,7 @@ namespace Js
         JavascriptArray* trapResult = JavascriptOperators::GetOwnPropertyNames(this, requestContext);
         ProxyOwnkeysEnumerator* ownKeysEnum = RecyclerNew(requestContext->GetRecycler(), ProxyOwnkeysEnumerator, requestContext, this, trapResult);
 
-        return enumerator->Initialize(ownKeysEnum, nullptr, nullptr, flags, requestContext, forInCache);
+        return enumerator->Initialize(ownKeysEnum, nullptr, nullptr, flags, requestContext, enumeratorCache);
     }
 
     BOOL JavascriptProxy::SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags)

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -106,7 +106,7 @@ namespace Js
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override;
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override;
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override;
         virtual BOOL Equals(__in Var other, __out BOOL* value, ScriptContext* requestContext) override;
         virtual BOOL StrictEquals(__in Var other, __out BOOL* value, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -36,11 +36,11 @@ namespace Js
         }
     }
 
-    BOOL JavascriptRegExpConstructor::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL JavascriptRegExpConstructor::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         return GetEnumeratorWithPrefix(
             RecyclerNew(GetScriptContext()->GetRecycler(), JavascriptRegExpEnumerator, this, flags, requestContext),
-            enumerator, flags, requestContext, forInCache);
+            enumerator, flags, requestContext, enumeratorCache);
     }
 
     void JavascriptRegExpConstructor::SetLastMatch(UnifiedRegex::RegexPattern* lastPattern, JavascriptString* lastInput, UnifiedRegex::GroupInfo lastMatch)

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -37,7 +37,7 @@ namespace Js
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL IsConfigurable(PropertyId propertyId) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         BOOL GetSpecialNonEnumerablePropertyName(uint32 index, Var *propertyName, ScriptContext * requestContext);
         uint GetSpecialNonEnumerablePropertyCount() const;
         PropertyId const * GetSpecialNonEnumerablePropertyIds() const;

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3744,11 +3744,11 @@ case_2:
         return JavascriptConversion::BooleanToPropertyQueryFlags(this->GetItemAt(index, value));
     }
 
-    BOOL JavascriptString::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL JavascriptString::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         return enumerator->Initialize(
             RecyclerNew(GetScriptContext()->GetRecycler(), JavascriptStringEnumerator, this, requestContext),
-            nullptr, nullptr, flags, requestContext, forInCache);
+            nullptr, nullptr, flags, requestContext, enumeratorCache);
     }
 
     BOOL JavascriptString::DeleteProperty(PropertyId propertyId, PropertyOperationFlags propertyOperationFlags)

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -105,7 +105,7 @@ namespace Js
         virtual PropertyQueryFlags HasItemQuery(uint32 index) override sealed;
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
         virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags propertyOperationFlags) override;

--- a/lib/Runtime/Library/JavascriptStringObject.cpp
+++ b/lib/Runtime/Library/JavascriptStringObject.cpp
@@ -396,11 +396,11 @@ namespace Js
         return DynamicObject::SetItem(index, value, flags);
     }
 
-    BOOL JavascriptStringObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL JavascriptStringObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         return GetEnumeratorWithPrefix(
             RecyclerNew(GetScriptContext()->GetRecycler(), JavascriptStringEnumerator, this->Unwrap(), requestContext),
-            enumerator, flags, requestContext, forInCache);
+            enumerator, flags, requestContext, enumeratorCache);
     }
 
     BOOL JavascriptStringObject::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptStringObject.h
+++ b/lib/Runtime/Library/JavascriptStringObject.h
@@ -55,7 +55,7 @@ namespace Js
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
         virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetSpecialPropertyName(uint32 index, JavascriptString ** propertyName, ScriptContext * requestContext) override;

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -938,9 +938,9 @@ namespace Js
         return __super::GetItemSetter(index, setterValue, requestContext);
     }
 
-    BOOL TypedArrayBase::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL TypedArrayBase::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
-        return enumerator->Initialize(nullptr, this, this, flags, requestContext, forInCache);
+        return enumerator->Initialize(nullptr, this, this, flags, requestContext, enumeratorCache);
     }
 
     JavascriptEnumerator * TypedArrayBase::GetIndexEnumerator(EnumeratorFlags flags, ScriptContext * requestContext)

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -116,7 +116,7 @@ namespace Js
         virtual BOOL DeleteProperty(Js::PropertyId propertyId, Js::PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, Js::PropertyOperationFlags flags) override;
         virtual PropertyQueryFlags GetItemReferenceQuery(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * requestContext) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual JavascriptEnumerator * GetIndexEnumerator(EnumeratorFlags flags, ScriptContext * requestContext) override;
 
         virtual BOOL IsEnumerable(PropertyId propertyId)  override;

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -83,7 +83,7 @@ namespace Js
     struct ByteCodeReader;
     struct ByteCodeWriter;
     enum class EnumeratorFlags : byte;
-    struct ForInCache;
+    struct EnumeratorCache;
     class JavascriptStaticEnumerator;
     class ForInObjectEnumerator;
     class JavascriptConversion;

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -253,7 +253,7 @@ namespace Js
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override;
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override;
         virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override;
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * scriptContext, ForInCache * forInCache = nullptr) override;
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * scriptContext, EnumeratorCache * enumeratorCache = nullptr) override;
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override;
         virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override;
         virtual BOOL IsWritable(PropertyId propertyId) override;
@@ -306,7 +306,7 @@ namespace Js
 
         void SetObjectArray(ArrayObject* objectArray);
     protected:
-        BOOL GetEnumeratorWithPrefix(JavascriptEnumerator * prefixEnumerator, JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * scriptContext, ForInCache * forInCache);
+        BOOL GetEnumeratorWithPrefix(JavascriptEnumerator * prefixEnumerator, JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * scriptContext, EnumeratorCache * enumeratorCache);
 
         // These are only call for arrays
         void InitArrayFlags(DynamicObjectFlags flags);

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -38,7 +38,7 @@ namespace Js
         this->initialPropertyCount = initialPropertyCount;
     }
 
-    bool DynamicObjectPropertyEnumerator::Initialize(DynamicObject * object, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache)
+    bool DynamicObjectPropertyEnumerator::Initialize(DynamicObject * object, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache)
     {
         this->scriptContext = requestContext;
         this->object = object;
@@ -66,9 +66,9 @@ namespace Js
         DynamicType * type = object->GetDynamicType();
 
         CachedData * data;
-        if (forInCache && type == forInCache->type)
+        if (enumeratorCache && type == enumeratorCache->type)
         {
-            data = (CachedData *)forInCache->data;
+            data = (CachedData *)enumeratorCache->data;
 
             Assert(data != nullptr);
             Assert(data->scriptContext == this->scriptContext); // The cache data script context should be the same as request context
@@ -86,10 +86,10 @@ namespace Js
         {
             Initialize(type, data, data->propertyCount);
 
-            if (forInCache)
+            if (enumeratorCache)
             {
-                forInCache->type = type;
-                forInCache->data = data;
+                enumeratorCache->type = type;
+                enumeratorCache->data = data;
             }
             return true;
         }
@@ -122,10 +122,10 @@ namespace Js
         requestContext->GetThreadContext()->AddDynamicObjectEnumeratorCache(type, data);
         Initialize(type, data, propertyCount);
 
-        if (forInCache)
+        if (enumeratorCache)
         {
-            forInCache->type = type;
-            forInCache->data = data;
+            enumeratorCache->type = type;
+            enumeratorCache->data = data;
         }
         return true;
     }

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -68,13 +68,10 @@ namespace Js
         CachedData * data;
         if (forInCache && type == forInCache->type)
         {
-            // We shouldn't have a for in cache when asking to enum symbols
-            Assert(!GetEnumSymbols());
             data = (CachedData *)forInCache->data;
 
             Assert(data != nullptr);
             Assert(data->scriptContext == this->scriptContext); // The cache data script context should be the same as request context
-            Assert(!data->enumSymbols);
 
             if (data->enumNonEnumerable == GetEnumNonEnumerable())
             {

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
@@ -47,7 +47,7 @@ namespace Js
         bool GetUseCache() const;
         ScriptContext * GetScriptContext() const { return scriptContext; }
 
-        bool Initialize(DynamicObject * object, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache);
+        bool Initialize(DynamicObject * object, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache);
         bool IsNullEnumerator() const;
         void Reset();
         void Clear(EnumeratorFlags flags, ScriptContext * requestContext);

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -461,7 +461,7 @@ namespace Js
         return false;
     }
 
-    BOOL DynamicObject::GetEnumeratorWithPrefix(JavascriptEnumerator * prefixEnumerator, JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache)
+    BOOL DynamicObject::GetEnumeratorWithPrefix(JavascriptEnumerator * prefixEnumerator, JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache)
     {
         Js::ArrayObject * arrayObject = nullptr;
         if (this->HasObjectArray())
@@ -469,12 +469,12 @@ namespace Js
             arrayObject = this->GetObjectArrayOrFlagsAsArray();
             Assert(arrayObject->GetPropertyCount() == 0);
         }
-        return enumerator->Initialize(prefixEnumerator, arrayObject, this, flags, requestContext, forInCache);
+        return enumerator->Initialize(prefixEnumerator, arrayObject, this, flags, requestContext, enumeratorCache);
     }
 
-    BOOL DynamicObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache)
+    BOOL DynamicObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache)
     {
-        return GetEnumeratorWithPrefix(nullptr, enumerator, flags, requestContext, forInCache);
+        return GetEnumeratorWithPrefix(nullptr, enumerator, flags, requestContext, enumeratorCache);
     }
 
     BOOL DynamicObject::SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags)

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
@@ -8,12 +8,12 @@ namespace Js
 {
 
     bool JavascriptStaticEnumerator::Initialize(JavascriptEnumerator * prefixEnumerator, ArrayObject * arrayToEnumerate,
-        DynamicObject * objectToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache)
+        DynamicObject * objectToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache)
     {
         this->prefixEnumerator = prefixEnumerator;
         this->arrayEnumerator = arrayToEnumerate ? arrayToEnumerate->GetIndexEnumerator(flags, requestContext) : nullptr;
         this->currentEnumerator = prefixEnumerator ? prefixEnumerator : PointerValue(arrayEnumerator);
-        return this->propertyEnumerator.Initialize(objectToEnumerate, flags, requestContext, forInCache);
+        return this->propertyEnumerator.Initialize(objectToEnumerate, flags, requestContext, enumeratorCache);
     }
 
     void JavascriptStaticEnumerator::Clear(EnumeratorFlags flags, ScriptContext * requestContext)

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.h
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.h
@@ -29,7 +29,7 @@ namespace Js
         JavascriptString * MoveAndGetNextFromEnumerator(PropertyId& propertyId, PropertyAttributes* attributes);
     public:
         JavascriptStaticEnumerator() { Clear(EnumeratorFlags::None, nullptr); }
-        bool Initialize(JavascriptEnumerator * prefixEnumerator, ArrayObject * arrayToEnumerate, DynamicObject* objectToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache);
+        bool Initialize(JavascriptEnumerator * prefixEnumerator, ArrayObject * arrayToEnumerate, DynamicObject* objectToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext, EnumeratorCache * enumeratorCache);
         bool IsNullEnumerator() const;
         bool CanUseJITFastPath() const;
         ScriptContext * GetScriptContext() const { return propertyEnumerator.GetScriptContext(); }

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -461,7 +461,7 @@ namespace Js
         return true;
     }
 
-    BOOL RecyclableObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
+    BOOL RecyclableObject::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache)
     {
         return false;
     }

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -326,7 +326,7 @@ namespace Js {
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) { return None; }
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags);
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags);
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr);
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr);
         virtual BOOL ToPrimitive(JavascriptHint hint, Var* value, ScriptContext * requestContext);
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None);
         virtual BOOL Equals(__in Var other, __out BOOL* value, ScriptContext* requestContext);

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -54,7 +54,7 @@ namespace Js
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override { AssertAndFailFast(); return FALSE; };
-        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override { AssertAndFailFast(); return FALSE; };
+        virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL IsWritable(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -58,7 +58,7 @@ namespace Js
             virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { UNWRAP_FAILFAST(); return FALSE; };
             virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { UNWRAP_FAILFAST(); return FALSE; };
             virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return FALSE; };
-            virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr) override { UNWRAP_FAILFAST(); return FALSE; };
+            virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, EnumeratorCache * enumeratorCache = nullptr) override { UNWRAP_FAILFAST(); return FALSE; };
             virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { UNWRAP_FAILFAST(); return FALSE; };
             virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { UNWRAP_FAILFAST(); return FALSE; };
             virtual BOOL IsWritable(PropertyId propertyId) override { UNWRAP_FAILFAST(); return FALSE; };

--- a/test/es6/object-assign.js
+++ b/test/es6/object-assign.js
@@ -114,6 +114,8 @@ var tests = [
             var y = Symbol("y");
             o2[y] = 10;
             assert.isTrue((Object.assign({}, o2))[y] === 10, "Symbols are assigned to target object ");
+            assert.isTrue((Object.assign({a:1}, o2))[y] === 10, "Symbols are assigned to target object (for non-empty assignee)");
+            assert.isTrue((Object.assign({a:1}, o2))[y] === 10, "Symbols are assigned to target object (when hitting cache)");
         }
     },
     {


### PR DESCRIPTION
Adds a per-ScriptContext polymorphic cache of size 16 for Object.assign.
Preliminary perf looks like it improves React-redux by about 8%.

Full perf run gave me numbers that are too good to be true (5% geomean improvement), but I'm not sure I believe it.