### PR TITLE
Wasm/AsmJs: Cleanup jit memory reload

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -700,69 +700,69 @@ IRBuilderAsmJs::CreateRelocRecord(IR::BranchInstr * branchInstr, uint32 offset, 
 }
 
 void
-IRBuilderAsmJs::BuildHeapBufferReload(uint32 offset)
+IRBuilderAsmJs::BuildHeapBufferReload(uint32 offset, bool isFirstLoad)
 {
-    IR::RegOpnd* bufferInfoSrc = nullptr;
-    int bufferOffset = 0;
-    int bufferLengthOffset = 0;
+    enum ShouldReload
+    {
+        DoReload,
+        DontReload
+    };
+    const auto AddLoadField = [&](AsmJsRegSlots::ConstSlots dst, AsmJsRegSlots::ConstSlots src, int32 fieldOffset, IRType type, ShouldReload shouldReload)
+    {
+        if (isFirstLoad || shouldReload == DoReload)
+        {
+            IR::RegOpnd * dstOpnd = BuildDstOpnd(dst, type);
+            IR::Opnd * srcOpnd = IR::IndirOpnd::New(BuildSrcOpnd(src, type), fieldOffset, type, m_func);
+            IR::Instr * instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
+            AddInstr(instr, offset);
+        }
+    };
 
 #ifdef ENABLE_WASM
-    if(m_func->GetJITFunctionBody()->IsWasmFunction())
+    const bool isWasm = m_func->GetJITFunctionBody()->IsWasmFunction();
+    const bool isSharedMem = m_func->GetJITFunctionBody()->GetAsmJsInfo()->IsSharedMemory();
+
+    if(isWasm)
     {
-        // WebAssembly.Memory
-        IR::RegOpnd * dstOpnd = BuildDstOpnd(AsmJsRegSlots::WasmMemoryReg, TyVar);
-        IR::Opnd * srcOpnd = IR::IndirOpnd::New(BuildSrcOpnd(AsmJsRegSlots::ModuleMemReg, TyVar), (int32)Js::WebAssemblyModule::GetMemoryOffset(), TyVar, m_func);
-        IR::Instr * instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-        AddInstr(instr, offset);
+        // WebAssembly.Memory only needs to be loaded once as it can't change over the course of the function
+        AddLoadField(AsmJsRegSlots::WasmMemoryReg, AsmJsRegSlots::ModuleMemReg, (int32)Js::WebAssemblyModule::GetMemoryOffset(), TyVar, DontReload);
 
-        // ArrayBuffer
-        dstOpnd = BuildDstOpnd(AsmJsRegSlots::ArrayReg, TyVar);
-        srcOpnd = IR::IndirOpnd::New(BuildSrcOpnd(AsmJsRegSlots::WasmMemoryReg, TyVar), Js::WebAssemblyMemory::GetOffsetOfArrayBuffer(), TyVar, m_func);
-        instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-        AddInstr(instr, offset);
-
-#ifdef ENABLE_WASM_THREADS
-        if (m_func->GetJITFunctionBody()->GetAsmJsInfo()->IsSharedMemory())
+        if (!isSharedMem)
         {
-            // SharedContents
-            dstOpnd = BuildDstOpnd(AsmJsRegSlots::SharedContents, TyVar);
-            srcOpnd = IR::IndirOpnd::New(BuildSrcOpnd(AsmJsRegSlots::ArrayReg, TyVar), Js::SharedArrayBuffer::GetSharedContentsOffset(), TyVar, m_func);
-            instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-            AddInstr(instr, offset);
-
-            bufferInfoSrc = BuildSrcOpnd(AsmJsRegSlots::SharedContents, TyVar);
-            bufferOffset = Js::SharedContents::GetBufferOffset();
-            bufferLengthOffset = Js::SharedContents::GetBufferLengthOffset();
+            // ArrayBuffer
+            // GrowMemory can change the ArrayBuffer, we have to reload it
+            AddLoadField(AsmJsRegSlots::ArrayReg, AsmJsRegSlots::WasmMemoryReg, Js::WebAssemblyMemory::GetOffsetOfArrayBuffer(), TyVar, DoReload);
+            // ArrayBuffer.buffer
+            // The buffer doesn't change when using Fast Virtual buffer even if we grow the memory
+            ShouldReload shouldReloadBufferPointer = m_func->GetJITFunctionBody()->UsesWAsmJsFastVirtualBuffer() ? DontReload : DoReload;
+            AddLoadField(AsmJsRegSlots::BufferReg, AsmJsRegSlots::ArrayReg, Js::ArrayBuffer::GetBufferOffset(), TyVar, shouldReloadBufferPointer);
+            // ArrayBuffer.length
+            AddLoadField(AsmJsRegSlots::LengthReg, AsmJsRegSlots::ArrayReg, Js::ArrayBuffer::GetByteLengthOffset(), TyUint32, DoReload);
         }
-#endif
+        else
+        {
+            // SharedArrayBuffer
+            // SharedArrayBuffer cannot be detached and the buffer cannot change, no need to reload
+            AddLoadField(AsmJsRegSlots::ArrayReg, AsmJsRegSlots::WasmMemoryReg, Js::WebAssemblyMemory::GetOffsetOfArrayBuffer(), TyVar, DontReload);
+            // SharedArrayBuffer.SharedContents
+            AddLoadField(AsmJsRegSlots::SharedContents, AsmJsRegSlots::ArrayReg, Js::SharedArrayBuffer::GetSharedContentsOffset(), TyVar, DontReload);
+            // SharedContents.buffer
+            AddLoadField(AsmJsRegSlots::BufferReg, AsmJsRegSlots::SharedContents, Js::SharedContents::GetBufferOffset(), TyVar, DontReload);
+            // SharedContents.length
+            AddLoadField(AsmJsRegSlots::LengthReg, AsmJsRegSlots::SharedContents, Js::SharedContents::GetBufferLengthOffset(), TyUint32, DoReload);
+        }
     }
     else
 #endif
     {
         // ArrayBuffer
-        IR::RegOpnd * dstOpnd = BuildDstOpnd(AsmJsRegSlots::ArrayReg, TyVar);
-        IR::Opnd * srcOpnd = IR::IndirOpnd::New(BuildSrcOpnd(AsmJsRegSlots::ModuleMemReg, TyVar), (int32)Js::AsmJsModuleMemory::MemoryTableBeginOffset, TyVar, m_func);
-        IR::Instr * instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-        AddInstr(instr, offset);
+        // The ArrayBuffer can be changed on the environment, if it is detached, we'll throw
+        AddLoadField(AsmJsRegSlots::ArrayReg, AsmJsRegSlots::ModuleMemReg, (int32)Js::AsmJsModuleMemory::MemoryTableBeginOffset, TyVar, DontReload);
+        // ArrayBuffer.buffer
+        AddLoadField(AsmJsRegSlots::BufferReg, AsmJsRegSlots::ArrayReg, Js::ArrayBuffer::GetBufferOffset(), TyVar, DontReload);
+        // ArrayBuffer.length
+        AddLoadField(AsmJsRegSlots::LengthReg, AsmJsRegSlots::ArrayReg, Js::ArrayBuffer::GetByteLengthOffset(), TyUint32, DontReload);
     }
-
-    if (!bufferInfoSrc)
-    {
-        bufferInfoSrc = BuildSrcOpnd(AsmJsRegSlots::ArrayReg, TyVar);
-        bufferOffset = Js::ArrayBuffer::GetBufferOffset();
-        bufferLengthOffset = Js::ArrayBuffer::GetByteLengthOffset();
-    }
-    // ArrayBuffer buffer
-    IR::RegOpnd * dstOpnd = BuildDstOpnd(AsmJsRegSlots::BufferReg, TyVar);
-    IR::Opnd * srcOpnd = IR::IndirOpnd::New(bufferInfoSrc, bufferOffset, TyVar, m_func);
-    IR::Instr * instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-    AddInstr(instr, offset);
-
-    // ArrayBuffer length
-    dstOpnd = BuildDstOpnd(AsmJsRegSlots::LengthReg, TyUint32);
-    srcOpnd = IR::IndirOpnd::New(bufferInfoSrc, bufferLengthOffset, TyUint32, m_func);
-    instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
-    AddInstr(instr, offset);
 }
 
 template<typename T, typename ConstOpnd, typename F>
@@ -811,7 +811,7 @@ IRBuilderAsmJs::BuildConstantLoads()
     // Load heap buffer
     if (m_asmFuncInfo->UsesHeapBuffer())
     {
-        BuildHeapBufferReload(Js::Constants::NoByteCodeOffset);
+        BuildHeapBufferReload(Js::Constants::NoByteCodeOffset, true);
     }
     if (!constTable)
     {
@@ -1542,9 +1542,7 @@ IRBuilderAsmJs::BuildWasmMemAccess(Js::OpCodeAsmJs newOpcode, uint32 offset, uin
         instr = IR::Instr::New(op, indirOpnd, regOpnd, m_func);
     }
 
-#if ENABLE_FAST_ARRAYBUFFER
-    if (!CONFIG_FLAG(WasmFastArray))
-#endif
+    if (!m_func->GetJITFunctionBody()->UsesWAsmJsFastVirtualBuffer())
     {
         instr->SetSrc2(BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32));
     }
@@ -1657,9 +1655,10 @@ IRBuilderAsmJs::BuildAsmTypedArr(Js::OpCodeAsmJs newOpcode, uint32 offset, uint3
         instr = IR::Instr::New(op, indirOpnd, regOpnd, m_func);
     }
 
-#if !ENABLE_FAST_ARRAYBUFFER
-    instr->SetSrc2(BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32));
-#endif
+    if (!m_func->GetJITFunctionBody()->UsesWAsmJsFastVirtualBuffer())
+    {
+        instr->SetSrc2(BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32));
+    }
     AddInstr(instr, offset);
 }
 

--- a/lib/Backend/IRBuilderAsmJs.h
+++ b/lib/Backend/IRBuilderAsmJs.h
@@ -132,7 +132,7 @@ private:
     uint                    AddStatementBoundary(uint statementIndex, uint offset);
     BranchReloc *           AddBranchInstr(IR::BranchInstr *instr, uint32 offset, uint32 targetOffset);
     BranchReloc *           CreateRelocRecord(IR::BranchInstr * branchInstr, uint32 offset, uint32 targetOffset);
-    void                    BuildHeapBufferReload(uint32 offset);
+    void                    BuildHeapBufferReload(uint32 offset, bool isFirstLoad = false);
     template<typename T, typename ConstOpnd, typename F>
     void                    CreateLoadConstInstrForType(byte* table, Js::RegSlot& regAllocated, uint32 constCount, uint32 offset, IRType irType, ValueType valueType, Js::OpCode opcode, F extraProcess);
     void                    BuildConstantLoads();

--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -605,17 +605,7 @@ bool JITTimeFunctionBody::UsesWAsmJsFastVirtualBuffer() const
 #ifdef ENABLE_WASM
     if (IsWasmFunction())
     {
-        if (CONFIG_FLAG(WasmFastArray))
-        {
-            return true;
-        }
-#ifdef _WIN32
-        if (GetAsmJsInfo()->IsSharedMemory() && CONFIG_FLAG(WasmSharedArrayVirtualBuffer))
-        {
-            return true;
-        }
-#endif
-        return false;
+        return CONFIG_FLAG(WasmFastArray);
     }
 #endif
     return true;

--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -598,6 +598,32 @@ JITTimeFunctionBody::IsWasmFunction() const
     return m_bodyData.isWasmFunction != FALSE;
 }
 
+bool JITTimeFunctionBody::UsesWAsmJsFastVirtualBuffer() const
+{
+    // Using Fast Virtual Buffer means that bounds checks can be omitted
+#if ENABLE_FAST_ARRAYBUFFER
+#ifdef ENABLE_WASM
+    if (IsWasmFunction())
+    {
+        if (CONFIG_FLAG(WasmFastArray))
+        {
+            return true;
+        }
+#ifdef _WIN32
+        if (GetAsmJsInfo()->IsSharedMemory() && CONFIG_FLAG(WasmSharedArrayVirtualBuffer))
+        {
+            return true;
+        }
+#endif
+        return false;
+    }
+#endif
+    return true;
+#else
+    return false;
+#endif
+}
+
 bool
 JITTimeFunctionBody::IsStrictMode() const
 {

--- a/lib/Backend/JITTimeFunctionBody.h
+++ b/lib/Backend/JITTimeFunctionBody.h
@@ -75,6 +75,7 @@ public:
     bool IsLambda() const;
     bool IsAsmJsMode() const;
     bool IsWasmFunction() const;
+    bool UsesWAsmJsFastVirtualBuffer() const;
     bool IsStrictMode() const;
     bool IsEval() const;
     bool HasImplicitArgIns() const;

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1351,11 +1351,7 @@ PolymorphicEmitInfo WasmBytecodeGenerator::EmitCall()
     }
     AdeleteArray(&m_alloc, nArgs, argsList);
 
-    if (isImportCall && (m_module->HasMemory() || m_module->HasMemoryImport()))
-    {
-        m_writer->EmptyAsm(Js::OpCodeAsmJs::CheckHeap);
-        SetUsesMemory(0);
-    }
+    // WebAssemblyArrayBuffer is not detachable, no need to check for detached state here
 
     // track stack requirements for out params
 

--- a/test/wasm/reload.js
+++ b/test/wasm/reload.js
@@ -1,0 +1,93 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test(shared) {
+  if (shared) {
+    WScript.Flag("-WasmThreads");
+  }
+  const memPrefix = shared ? "i32.atomic" : "i32";
+  const buf = WebAssembly.wabt.convertWast2Wasm(`
+  (module
+    (import "test" "grow" (func $grow_import))
+    (memory (export "mem") 1 100 ${shared ? "shared" : ""})
+    (func $grow (grow_memory (i32.const 1)) drop)
+    (func $empty)
+    (func (export "test") (param $i i32) (result i32)
+      (local $v i32)
+      (i32.ge_s (get_local $i) (i32.const 10))
+      (if (result i32)
+        ;; not growing scenario
+        (then
+          (${memPrefix}.store (i32.const 0) (get_local $i))
+          (call $empty)
+          (i32.load (i32.const 0))
+          (set_local $v (i32.add (i32.const 1)))
+          (i32.store (i32.const 2) (get_local $v))
+          (call $empty)
+          (${memPrefix}.load (i32.const 0))
+        )
+        ;; growing scenario
+        (else
+          (${memPrefix}.store (i32.const 0) (get_local $i))
+          (call $grow)
+          (${memPrefix}.load (i32.const 0))
+          (set_local $v (i32.add (get_local $i)))
+          (i32.store (i32.const 2) (get_local $v))
+          (call $grow_import)
+          (${memPrefix}.load (i32.const 0))
+        )
+      )
+    )
+  )`);
+
+  const hex = v => "0x" + v.toString(16);
+
+  function validate(res, val) {
+    const growing = val < 10;
+    const expected = !growing
+      ? (val & 0xFFFF) + (((val + 1) << 16) & 0xFFFFFFFF)
+      : (val & 0xFFFF) + (((val + val) << 16) & 0xFFFFFFFF);
+    if (res !== expected) {
+      const testType = growing ? ".grow" : "";
+      const sharing = shared ? "shared memory" : "normal memory";
+      console.log(`${sharing}: test${testType}(${val}) Invalid value. Expected ${hex(expected)}, got ${hex(res)}`);
+    }
+  }
+
+  const mod = new WebAssembly.Module(buf);
+  const {exports} = new WebAssembly.Instance(mod, {
+    test: {grow() {
+      try {
+        // try to detach, should not be possible
+        ArrayBuffer.detach(exports.mem.buffer);
+        console.log("ArrayBuffer.detach should not have succeeded");
+      } catch (e) {
+        if (
+          // WebAssemblySharedArrayBuffer are not classic ArrayBuffer
+          (shared && !e.message.includes("ArrayBuffer object expected")) ||
+          (!shared && !e.message.includes("Not allowed to detach WebAssembly.Memory buffer"))
+        ) {
+           console.log(e);
+        }
+      }
+      exports.mem.grow(1);
+    }}
+  });
+
+  validate(exports.test(5), 5);
+
+  for (let i = 0; i < 100; ++i) {
+    // Warm up with empty calls
+    const val = ((i % 20) + 15)|0;
+    validate(exports.test(val), val);
+  }
+
+  validate(exports.test(5), 5);
+}
+
+test(false);
+test(true);
+
+console.log("pass");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -420,4 +420,11 @@
     <compile-flags>-wasmthreads -ESSharedArrayBuffer -args summary -endargs</compile-flags>
   </default>
 </test>
+<test>
+  <default>
+    <files>reload.js</files>
+    <compile-flags>-wasmthreads -ESSharedArrayBuffer</compile-flags>
+    <tags>exclude_jshost</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
Reduce the number of Buffer reloads to do in WebAssembly and Asm.js.
Do not check for detached heap in Wasm as it can't be detached.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4874)
<!-- Reviewable:end -->
