### PR TITLE
[MSFT 16526028] Don't let cross-site functions have PathTypeHandler's

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5034,13 +5034,11 @@ namespace Js
 
         if (ScriptFunction::Is(function))
         {
-            function->ChangeType();
-            function->SetEntryPoint(scriptContext->CurrentCrossSiteThunk);
+            this->SetCrossSiteForLockedNonBuiltInFunctionType(function);
         }
         else if (BoundFunction::Is(function))
         {
-            function->ChangeType();
-            function->SetEntryPoint(scriptContext->CurrentCrossSiteThunk);
+            this->SetCrossSiteForLockedNonBuiltInFunctionType(function);
         }
         else
         {
@@ -5060,10 +5058,23 @@ namespace Js
             }
             else
             {
-                function->ChangeType();
-                function->SetEntryPoint(scriptContext->CurrentCrossSiteThunk);
+                this->SetCrossSiteForLockedNonBuiltInFunctionType(function);
             }
         }
+    }
+
+    void JavascriptLibrary::SetCrossSiteForLockedNonBuiltInFunctionType(JavascriptFunction * function)
+    {
+        DynamicTypeHandler *typeHandler = function->GetTypeHandler();
+        if (typeHandler->IsPathTypeHandler())
+        {
+            PathTypeHandlerBase::FromTypeHandler(typeHandler)->ConvertToNonShareableTypeHandler(function);
+        }
+        else
+        {
+            function->ChangeType();
+        }
+        function->SetEntryPoint(scriptContext->CurrentCrossSiteThunk);
     }
 
     JavascriptExternalFunction*

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1090,6 +1090,7 @@ namespace Js
         JavascriptFunction* EnsureObjectFreezeFunction();
 
         void SetCrossSiteForLockedFunctionType(JavascriptFunction * function);
+        void SetCrossSiteForLockedNonBuiltInFunctionType(JavascriptFunction * function);
 
         bool IsPRNGSeeded() { return isPRNGSeeded; }
         uint64 GetRandSeed0() { return randSeed0; }

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1505,6 +1505,11 @@ namespace Js
         return ConvertToTypeHandler<ES5ArrayTypeHandler>(instance);
     }
 
+    DynamicTypeHandler* PathTypeHandlerBase::ConvertToNonShareableTypeHandler(DynamicObject* instance)
+    {
+        return TryConvertToSimpleDictionaryType<SimpleDictionaryTypeHandler>(instance, GetPathLength(), false);
+    }
+
     template <typename T>
     DynamicTypeHandler * PathTypeHandlerBase::TryConvertToSimpleDictionaryType(DynamicObject* instance, int propertyCapacity, bool mayBecomeShared)
     {

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -202,6 +202,8 @@ namespace Js
         virtual bool CanStorePropertyValueDirectly(const DynamicObject* instance, PropertyId propertyId, bool allowLetConst) override;
 #endif
 
+        DynamicTypeHandler* ConvertToNonShareableTypeHandler(DynamicObject* instance);
+
 #if ENABLE_FIXED_FIELDS
         virtual void DoShareTypeHandler(ScriptContext* scriptContext) override;
         virtual BOOL IsFixedProperty(const DynamicObject* instance, PropertyId propertyId) override;

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -89,6 +89,7 @@ namespace Js
         DictionaryTypeHandler* ConvertToDictionaryType(DynamicObject* instance);
         SimpleDictionaryTypeHandler* ConvertToSimpleDictionaryType(DynamicObject* instance);
         ES5ArrayTypeHandler* ConvertToES5ArrayType(DynamicObject* instance);
+        SimpleTypeHandler<size>* ConvertToNonSharedSimpleType(DynamicObject * instance);
 
         BOOL GetDescriptor(PropertyId propertyId, PropertyIndex * index);
         BOOL SetAttribute(DynamicObject* instance, PropertyIndex index, PropertyAttributes attribute);


### PR DESCRIPTION
Naively letting a function type participate in a type path when its entryPoint is set to a cross-site thunk means that it can transition to a non-cross-site type by having properties added or attributes set on existing properties. If a function type is already cross-site on first property access, go to a non-shared SimpleTypeHandler instead of PathTypeHandler. If a function type with a PathTypeHandler becomes a cross-site type, go to (Simple)DictionaryTypeHandler.