### PR TITLE
Enable jitting loops with try/finally

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -172,7 +172,7 @@ FlowGraph::Build(void)
 
     bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
         (this->func->IsSimpleJit() && this->func->hasBailout) ||
-        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
+        this->func->IsLoopBodyInTryFinally());
 
     // We don't optimize fully with SimpleJit. But, when JIT loop body is enabled, we do support
     // bailing out from a simple jitted function to do a full jit of a loop body in the function
@@ -536,7 +536,7 @@ FlowGraph::Build(void)
         } NEXT_BLOCK_ALL;
     }
 
-    if (this->func->HasFinally() && this->func->IsLoopBodyInTry())
+    if (this->func->IsLoopBodyInTryFinally())
     {
         FOREACH_BLOCK_IN_FUNC(block, this->func)
         {
@@ -1089,7 +1089,7 @@ FlowGraph::MoveBlocksBefore(BasicBlock *blockStart, BasicBlock *blockEnd, BasicB
 
     bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
         (this->func->IsSimpleJit() && this->func->hasBailout) ||
-        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
+        this->func->IsLoopBodyInTryFinally());
 
     if (dstLastInstr->IsBranchInstr() && dstLastInstr->AsBranchInstr()->HasFallThrough())
     {
@@ -1878,7 +1878,7 @@ FlowGraph::UpdateRegionForBlock(BasicBlock * block)
 #if DBG
         bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
         (this->func->IsSimpleJit() && this->func->hasBailout) ||
-        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
+        this->func->IsLoopBodyInTryFinally());
         Assert(assignRegionsBeforeGlobopt);
 #endif
         return;
@@ -2420,7 +2420,7 @@ FlowGraph::InsertCompensationCodeForBlockMove(FlowEdge * edge,  bool insertToLoo
 
     bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
         (this->func->IsSimpleJit() && this->func->hasBailout) ||
-        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
+        this->func->IsLoopBodyInTryFinally());
 
     if (assignRegionsBeforeGlobopt)
     {

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -22,18 +22,33 @@ IR::LabelInstr * FlowGraph::DeleteLeaveChainBlocks(IR::BranchInstr *leaveInstr, 
 {
     // Cleanup Rest of the Leave chain
     IR::LabelInstr * leaveTarget = leaveInstr->GetTarget();
-    Assert(leaveTarget->GetNextRealInstr()->IsBranchInstr());
-    IR::BranchInstr *leaveChain = leaveTarget->GetNextRealInstr()->AsBranchInstr();
+    Assert(leaveTarget->GetNextBranchOrLabel()->IsBranchInstr());
+    IR::BranchInstr *leaveChain = leaveTarget->GetNextBranchOrLabel()->AsBranchInstr();
     IR::LabelInstr * curLabel = leaveTarget->AsLabelInstr();
 
     while (leaveChain->m_opcode != Js::OpCode::Br)
     {
         Assert(leaveChain->m_opcode == Js::OpCode::Leave || leaveChain->m_opcode == Js::OpCode::BrOnException);
-        IR::LabelInstr * nextLabel = leaveChain->m_next->AsLabelInstr();
-        leaveChain = nextLabel->m_next->AsBranchInstr();
+        IR::Instr * nextLabel = leaveChain->GetNextRealInstrOrLabel();
+        if (!nextLabel->GetNextRealInstrOrLabel()->IsBranchInstr())
+        {
+            // For jit loop bodies - we can encounter ProfiledLoopEnd before every early return
+            Assert(nextLabel->GetNextRealInstrOrLabel()->m_opcode == Js::OpCode::ProfiledLoopEnd);
+            IR::Instr * loopEnd = nextLabel->GetNextRealInstrOrLabel();
+            while (!loopEnd->GetNextRealInstrOrLabel()->IsBranchInstr())
+            {
+                Assert(loopEnd->m_opcode == Js::OpCode::ProfiledLoopEnd);
+                loopEnd = loopEnd->GetNextRealInstrOrLabel();
+            }
+            leaveChain = loopEnd->GetNextRealInstrOrLabel()->AsBranchInstr();
+        }
+        else
+        {
+            leaveChain = nextLabel->GetNextRealInstrOrLabel()->AsBranchInstr();
+        }
         BasicBlock *curBlock = curLabel->GetBasicBlock();
         this->RemoveBlock(curBlock);
-        curLabel = nextLabel;
+        curLabel = nextLabel->AsLabelInstr();
     }
 
     instrPrev = leaveChain->m_next;
@@ -67,13 +82,19 @@ bool FlowGraph::Dominates(Region *region1, Region *region2)
 bool FlowGraph::DoesExitLabelDominate(IR::BranchInstr *leaveInstr)
 {
     IR::LabelInstr * leaveTarget = leaveInstr->GetTarget();
-    Assert(leaveTarget->GetNextRealInstr()->IsBranchInstr());
-    IR::BranchInstr *leaveChain = leaveTarget->GetNextRealInstr()->AsBranchInstr();
+    Assert(leaveTarget->GetNextRealInstr()->IsBranchInstr() || leaveTarget->GetNextRealInstr()->m_opcode == Js::OpCode::ProfiledLoopEnd);
+    IR::BranchInstr *leaveChain = leaveTarget->GetNextBranchOrLabel()->AsBranchInstr();
 
     while (leaveChain->m_opcode != Js::OpCode::Br)
     {
         Assert(leaveChain->m_opcode == Js::OpCode::Leave || leaveChain->m_opcode == Js::OpCode::BrOnException);
         IR::LabelInstr * nextLabel = leaveChain->m_next->AsLabelInstr();
+        if (!nextLabel->m_next->IsBranchInstr())
+        {
+            // For jit loop bodies - we can encounter ProfiledLoopEnd before every early return
+            Assert(nextLabel->m_next->m_opcode == Js::OpCode::ProfiledLoopEnd);
+            break;
+        }
         leaveChain = nextLabel->m_next->AsBranchInstr();
     }
     IR::LabelInstr * exitLabel = leaveChain->GetTarget();
@@ -148,6 +169,10 @@ FlowGraph::Build(void)
     BEGIN_CODEGEN_PHASE(func, Js::FGPeepsPhase);
     this->RunPeeps();
     END_CODEGEN_PHASE(func, Js::FGPeepsPhase);
+
+    bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
+        (this->func->IsSimpleJit() && this->func->hasBailout) ||
+        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
 
     // We don't optimize fully with SimpleJit. But, when JIT loop body is enabled, we do support
     // bailing out from a simple jitted function to do a full jit of a loop body in the function
@@ -241,7 +266,8 @@ FlowGraph::Build(void)
             //          <try code>
             //          Leave L2
             //  L2 :    Br L3
-            //  L1 :    <finally code>
+            //  L1 :    Finally
+            //          <finally code>
             //          LeaveNull
             //  L3 :    <code after try finally>
             //
@@ -250,7 +276,7 @@ FlowGraph::Build(void)
             //          TryFinally L1
             //          <try code>
             //          BrOnException L1
-            //          Leave L1'
+            //          Leave L2
             //  L1 :    BailOnException
             //  L2 :    Finally
             //          <finally code>
@@ -263,8 +289,9 @@ FlowGraph::Build(void)
 
             IR::LabelInstr * finallyLabel = instr->m_prev->AsLabelInstr();
 
-            // Find leave label
+            this->finallyLabelStack->Push(finallyLabel);
 
+            // Find leave label
             Assert(finallyLabel->m_prev->m_opcode == Js::OpCode::Br && finallyLabel->m_prev->m_prev->m_opcode == Js::OpCode::Label);
 
             IR::Instr * insertPoint = finallyLabel->m_prev;
@@ -279,8 +306,6 @@ FlowGraph::Build(void)
             IR::Instr * bailOnException = IR::BailOutInstr::New(Js::OpCode::BailOnException, IR::BailOutOnException, instr->m_next, instr->m_func);
             insertPoint->InsertBefore(bailOnException);
             insertPoint->Remove();
-
-            this->finallyLabelStack->Push(finallyLabel);
 
             Assert(leaveTarget->labelRefs.HasOne());
             IR::BranchInstr * brOnException = IR::BranchInstr::New(Js::OpCode::BrOnException, finallyLabel, instr->m_func);
@@ -385,9 +410,6 @@ FlowGraph::Build(void)
     //     2. SimpleJit: Same case of correct restoration as above applies in SimpleJit too. However, the only bailout
     //        we have in Simple Jitted code right now is BailOnSimpleJitToFullJitLoopBody, installed in IRBuilder. So,
     //        for now, we can just check if the func has a bailout to assign regions pre globopt while running SimpleJit.
-
-    bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
-        (this->func->IsSimpleJit() && this->func->hasBailout));
 
     blockNum = 0;
     FOREACH_BLOCK_ALL(block, this)
@@ -512,6 +534,24 @@ FlowGraph::Build(void)
         {
             block->SetBlockNum(blockNum++);
         } NEXT_BLOCK_ALL;
+    }
+
+    if (this->func->HasFinally() && this->func->IsLoopBodyInTry())
+    {
+        FOREACH_BLOCK_IN_FUNC(block, this->func)
+        {
+            FOREACH_INSTR_IN_BLOCK_EDITING(instr, instrNext, block)
+            {
+                if (instr->m_opcode == Js::OpCode::Leave && (block->GetFirstInstr()->AsLabelInstr()->GetRegion()->GetType() == RegionTypeRoot))
+                {
+                    // Found an orphaned leave, should be an early return from the loop body, insert bailout
+                    Assert(instr->AsBranchInstr()->m_isOrphanedLeave);
+                    IR::Instr * bailOnEarlyExit = IR::BailOutInstr::New(Js::OpCode::BailOnEarlyExit, IR::BailOutOnEarlyExit, instr, instr->m_func);
+                    instr->InsertBefore(bailOnEarlyExit);
+                }
+            }
+            NEXT_INSTR_IN_BLOCK_EDITING
+        } NEXT_BLOCK_IN_FUNC;
     }
 
     this->FindLoops();
@@ -1048,7 +1088,8 @@ FlowGraph::MoveBlocksBefore(BasicBlock *blockStart, BasicBlock *blockEnd, BasicB
     IR::Instr *dstLastInstr = dstPredBlockLastInstr;
 
     bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
-        (this->func->IsSimpleJit() && this->func->hasBailout));
+        (this->func->IsSimpleJit() && this->func->hasBailout) ||
+        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
 
     if (dstLastInstr->IsBranchInstr() && dstLastInstr->AsBranchInstr()->HasFallThrough())
     {
@@ -1700,7 +1741,9 @@ FlowGraph::Destroy(void)
                         break;
                     case Js::OpCode::Leave:
                         AssertMsg(region == predRegion->GetParent() || (predRegion->GetType() == RegionTypeTry && predRegion->GetMatchingFinallyRegion(false) == region) ||
-                            (region == predRegion && this->func->IsLoopBodyInTry()), "Bad region prop on leaving try-catch/finally");
+                            (region == predRegion && this->func->IsLoopBodyInTry() ||
+                            // edge from early exit to finally in simplejit - in fulljit this Leave would have been deadcoded due to preceeding BailOutOnEarlyExit
+                            (predBlock->GetLastInstr()->GetPrevRealInstr()->m_opcode == Js::OpCode::BailOnEarlyExit && region->GetType() == RegionTypeFinally && this->func->IsSimpleJit())), "Bad region prop on leaving try-catch/finally");
                         break;
                     case Js::OpCode::LeaveNull:
                         AssertMsg(region == predRegion->GetParent() || (region == predRegion && this->func->IsLoopBodyInTry()), "Bad region prop on leaving try-catch/finally");
@@ -1757,13 +1800,13 @@ FlowGraph::Destroy(void)
                 break;
 
             case RegionTypeTry:
-                if ((this->func->IsSimpleJit() && this->func->hasBailout) || !this->func->DoOptimizeTry())
+                if (this->func->DoOptimizeTry() || (this->func->IsSimpleJit() && this->func->hasBailout))
                 {
-                    Assert((region->GetMatchingCatchRegion() != nullptr) ^ (region->GetMatchingFinallyRegion(true) && !region->GetMatchingFinallyRegion(false)));
+                    Assert((region->GetMatchingCatchRegion() != nullptr) ^ (region->GetMatchingFinallyRegion(true) && region->GetMatchingFinallyRegion(false)));
                 }
                 else
                 {
-                    Assert((region->GetMatchingCatchRegion() != nullptr) ^ (region->GetMatchingFinallyRegion(true) && region->GetMatchingFinallyRegion(false)));
+                    Assert((region->GetMatchingCatchRegion() != nullptr) ^ (region->GetMatchingFinallyRegion(true) && !region->GetMatchingFinallyRegion(false)));
                 }
                 break;
 
@@ -1832,7 +1875,12 @@ FlowGraph::UpdateRegionForBlock(BasicBlock * block)
     IR::Instr * firstInstr = block->GetFirstInstr();
     if (firstInstr->IsLabelInstr() && firstInstr->AsLabelInstr()->GetRegion())
     {
-        Assert(this->func->HasTry() && (this->func->DoOptimizeTry() || (this->func->IsSimpleJit() && this->func->hasBailout)));
+#if DBG
+        bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
+        (this->func->IsSimpleJit() && this->func->hasBailout) ||
+        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
+        Assert(assignRegionsBeforeGlobopt);
+#endif
         return;
     }
 
@@ -2371,7 +2419,8 @@ FlowGraph::InsertCompensationCodeForBlockMove(FlowEdge * edge,  bool insertToLoo
     }
 
     bool assignRegionsBeforeGlobopt = this->func->HasTry() && (this->func->DoOptimizeTry() ||
-        (this->func->IsSimpleJit() && this->func->hasBailout));
+        (this->func->IsSimpleJit() && this->func->hasBailout) ||
+        (this->func->HasFinally() && this->func->IsLoopBodyInTry()));
 
     if (assignRegionsBeforeGlobopt)
     {

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -278,6 +278,12 @@ Func::IsLoopBodyInTry() const
     return IsLoopBody() && m_workItem->GetLoopHeader()->isInTry;
 }
 
+bool
+Func::IsLoopBodyInTryFinally() const
+{
+    return IsLoopBody() && m_workItem->GetLoopHeader()->isInTryFinally;
+}
+
 /* static */
 void
 Func::Codegen(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -187,6 +187,7 @@ public:
     bool HasArgumentSlot() const { return this->GetInParamsCount() != 0 && !this->IsLoopBody(); }
     bool IsLoopBody() const { return m_workItem->IsLoopBody(); }
     bool IsLoopBodyInTry() const;
+    bool IsLoopBodyInTryFinally() const;
     bool CanAllocInPreReservedHeapPageSegment();
     void SetDoFastPaths();
     bool DoFastPaths() const { Assert(this->hasCalledSetDoFastPaths); return this->m_doFastPaths; }

--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -157,6 +157,7 @@ JITTimeFunctionBody::InitializeJITFunctionData(
             jitBody->loopHeaders[i].endOffset = loopHeaders[i].endOffset;
             jitBody->loopHeaders[i].isNested = loopHeaders[i].isNested;
             jitBody->loopHeaders[i].isInTry = loopHeaders[i].isInTry;
+            jitBody->loopHeaders[i].isInTryFinally = loopHeaders[i].isInTryFinally;
             jitBody->loopHeaders[i].interpretCount = functionBody->GetLoopInterpretCount(&loopHeaders[i]);
         }
     }

--- a/lib/Backend/JnHelperMethod.cpp
+++ b/lib/Backend/JnHelperMethod.cpp
@@ -250,8 +250,8 @@ DECLSPEC_GUARDIGNORE  _NOINLINE intptr_t GetNonTableMethodAddress(ThreadContextI
         return ShiftStdcallAddr(context, Js::JavascriptExceptionOperators::OP_TryFinally);
 
 
-    case HelperOp_TryFinallySimpleJit:
-        return ShiftStdcallAddr(context, Js::JavascriptExceptionOperators::OP_TryFinallySimpleJit);
+    case HelperOp_TryFinallyNoOpt:
+        return ShiftStdcallAddr(context, Js::JavascriptExceptionOperators::OP_TryFinallyNoOpt);
 
         //
         // Methods that we don't want to get marked as CFG targets as they dump all registers to a controlled address

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -356,7 +356,7 @@ HELPERCALL(Simd128ConvertUD2, (void(*)(SIMDValue*, SIMDValue*))&Js::SIMDFloat64x
 
 HELPERCALL(Op_TryCatch, nullptr, 0)
 HELPERCALL(Op_TryFinally, nullptr, AttrCanThrow)
-HELPERCALL(Op_TryFinallySimpleJit, nullptr, AttrCanThrow)
+HELPERCALL(Op_TryFinallyNoOpt, nullptr, AttrCanThrow)
 #if _M_X64
 HELPERCALL(Op_ReturnFromCallWithFakeFrame, amd64_ReturnFromCallWithFakeFrame, 0)
 #endif

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -2567,13 +2567,13 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::LeaveNull:
-            if (this->m_func->IsSimpleJit() || !this->m_func->DoOptimizeTry())
+            if (this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))
             {
-                instrPrev = m_lowererMD.LowerLeaveNull(instr);
+                instr->Remove();
             }
             else
             {
-                instr->Remove();
+                instrPrev = m_lowererMD.LowerLeaveNull(instr);
             }
             break;
 
@@ -26380,8 +26380,7 @@ Lowerer::LowerTry(IR::Instr* instr, bool tryCatch)
     instr->InsertBefore(setInstr);
     LowererMD::Legalize(setInstr);
 
-    return m_lowererMD.LowerTry(instr, tryCatch ? IR::HelperOp_TryCatch : ((this->m_func->IsSimpleJit() && !this->m_func->hasBailout) || !this->m_func->DoOptimizeTry()) ?
-        IR::HelperOp_TryFinallySimpleJit : IR::HelperOp_TryFinally);
+    return m_lowererMD.LowerTry(instr, tryCatch ? IR::HelperOp_TryCatch : ((this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))? IR::HelperOp_TryFinally : IR::HelperOp_TryFinallySimpleJit));
 }
 
 IR::Instr *

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -26380,7 +26380,7 @@ Lowerer::LowerTry(IR::Instr* instr, bool tryCatch)
     instr->InsertBefore(setInstr);
     LowererMD::Legalize(setInstr);
 
-    return m_lowererMD.LowerTry(instr, tryCatch ? IR::HelperOp_TryCatch : ((this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))? IR::HelperOp_TryFinally : IR::HelperOp_TryFinallySimpleJit));
+    return m_lowererMD.LowerTry(instr, tryCatch ? IR::HelperOp_TryCatch : ((this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))? IR::HelperOp_TryFinally : IR::HelperOp_TryFinallyNoOpt));
 }
 
 IR::Instr *

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -367,7 +367,7 @@ LowererMD::LowerTry(IR::Instr *tryInstr, IR::JnHelperMethod helperMethod)
     // Arg 5: ScriptContext
     this->m_lowerer->LoadScriptContext(tryAddr);
 
-    if (tryInstr->m_opcode == Js::OpCode::TryCatch || this->m_func->DoOptimizeTry())
+    if (tryInstr->m_opcode == Js::OpCode::TryCatch || (this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout)))
     {
         // Arg 4 : hasBailedOutOffset
         IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->m_hasBailedOutSym->m_offset, TyInt32, this->m_func);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -328,6 +328,7 @@ PHASE(All)
 #endif
         PHASE(JITLoopBody)
         PHASE(JITLoopBodyInTryCatch)
+        PHASE(JITLoopBodyInTryFinally)
         PHASE(ReJIT)
         PHASE(ExecutionMode)
         PHASE(SimpleJitDynamicProfile)

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -393,7 +393,8 @@ typedef struct JITLoopHeaderIDL
 {
     boolean isNested;
     boolean isInTry;
-    IDL_PAD2(0)
+    boolean isInTryFinally;
+    IDL_PAD1(0)
     unsigned int interpretCount;
     unsigned int startOffset;
     unsigned int endOffset;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1021,6 +1021,7 @@ namespace Js
 #endif
         Field(bool) isNested;
         Field(bool) isInTry;
+        Field(bool) isInTryFinally;
         Field(FunctionBody *) functionBody;
 
 #if DBG_DUMP

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -210,8 +210,8 @@ namespace Js
         }
 
         if (this->DoJitLoopBodies() &&
-            !this->m_functionWrite->GetFunctionBody()->GetHasFinally() &&
-            !(this->m_functionWrite->GetFunctionBody()->GetHasTry() && PHASE_OFF(Js::JITLoopBodyInTryCatchPhase, this->m_functionWrite)))
+            !(this->m_functionWrite->GetFunctionBody()->GetHasTry() && PHASE_OFF(Js::JITLoopBodyInTryCatchPhase, this->m_functionWrite)) &&
+            !(this->m_functionWrite->GetFunctionBody()->GetHasFinally() && PHASE_OFF(Js::JITLoopBodyInTryFinallyPhase, this->m_functionWrite)))
         {
             AllocateLoopHeaders();
         }

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1090,7 +1090,8 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         bool doJITLoopBody =
             !this->executeFunction->GetScriptContext()->GetConfig()->IsNoNative() &&
-            !(this->executeFunction->GetHasTry() && (PHASE_OFF((Js::JITLoopBodyInTryCatchPhase), this->executeFunction) || this->executeFunction->GetHasFinally())) &&
+            !(this->executeFunction->GetHasTry() && (PHASE_OFF((Js::JITLoopBodyInTryCatchPhase), this->executeFunction))) &&
+            !(this->executeFunction->GetHasFinally() && (PHASE_OFF((Js::JITLoopBodyInTryFinallyPhase), this->executeFunction))) &&
             (this->executeFunction->ForceJITLoopBody() || this->executeFunction->IsJitLoopBodyPhaseEnabled()) &&
             !this->executeFunction->IsInDebugMode();
 #endif

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -5754,6 +5754,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
 
         Js::LoopHeader *loopHeader = fn->GetLoopHeader(loopNumber);
         loopHeader->isInTry = this->TestFlags(Js::InterpreterStackFrameFlags_WithinTryBlock);
+        loopHeader->isInTryFinally = this->TestFlags(Js::InterpreterStackFrameFlags_WithinTryFinallyBlock);
 
         Js::LoopEntryPointInfo * entryPointInfo = loopHeader->GetCurrentEntryPointInfo();
 
@@ -6538,6 +6539,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
                 // mark the stackFrame as 'in try block'
                 this->OrFlags(InterpreterStackFrameFlags_WithinTryBlock);
 
+                if (finallyOffset != 0)
+                {
+                    this->OrFlags(InterpreterStackFrameFlags_WithinTryFinallyBlock);
+                }
+
                 if (tryNestingDepth != 0)
                 {
                     this->ProcessTryHandlerBailout(ehBailoutData->child, --tryNestingDepth);
@@ -6638,7 +6644,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
         if (--this->nestedTryDepth == -1)
         {
             // unmark the stackFrame as 'in try block'
-            this->ClearFlags(InterpreterStackFrameFlags_WithinTryBlock);
+            this->ClearFlags(InterpreterStackFrameFlags_WithinTryBlock | InterpreterStackFrameFlags_WithinTryFinallyBlock);
         }
 
         // Now that the stack is unwound, let's run the catch block.
@@ -6844,7 +6850,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
 
             this->nestedTryDepth++;
             // mark the stackFrame as 'in try block'
-            this->OrFlags(InterpreterStackFrameFlags_WithinTryBlock);
+            this->OrFlags(InterpreterStackFrameFlags_WithinTryBlock | InterpreterStackFrameFlags_WithinTryFinallyBlock);
 
             if (shouldCacheSP)
             {
@@ -6887,7 +6893,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
         if (--this->nestedTryDepth == -1)
         {
             // unmark the stackFrame as 'in try block'
-            this->ClearFlags(InterpreterStackFrameFlags_WithinTryBlock);
+            this->ClearFlags(InterpreterStackFrameFlags_WithinTryBlock | InterpreterStackFrameFlags_WithinTryFinallyBlock);
         }
 
         shouldCacheSP = !skipFinallyBlock;

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -29,6 +29,7 @@ namespace Js
         InterpreterStackFrameFlags_ProcessingBailOutFromEHCode = 0x20,
         InterpreterStackFrameFlags_FromBailOutInInlinee = 0x40,
         InterpreterStackFrameFlags_ProcessingBailOutOnArraySpecialization = 0x80,
+        InterpreterStackFrameFlags_WithinTryFinallyBlock = 0x100,
         InterpreterStackFrameFlags_All = 0xFFFF,
     };
 

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -208,7 +208,7 @@ namespace Js
         return tryContinuation;
     }
 
-    void * JavascriptExceptionOperators::OP_TryFinallySimpleJit(void * tryAddr, void * finallyAddr, void * frame, size_t spillSize, size_t argsSize, ScriptContext * scriptContext)
+    void * JavascriptExceptionOperators::OP_TryFinallyNoOpt(void * tryAddr, void * finallyAddr, void * frame, size_t spillSize, size_t argsSize, ScriptContext * scriptContext)
     {
         void                      *tryContinuation = nullptr;
         void                      *finallyContinuation = nullptr;
@@ -384,7 +384,7 @@ namespace Js
         return tryContinuation;
     }
 
-    void *JavascriptExceptionOperators::OP_TryFinallySimpleJit(
+    void *JavascriptExceptionOperators::OP_TryFinallyNoOpt(
         void *tryAddr,
         void *finallyAddr,
         void *framePtr,
@@ -759,7 +759,7 @@ namespace Js
         return continuationAddr;
     }
 
-    void* JavascriptExceptionOperators::OP_TryFinallySimpleJit(void* tryAddr, void* handlerAddr, void* framePtr, ScriptContext *scriptContext)
+    void* JavascriptExceptionOperators::OP_TryFinallyNoOpt(void* tryAddr, void* handlerAddr, void* framePtr, ScriptContext *scriptContext)
     {
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
         void* continuationAddr = NULL;

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -65,15 +65,15 @@ namespace Js
 #ifdef _M_X64
         static void *OP_TryCatch(void *try_, void *catch_, void *frame, size_t spillSize, size_t argsSize, int hasBailedOutOffset, ScriptContext *scriptContext);
         static void *OP_TryFinally(void *try_, void *finally_, void *frame, size_t spillSize, size_t argsSize, int hasBailedOutOffset, ScriptContext *scriptContext);
-        static void *OP_TryFinallySimpleJit(void *try_, void *finally_, void *frame, size_t spillSize, size_t argsSize, ScriptContext *scriptContext);
+        static void *OP_TryFinallyNoOpt(void *try_, void *finally_, void *frame, size_t spillSize, size_t argsSize, ScriptContext *scriptContext);
 #elif defined(_M_ARM32_OR_ARM64)
         static void* OP_TryCatch(void* continuationAddr, void* handlerAddr, void* framePtr, void *localsPtr, size_t argsSize, int hasBailedOutOffset, ScriptContext* scriptContext);
         static void* OP_TryFinally(void* continuationAddr, void* handlerAddr, void* framePtr, void *localsPtr, size_t argsSize, int hasBailedOutOffset, ScriptContext* scriptContext);
-        static void* OP_TryFinallySimpleJit(void* continuationAddr, void* handlerAddr, void* framePtr, void *localsPtr, size_t argsSize, ScriptContext* scriptContext);
+        static void* OP_TryFinallyNoOpt(void* continuationAddr, void* handlerAddr, void* framePtr, void *localsPtr, size_t argsSize, ScriptContext* scriptContext);
 #else
         static void* OP_TryCatch(void* continuationAddr, void* handlerAddr, void* framePtr, int hasBailedOutOffset, ScriptContext* scriptContext);
         static void* OP_TryFinally(void* continuationAddr, void* handlerAddr, void* framePtr, int hasBailedOutOffset, ScriptContext* scriptContext);
-        static void* OP_TryFinallySimpleJit(void* continuationAddr, void* handlerAddr, void* framePtr, ScriptContext* scriptContext);
+        static void* OP_TryFinallyNoOpt(void* continuationAddr, void* handlerAddr, void* framePtr, ScriptContext* scriptContext);
 #endif
 #if defined(DBG) && defined(_M_IX86)
         static void DbgCheckEHChain();


### PR DESCRIPTION
This enables jitting sooner, when we have higher iterations of forof loops.

- Identify early returns in jit loop body : We assign regions and all orphaned leaves will be early returns for which we insert BailOutOnEarlyExit
- Now SimpleJit has BailOutFromSimpleJitToFullJitLoopBody, when we have bailouts we need to have accurate flow to build liveness bvs, so
  we allow SimpleJit with bailout to fall through the same codepath as fulljit for tryfinallys before
