### PR TITLE
Add jit fastpath for symbol compares

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -22805,6 +22805,11 @@ bool Lowerer::GenerateFastBooleanAndObjectEqLikely(IR::Instr * instr, IR::Opnd *
             }
         }
     }
+    else if (src1->GetValueType().IsLikelySymbol() && src2->GetValueType().IsLikelySymbol())
+    {
+        this->GenerateSymbolTest(src1->AsRegOpnd(), instr, labelHelper, nullptr, false);
+        this->GenerateSymbolTest(src2->AsRegOpnd(), instr, labelHelper, nullptr, false);
+    }
     else
     {
         return false;

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -199,17 +199,15 @@ CommonNumber:
                 return JavascriptString::Equals(JavascriptString::UnsafeFromVar(aLeft), JavascriptString::UnsafeFromVar(aRight));
             }
             break;
+#if DBG
         case TypeIds_Symbol:
-            switch (rightType)
+            if (rightType == TypeIds_Symbol)
             {
-            case TypeIds_Symbol:
-                {
-                    JavascriptSymbol* leftSymbol = JavascriptSymbol::UnsafeFromVar(aLeft);
-                    JavascriptSymbol* rightSymbol = JavascriptSymbol::UnsafeFromVar(aRight);
-                    return leftSymbol->GetValue() == rightSymbol->GetValue();
-                }
+                JavascriptSymbol* leftSymbol = JavascriptSymbol::UnsafeFromVar(aLeft);
+                JavascriptSymbol* rightSymbol = JavascriptSymbol::UnsafeFromVar(aRight);
+                Assert(leftSymbol->GetValue() != rightSymbol->GetValue());
             }
-            return false;
+#endif
         default:
             break;
         }

--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -300,7 +300,6 @@ namespace Js {
 #endif
        }
        case TypeIds_String:
-       case TypeIds_Symbol:
            return nullptr;
 
        default:

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -883,19 +883,15 @@ CommonNumber:
 
         case TypeIds_Array:
             return (rightType == TypeIds_Array && aLeft == aRight);
-
+#if DBG
         case TypeIds_Symbol:
-            switch (rightType)
+            if (rightType == TypeIds_Symbol)
             {
-            case TypeIds_Symbol:
-                {
                     const PropertyRecord* leftValue = JavascriptSymbol::UnsafeFromVar(aLeft)->GetValue();
                     const PropertyRecord* rightValue = JavascriptSymbol::UnsafeFromVar(aRight)->GetValue();
-                    return leftValue == rightValue;
-                }
+                    Assert(leftValue != rightValue);
             }
-            return false;
-
+#endif
         case TypeIds_GlobalObject:
         case TypeIds_HostDispatch:
             switch (rightType)

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -26,7 +26,7 @@ namespace Js
             // Addition of a Var that is not comparable by pointer value causes the set to be promoted to a ComplexVarSet
             SimpleVarMap,
             // A ComplexVarMap is a map containing Vars for which we must inspect the values to do a comparison
-            // This includes Strings, Symbols, and (sometimes) JavascriptNumbers
+            // This includes Strings and (sometimes) JavascriptNumbers
             ComplexVarMap
         };
 

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -34,7 +34,7 @@ namespace Js
             // Addition of a Var that is not comparable by pointer value causes the set to be promoted to a ComplexVarSet
             SimpleVarSet,
             // A ComplexVarSet is a set containing Vars for which we must inspect the values to do a comparison
-            // This includes Strings, Symbols, and (sometimes) JavascriptNumbers
+            // This includes Strings and (sometimes) JavascriptNumbers
             ComplexVarSet
         };
 

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -266,10 +266,12 @@ namespace Js
         switch (typeId)
         {
         case TypeIds_Symbol:
-            *value = left->GetValue() == JavascriptSymbol::FromVar(right)->GetValue();
+            *value = left == JavascriptSymbol::UnsafeFromVar(right);
+            Assert((left->GetValue() == JavascriptSymbol::UnsafeFromVar(right)->GetValue()) == *value);
             break;
         case TypeIds_SymbolObject:
-            *value = left->GetValue() == JavascriptSymbolObject::FromVar(right)->GetValue();
+            *value = left == JavascriptSymbol::UnsafeFromVar(JavascriptSymbolObject::UnsafeFromVar(right)->Unwrap());
+            Assert((left->GetValue() == JavascriptSymbolObject::UnsafeFromVar(right)->GetValue()) == *value);
             break;
         default:
             *value = FALSE;

--- a/lib/Runtime/Library/SameValueComparer.h
+++ b/lib/Runtime/Library/SameValueComparer.h
@@ -89,12 +89,6 @@ namespace Js
                     return JsUtil::CharacterBuffer<WCHAR>::StaticGetHashCode(v->GetString(), v->GetLength());
                 }
 
-            case TypeIds_Symbol:
-            {
-                JavascriptSymbol* sym = JavascriptSymbol::UnsafeFromVar(i);
-                return sym->GetValue()->GetHashCode();
-            }
-
             default:
                 return RecyclerPointerComparer<Var>::GetHashCode(i);
             }

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -712,10 +712,12 @@ namespace Js
             case TypeIds_Boolean:
                 goto ReturnFalse;
             case TypeIds_Symbol:
-                *value = JavascriptSymbol::FromVar(aLeft)->GetValue() == JavascriptSymbol::FromVar(aRight)->GetValue();
+                *value = (aLeft == aRight);
+                Assert((JavascriptSymbol::UnsafeFromVar(aLeft)->GetValue() == JavascriptSymbol::UnsafeFromVar(aRight)->GetValue()) == *value);
                 return TRUE;
             case TypeIds_SymbolObject:
-                *value = JavascriptSymbol::FromVar(aLeft)->GetValue() == JavascriptSymbolObject::FromVar(aRight)->GetValue();
+                *value = (aLeft == JavascriptSymbolObject::UnsafeFromVar(aRight)->Unwrap());
+                Assert((JavascriptSymbol::UnsafeFromVar(aLeft)->GetValue() == JavascriptSymbolObject::UnsafeFromVar(aRight)->GetValue()) == *value);
                 return TRUE;
             default:
                 goto RedoRight;


### PR DESCRIPTION
Added a jit fastpath in lowerer to do symbol compare.

This improves Ares-6's Air benchmark by nearly 18%