### PR TITLE
Restoring additional telemetry counting logic that was removed in previous cleanup

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -354,42 +354,17 @@
 // Telemetry features (non-DEBUG related)
 #ifdef ENABLE_BASIC_TELEMETRY
 
-    // These defines can be "overridden" in other headers (e.g. ESBuiltInsTelemetryProvider.h) in case a specific telemetry provider wants to change an option for performance.
-    #define TELEMETRY_OPCODE_OFFSET_ENABLED true              // If the BytecodeOffset and FunctionId are logged.
-    #define TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId) true // Any filter to apply on a per propertyId basis in the opcode handler for GetProperty/TypeofProperty/GetMethodProperty/etc.
-    #define TELEMETRY_OPCODE_GET_PROPERTY_VALUES true         // If no telemetry providers need the values of properties then this option skips getting the value in the TypeofProperty opcode handler.
-
 //    #define TELEMETRY_PROFILED    // If telemetry should capture "Profiled*" operations
-//    #define TELEMETRY_CACHEHIT    // If telemetry should capture data that was gotten with a Cache Hit
+
 //    #define TELEMETRY_JSO         // If telemetry should capture JavascriptOperators (expensive, as it happens during JITed code too, not just interpreted mode)
     #define TELEMETRY_AddToCache    // If telemetry should capture property-gets only when the propertyId is added to the cache (generally this means only the first usage of any feature is logged)
 //    #define TELEMETRY_INTERPRETER // If telemetry should capture more interpreter events compared to just TELEMETRY_AddToCache
 
-
-    #define TELEMETRY_TRACELOGGING   // Telemetry output using TraceLogging
-//    #define TELEMETRY_OUTPUTPRINT    // Telemetry output using Output::Print
-
-    // Enable/disable specific telemetry providers:
-    #define TELEMETRY_ESB  // Telemetry of ECMAScript Built-Ins usage or detection.
-//    #define TELEMETRY_ARRAY_USAGE // Telemetry of Array usage statistics
-    #define TELEMETRY_DateParse // Telemetry of `Date.parse`
-
-    #ifdef TELEMETRY_ESB
-        // Because ESB telemetry is in-production and has major performance implications, this redefines some of the #defines above to disable non-critical functionality to get more performance.
-        #undef TELEMETRY_OPCODE_OFFSET_ENABLED // Disable the FunctionId+Offset tracker.
-        #define TELEMETRY_OPCODE_OFFSET_ENABLED false
-        #undef TELEMETRY_PROPERTY_OPCODE_FILTER // Redefine the Property Opcode filter to ignore non-built-in properties.
-        #define TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId) (propertyId < Js::PropertyIds::_countJSOnlyProperty)
-        #undef TELEMETRY_OPCODE_GET_PROPERTY_VALUES
-        #define TELEMETRY_OPCODE_GET_PROPERTY_VALUES false
-
-        //#define TELEMETRY_ESB_GetConstructorPropertyPolyfillDetection // Whether telemetry will inspect the `.constructor` property of every Object instance to determine if it's a polyfill of a known ES built-in.
-    #endif
+     #define TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId) (propertyId < Js::PropertyIds::_countJSOnlyProperty)
 
     #define REJIT_STATS
 #else
 
-    #define TELEMETRY_OPCODE_OFFSET_ENABLED false
     #define TELEMETRY_OPCODE_FILTER(propertyId) false
 
 #endif

--- a/lib/Runtime/Language/CacheOperators.cpp
+++ b/lib/Runtime/Language/CacheOperators.cpp
@@ -71,7 +71,7 @@ namespace Js
         {
             if (TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId))
             {
-                requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(objectWithProperty, propertyId, nullptr, !isMissing);
+                requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(objectWithProperty, propertyId, nullptr);
             }
         }
 #endif
@@ -137,7 +137,7 @@ namespace Js
         {
             if (TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId))
             {
-                requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(info->GetInstance(), propertyId, nullptr, true /* true, because if a getter is being evaluated then the property does exist. */);
+                requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(info->GetInstance(), propertyId, nullptr);
             }
         }
 #endif

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1762,7 +1762,7 @@ CommonNumber:
             {
                 if (info && info->AllowResizingPolymorphicInlineCache()) // If in interpreted mode, not JIT.
                 {
-                    requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(instance, propertyId, nullptr, /*successful: */false);
+                    requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(instance, propertyId, nullptr);
                 }
             }
 #endif
@@ -2030,7 +2030,7 @@ CommonNumber:
             {
                 if (info && info->AllowResizingPolymorphicInlineCache()) // If in interpreted mode, not JIT.
                 {
-                    requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(instance, propertyId, nullptr, /*successful: */false);
+                    requestContext->GetTelemetry().GetOpcodeTelemetry().GetProperty(instance, propertyId, nullptr);
                 }
             }
 #endif


### PR DESCRIPTION
When cleaning up telemetry in a previous PR, I removed some logic that will track counts for different builtins under some additional circumstances.  This PR restores that logic.  In addition , I cleaned up some unused #defines in CommonDefines.h 