### PR TITLE
[MSFT 16510487] Change type when assigning cross site entry point to a locked type

### DIFF
--- a/lib/Runtime/Base/CrossSite.cpp
+++ b/lib/Runtime/Base/CrossSite.cpp
@@ -58,11 +58,11 @@ namespace Js
             HostScriptContext * hostScriptContext = scriptContext->GetHostScriptContext();
             if (!hostScriptContext || !hostScriptContext->SetCrossSiteForFunctionType(function))
             {
-                if (function->GetDynamicType()->GetIsShared())
+                if (function->GetDynamicType()->GetIsLocked())
                 {
-                    TTD_XSITE_LOG(scriptContext, "SetCrossSiteForSharedFunctionType ", object);
+                    TTD_XSITE_LOG(scriptContext, "SetCrossSiteForLockedFunctionType ", object);
 
-                    function->GetLibrary()->SetCrossSiteForSharedFunctionType(function);
+                    function->GetLibrary()->SetCrossSiteForLockedFunctionType(function);
                 }
                 else
                 {
@@ -186,9 +186,9 @@ namespace Js
             //TODO: what happens if the gaurd in marshal (MarshalDynamicObject) isn't true?
             //
 
-            if(function->GetDynamicType()->GetIsShared())
+            if(function->GetTypeHandler()->GetIsLocked())
             {
-                function->GetLibrary()->SetCrossSiteForSharedFunctionType(function);
+                function->GetLibrary()->SetCrossSiteForLockedFunctionType(function);
             }
             else
             {

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5028,9 +5028,9 @@ namespace Js
 
 #endif // ENABLE_TTD
 
-    void JavascriptLibrary::SetCrossSiteForSharedFunctionType(JavascriptFunction * function)
+    void JavascriptLibrary::SetCrossSiteForLockedFunctionType(JavascriptFunction * function)
     {
-        Assert(function->GetDynamicType()->GetIsShared());
+        Assert(function->GetDynamicType()->GetIsLocked());
 
         if (ScriptFunction::Is(function))
         {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1086,7 +1086,7 @@ namespace Js
         JavascriptFunction* EnsureJSONStringifyFunction();
         JavascriptFunction* EnsureObjectFreezeFunction();
 
-        void SetCrossSiteForSharedFunctionType(JavascriptFunction * function);
+        void SetCrossSiteForLockedFunctionType(JavascriptFunction * function);
 
         bool IsPRNGSeeded() { return isPRNGSeeded; }
         uint64 GetRandSeed0() { return randSeed0; }


### PR DESCRIPTION
We've been evolving shared types (only) when we set their entry points to a cross-site thunk. Now that function types can belong to type paths, we need to do this when types are locked as well. This avoids the case where a function gets a cross-site type when a property is added to the object.