### PR TITLE
Remove isEval field from ByteCode Symbol class

### DIFF
--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -110,26 +110,6 @@ public:
         }
     }
 
-    // For JScript, this should not return NULL because
-    // there is always an enclosing global scope.
-    Symbol *FindSymbol(SymbolName const& name, SymbolType symbolType, bool fCreate = true)
-    {
-        Symbol *sym = FindLocalSymbol(name);
-        if (sym == nullptr)
-        {
-            if (enclosingScope != nullptr)
-            {
-                sym = enclosingScope->FindSymbol(name, symbolType);
-            }
-            else if (fCreate)
-            {
-                sym = Anew(alloc, Symbol, name, nullptr, symbolType);
-                AddNewSymbol(sym);
-            }
-        }
-        return sym;
-    }
-
     void AddSymbol(Symbol *sym)
     {
         if (enclosingScope == nullptr)

--- a/lib/Runtime/ByteCode/Symbol.h
+++ b/lib/Runtime/ByteCode/Symbol.h
@@ -32,7 +32,6 @@ private:
     BYTE isBlockVar : 1;
     BYTE isConst : 1;
     BYTE isGlobal : 1;
-    BYTE isEval : 1;
     BYTE hasNonLocalReference : 1;  // if true, then this symbol needs to be heap-allocated
     BYTE isFuncExpr : 1;              // if true, then this symbol is allocated on it's on activation object
     BYTE isCatch : 1;               // if true then this a catch identifier
@@ -76,7 +75,6 @@ public:
         isBlockVar(false),
         isConst(false),
         isGlobal(false),
-        isEval(false), // will get properly set in constructor body
         hasNonLocalReference(false),
         isFuncExpr(false),
         isCatch(false),
@@ -102,19 +100,11 @@ public:
     {
         SetSymbolType(symbolType);
 
-        // Set it so we don't have to check it explicitly
-        isEval = MatchName(_u("eval"), 4);
-
         if (PHASE_TESTTRACE1(Js::StackFuncPhase) && hasFuncAssignment)
         {
             Output::Print(_u("HasFuncDecl: %s\n"), this->GetName().GetBuffer());
             Output::Flush();
         }
-    }
-
-    bool MatchName(const char16 *key, int length)
-    {
-        return name == SymbolName(key, length);
     }
 
     void SetScope(Scope *scope)
@@ -303,11 +293,6 @@ public:
     bool GetIsFormal() const
     {
         return symbolType == STFormal;
-    }
-
-    bool GetIsEval() const
-    {
-        return isEval;
     }
 
     bool GetIsCatch() const


### PR DESCRIPTION
Everytime a Symbol is created it construct another symbol for eval and
then compare to check if current symbol is eval. This shows up in profile
traces during defered parsing when ExtractScopeInfo is called. This field
is never used so remove it and save some work.
