### PR TITLE
ValueType debugging experience

### DIFF
--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -1453,7 +1453,7 @@ void ValueType::ToVerboseString(char (&str)[VALUE_TYPE_MAX_STRING_SIZE]) const
     if(OneOn(Bits::Object))
     {
         // Exclude the object type for enumerating bits, and exclude bits specific to a different object type
-        b = _objectBits;
+        b = (Bits)_objectBits;
         if(IsLikelyArrayOrObjectWithArray())
             b &= ~(Bits::NonInts | Bits::NonFloats); // these are handled separately for better readability
         else

--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -1453,7 +1453,7 @@ void ValueType::ToVerboseString(char (&str)[VALUE_TYPE_MAX_STRING_SIZE]) const
     if(OneOn(Bits::Object))
     {
         // Exclude the object type for enumerating bits, and exclude bits specific to a different object type
-        b = (Bits)_objectBits;
+        b = static_cast<Bits>(_objectBits);
         if(IsLikelyArrayOrObjectWithArray())
             b &= ~(Bits::NonInts | Bits::NonFloats); // these are handled separately for better readability
         else

--- a/lib/Runtime/Language/ValueType.h
+++ b/lib/Runtime/Language/ValueType.h
@@ -30,6 +30,16 @@ private:
         #include "ValueTypes.h"
         #undef VALUE_TYPE_BIT
     };
+    enum class ObjectBits : TSize
+    {
+#define VALUE_TYPE_BIT(t, b)
+#define COMMON_TYPE_BIT(t, b) t = (b),
+#define OBJECT_TYPE_BIT(t, b) t = (b),
+        #include "ValueTypes.h"
+#undef VALUE_TYPE_BIT
+#undef OBJECT_TYPE_BIT
+#undef COMMON_TYPE_BIT
+    };
 
 public:
     #define BASE_VALUE_TYPE(t, b) static const ValueType t;
@@ -68,7 +78,7 @@ private:
         };
         struct
         {
-            Field(Bits) _objectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT;
+            Field(ObjectBits) _objectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT;
             Field(ObjectType) _objectType : sizeof(TSize) * 8 - (VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT); // use remaining bits
         };
 

--- a/lib/Runtime/Language/ValueTypes.h
+++ b/lib/Runtime/Language/ValueTypes.h
@@ -8,11 +8,19 @@
 
 #ifdef VALUE_TYPE_BIT
 
-VALUE_TYPE_BIT(Likely,                  static_cast<ValueType::TSize>(1 << 0    ))
-VALUE_TYPE_BIT(Undefined,               static_cast<ValueType::TSize>(1 << 1    ))
-VALUE_TYPE_BIT(Null,                    static_cast<ValueType::TSize>(1 << 2    ))
-VALUE_TYPE_BIT(CanBeTaggedValue,        static_cast<ValueType::TSize>(1 << 3    ))
-VALUE_TYPE_BIT(Object,                  static_cast<ValueType::TSize>(1 << 4    ))
+#ifndef COMMON_TYPE_BIT
+#define COMMON_TYPE_BIT VALUE_TYPE_BIT
+#endif
+
+#ifndef OBJECT_TYPE_BIT
+#define OBJECT_TYPE_BIT VALUE_TYPE_BIT
+#endif
+
+COMMON_TYPE_BIT(Likely,                  static_cast<ValueType::TSize>(1 << 0    ))
+COMMON_TYPE_BIT(Undefined,               static_cast<ValueType::TSize>(1 << 1    ))
+COMMON_TYPE_BIT(Null,                    static_cast<ValueType::TSize>(1 << 2    ))
+COMMON_TYPE_BIT(CanBeTaggedValue,        static_cast<ValueType::TSize>(1 << 3    ))
+COMMON_TYPE_BIT(Object,                  static_cast<ValueType::TSize>(1 << 4    ))
 
 #if !defined(VALUE_TYPE_OBJECT_BIT_INDEX)
 #define VALUE_TYPE_OBJECT_BIT_INDEX static_cast<ValueType::TSize>(4)
@@ -39,9 +47,9 @@ VALUE_TYPE_BIT(Simd,                    static_cast<ValueType::TSize>(1 << 14   
 #endif
 
 // The following bits only apply when the Object bit is set
-VALUE_TYPE_BIT(NoMissingValues,         static_cast<ValueType::TSize>(1 << 5    )) // array
-VALUE_TYPE_BIT(NonInts,                 static_cast<ValueType::TSize>(1 << 6    )) // array
-VALUE_TYPE_BIT(NonFloats,               static_cast<ValueType::TSize>(1 << 7    )) // array
+OBJECT_TYPE_BIT(NoMissingValues,         static_cast<ValueType::TSize>(1 << 5    )) // array
+OBJECT_TYPE_BIT(NonInts,                 static_cast<ValueType::TSize>(1 << 6    )) // array
+OBJECT_TYPE_BIT(NonFloats,               static_cast<ValueType::TSize>(1 << 7    )) // array
 
 #if !defined(VALUE_TYPE_ARRAY_BIT_COUNT)
 #define VALUE_TYPE_ARRAY_BIT_COUNT static_cast<ValueType::TSize>(3)
@@ -51,6 +59,8 @@ VALUE_TYPE_BIT(NonFloats,               static_cast<ValueType::TSize>(1 << 7    
 #define VALUE_TYPE_OBJECT_BIT_COUNT static_cast<ValueType::TSize>(3)
 #endif
 
+#undef OBJECT_TYPE_BIT
+#undef COMMON_TYPE_BIT
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Improve ValueType Debugger inspection by using a different enum for Object Bits

I have also added an entry for ValueType in our visualizer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4868)
<!-- Reviewable:end -->
