### PR TITLE
Be more conservative about Mul_A operand values in prepass to avoid rejit.

### DIFF
--- a/test/Optimizer/mul_rejit_bug.baseline
+++ b/test/Optimizer/mul_rejit_bug.baseline
@@ -1,11 +1,4 @@
-BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
-BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
-BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
-BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
+Rejit: function: factorial ( (#1.1), #2), bailOutCount: 4 callCount: 0 reason: AggressiveMulIntTypeSpecDisabled (BailOutOnMulOverflow | BailOutOnNegativeZero)
 6.209600278328219e+62
-BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
-BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
-BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
-BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
-BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+Rejit: function: exponent ( (#1.2), #3), bailOutCount: 5 callCount: 0 reason: AggressiveMulIntTypeSpecDisabled (BailOutOnMulOverflow)
 1125899906842624

--- a/test/Optimizer/mul_rejit_bug.baseline
+++ b/test/Optimizer/mul_rejit_bug.baseline
@@ -1,0 +1,11 @@
+BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
+BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
+BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
+BailOut: function: factorial ( (#1.1), #2) offset: #001a Opcode: Mul_I4 Kind: BailOutOnMulOverflow | BailOutOnNegativeZero
+6.209600278328219e+62
+BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+BailOut: function: exponent ( (#1.2), #3) offset: #0016 Opcode: Mul_I4 Kind: BailOutOnMulOverflow
+1125899906842624

--- a/test/Optimizer/mul_rejit_bug.js
+++ b/test/Optimizer/mul_rejit_bug.js
@@ -1,0 +1,47 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function factorial(n)
+{
+    let result = 1;
+    for(let i = 0; i < n; ++i)
+    {
+        result *= (n - i);
+    }
+    return result;
+}
+
+function exponent(n)
+{
+    let result = 1;
+    for(let i = 0; i < n; ++i)
+    {
+        result *= 2;
+    }
+    return result;
+}
+
+function testFact()
+{
+    let result = 0.9999;
+    for (let i = 0; i < 50; ++i)
+    {
+        result += factorial(i);
+    }
+    return result;
+}
+
+function testExp()
+{
+    let result = 0.9999;
+    for (let i = 0; i < 50; ++i)
+    {
+        result += exponent(i);
+    }
+    return result;
+}
+
+WScript.Echo(testFact());
+WScript.Echo(testExp());

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1489,7 +1489,7 @@
     <default>
       <files>mul_rejit_bug.js</files>
       <baseline>mul_rejit_bug.baseline</baseline>
-      <compile-flags>-mic:1 -oopjit- -bgJit- -off:simplejit -trace:bailout</compile-flags>
+      <compile-flags>-mic:1 -oopjit- -bgJit- -off:simplejit -trace:rejit</compile-flags>
       <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1485,4 +1485,12 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -oopjit- -off:bailonnoprofile -loopinterpretcount:0 -OOPJITMissingOpts- </compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>mul_rejit_bug.js</files>
+      <baseline>mul_rejit_bug.baseline</baseline>
+      <compile-flags>-mic:1 -oopjit- -bgJit- -off:simplejit -trace:bailout</compile-flags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes:https://github.com/Microsoft/ChakraCore/issues/4744

JIT tries to typespec `result` in the following code to `int32`, even with AggressiveMulIntTypeSpec off

That later results in a JIT time bailout when `result` fails to loslessly convert and triggers rejit with AggressiveIntTypeSpec  off. 

Interestingly, in this particular scenario, it happens only if `result` is initialized to literal `1`. 
If it is initialized to `2` or even to `1` , but in a more roundabout way, the code runs more than 2 times faster, since it becomes a float Mul right away.

```JS
function factorialA(n)
{
    let result = 1;
    for(let i = 0; i < n; ++i)
    {
        //   1 * whatever     in prepass 
        //  seems like will not overflow, right?    not really...
        result *= (n - i)     
    }
    return result;
}
```

The fix is to be less aggressive with no-overflow predictions for Mul_A when AggressiveMulIntTypeSpec is off

The idea is - If we don't definitely know the operand's min/max values, or if the operand is live on the back edge, we can assume it will have full range and will likely overflow and should just use float math, unless the other operand is definitely very small. -  basically `1` or `0`. Even `result *= 2` is likely to overflow real quick since growth, if happens, is exponential.
