### PR TITLE
Tune Number.toString conversion to be more like in Chrome

### DIFF
--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2473,17 +2473,20 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, __out_ecount(cchDst
     return TRUE;
 }
 
-// Maximum number of digits to show for each base.
+// Maximum number of digits to show for each base
+// so we keep the same precision as the original number.
+// Thus, the number is calculated as: ceil(ln(2**53)/ln(base)).
 static const int g_rgcchSig[] =
 {
-    00,00,53,34,27,24,22,20,19,18,
-    17,17,16,16,15,15,14,14,14,14,
-    14,13,13,13,13,13,13,12,12,12,
-    12,12,12,12,12,12,12
+    00,00,53,34,27,23,21,19,18,17,
+    16,16,15,15,14,14,14,13,13,13,
+    13,13,12,12,12,12,12,12,12,11,
+    11,11,11,11,11,11,11
 };
 
 //
-// Convert a non-Nan, non-Zero, non-Infinite double value to string. (Moved from JavascriptNumber.cpp).
+// Convert a non-Nan, non-Zero, non-Infinite double value to string representation 
+// with given radix. (Moved from JavascriptNumber.cpp, back compat port of FDblToStrRadix()).
 //
 _Success_(return)
 BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) int radix, _Out_writes_(nDstBufSize) WCHAR* psz, int nDstBufSize)
@@ -2495,46 +2498,46 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
     Assert(radix != 10);
     Assert(radix >= 2 && radix <= 36);
 
-    // convert to string with radix
-    //( back compat port of FDblToStrRadix())
-
-    int cbitDigit;
-    double valueDen, valueT;
-    int wExp2, wExp, wDig;
-    int maxOutDigits, cchSig, cch;
+    int wDig;
+    int cchSig, cch;
     int len = nDstBufSize;
     char16 * ppsz = psz;
 
+    // handle negative number
     if (0x80000000 & Js::NumberUtilities::LuHiDbl(dbl))
     {
         *ppsz++ = '-';
         len--;
         Js::NumberUtilities::LuHiDbl(dbl) &= 0x7FFFFFFF;
     }
+
+    // We special case log computations for powers of 2.
+    int cbitDigit = 0;
     switch (radix)
     {
-        // We special case log computations for powers of 2.
         case  2: cbitDigit = 1; break;
         case  4: cbitDigit = 2; break;
         case  8: cbitDigit = 3; break;
         case 16: cbitDigit = 4; break;
         case 32: cbitDigit = 5; break;
-        default: cbitDigit = 0; break;
     }
 
     // REVIEW : fix this to do more accurate conversions? This is exact for
     // powers of 2, but not for other radixes.
     // REVIEW : round?
-    wExp2 = (int)((Js::NumberUtilities::LuHiDbl(dbl) & 0x7FF00000) >> 20) - 0x03FF;
-    maxOutDigits = g_rgcchSig[radix];
+    const int maxOutDigits = g_rgcchSig[radix];
     __analysis_assume(maxOutDigits > 0);
 
     // Output the integer portion.
     if (1 <= dbl)
     {
+        double valueDen;
+
         if (0 != cbitDigit)
         {
-            wExp = wExp2 / cbitDigit;
+            int wExp2 = (int)((Js::NumberUtilities::LuHiDbl(dbl) & 0x7FF00000) >> 20) - 0x03FF;
+
+            int wExp = wExp2 / cbitDigit;
             wExp2 = wExp * cbitDigit;
 
             Js::NumberUtilities::LuHiDbl(valueDen) = (uint32)(0x03FF + wExp2) << 20;
@@ -2544,6 +2547,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
         else
         {
             cchSig = 1;
+            double valueT;
             for (valueDen = 1; (valueT = valueDen * radix) <= dbl; valueDen = valueT)
             {
                 cchSig++;
@@ -2591,6 +2595,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
         }
         len--;
         *ppsz++ = '.';
+
         do
         {
             dbl *= radix;
@@ -2599,24 +2604,46 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
             {
                 wDig = radix - 1;
             }
+
             if (len < 2)
             {
                 return FALSE; //We run out of buffer size.
             }
             len--;
-            *ppsz++ = ToDigit(wDig);
             dbl -= wDig;
+
+            // If this is the last digit we are going to output,
+            // peek into the next one and round the current based on it.
+            // Should we replace equivalent of decimal "0.599999999" with "0.56"?
+            if (cchSig == maxOutDigits - 1)
+            {
+                const int nextDig = (int)(dbl*radix);
+                if (nextDig >= radix / 2 && wDig < radix - 1)
+                    wDig++;
+            }
+
+            // Don't count leading zeros towards precision.
+            *ppsz++ = ToDigit(wDig);
             if (0 != wDig || 0 != cchSig)
             {
                 cchSig++;
             }
+
         } while (0 != dbl && cchSig < maxOutDigits);
+
+        // Trim trailing zeros, this would trim "0.0" to "0." 
+        // but "0.0" should have been treated as integer above.
+        while (*(ppsz - 1) == '0')
+        {
+            ppsz--;
+        }
     }
 
     if (len < 1)
     {
         return FALSE; //We run out of buffer size.
     }
+
     *ppsz = 0;
 
     return TRUE;

--- a/test/Number/toString_3.baseline
+++ b/test/Number/toString_3.baseline
@@ -50,7 +50,7 @@ n.toString(10):  444123.7891234568
 n.toString(8):  1543333.62401776537
 n.toString(2):  1101100011011011011.110010100000001111111110101011111
 n.toString(16):  6c6db.ca03feaf8
-n.toString(25):  13aen.ji518inh
+n.toString(25):  13aen.ji518io
 n.toFixed():  444124
 n.toFixed(0):  444124
 n.toFixed(2):  444123.79
@@ -73,7 +73,7 @@ n.toString(10):  -444123.7896363636
 n.toString(8):  -1543333.62422633653
 n.toString(2):  -1101100011011011011.110010100010010110011011110101011
 n.toString(16):  -6c6db.ca259bd58
-n.toString(25):  -13aen.jid1hf8b
+n.toString(25):  -13aen.jid1hf8
 n.toFixed():  -444124
 n.toFixed(0):  -444124
 n.toFixed(2):  -444123.79


### PR DESCRIPTION
Fixes #2512. This change doesn't make out Number.toString to produce the same output as Chrome does, but gets it a bit more aligned.