### PR TITLE
MSFT:16491614: allow IntConstOpnds for IsIn array optimization

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -10764,10 +10764,10 @@ GlobOpt::ToTypeSpecIndex(IR::Instr * instr, IR::RegOpnd * indexOpnd, IR::IndirOp
 
         if (!IsLoopPrePass())
         {
-            indexOpnd = indirOpnd ? indirOpnd->GetIndexOpnd() : instr->GetSrc1()->AsRegOpnd();
-            if (indexOpnd)
+            IR::Opnd * intOpnd = indirOpnd ? indirOpnd->GetIndexOpnd() : instr->GetSrc1();
+            if (intOpnd != nullptr)
             {
-                Assert(indexOpnd->m_sym->IsTypeSpec());
+                Assert(!intOpnd->IsRegOpnd() || intOpnd->AsRegOpnd()->m_sym->IsTypeSpec());
                 IntConstantBounds indexConstantBounds;
                 AssertVerify(indexValue->GetValueInfo()->TryGetIntConstantBounds(&indexConstantBounds));
                 if (ValueInfo::IsGreaterThanOrEqualTo(
@@ -10778,7 +10778,7 @@ GlobOpt::ToTypeSpecIndex(IR::Instr * instr, IR::RegOpnd * indexOpnd, IR::IndirOp
                     0,
                     0))
                 {
-                    indexOpnd->SetType(TyUint32);
+                    intOpnd->SetType(TyUint32);
                 }
             }
         }

--- a/lib/Backend/GlobOptArrays.h
+++ b/lib/Backend/GlobOptArrays.h
@@ -51,7 +51,7 @@ private:
     IR::Instr * baseOwnerInstr = nullptr;
     IR::IndirOpnd * baseOwnerIndir = nullptr;
     IR::RegOpnd * baseOpnd = nullptr;
-    IR::RegOpnd * indexOpnd = nullptr;
+    IR::Opnd * indexOpnd = nullptr;
     IR::RegOpnd * originalIndexOpnd = nullptr;
     bool isProfilableLdElem = false;
     bool isProfilableStElem = false;

--- a/test/Bugs/inbug2.js
+++ b/test/Bugs/inbug2.js
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo()
+{
+    0x40000000 in this;
+};
+
+foo();
+foo();
+
+WScript.Echo("Passed");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -453,6 +453,11 @@
   </test>
   <test>
     <default>
+      <files>inbug2.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>instancebug.js</files>
     </default>
   </test>


### PR DESCRIPTION
This fixes a bug on x86 where int consts greater than 0x3FFFFFFF were not getting copy prop'd because they didn't fit in a 31 bit int, but were getting converted by ToTypeSpecIndex to 31 bit unsigned ints, causing IsRegOpnd asserts to fail.

This change also allows copy prop'd const ints to be used in the optimization. The optimization was originally written requiring RegOpnds because OptArraySrc is called before type specialization, but copy-prop can cause IntConsts to be present in potentially optimizable cases.
