### PR TITLE
Update implementation of HostPromiseRejectionTracker

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -994,6 +994,7 @@ namespace Js
             scriptContext = nullptr;
         }
     }
+
     void JavascriptLibrary::Finalize(bool isShutdown)
     {
         __super::Finalize(isShutdown);
@@ -4442,12 +4443,6 @@ namespace Js
         this->nativeHostPromiseContinuationFunctionState = state;
     }
 
-    void JavascriptLibrary::SetNativeHostPromiseRejectionTrackerCallback(HostPromiseRejectionTrackerCallback function, void *state)
-    {
-        this->nativeHostPromiseRejectionTracker = function;
-        this->nativeHostPromiseContinuationFunctionState = state;
-    }
-
     void JavascriptLibrary::CallNativeHostPromiseRejectionTracker(Var promise, Var reason, bool handled)
     {
         if (this->nativeHostPromiseRejectionTracker != nullptr)
@@ -4455,7 +4450,7 @@ namespace Js
             BEGIN_LEAVE_SCRIPT(scriptContext);
             try
             {
-               this->nativeHostPromiseRejectionTracker(promise, reason, handled, this->nativeHostPromiseContinuationFunctionState);
+                this->nativeHostPromiseRejectionTracker(promise, reason, handled, this->nativeHostPromiseRejectionTrackerState);
             }
             catch (...)
             {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -247,7 +247,6 @@ namespace Js
         static DWORD GetRandSeed1Offset() { return offsetof(JavascriptLibrary, randSeed1); }
         static DWORD GetTypeDisplayStringsOffset() { return offsetof(JavascriptLibrary, typeDisplayStrings); }
         typedef bool (CALLBACK *PromiseContinuationCallback)(Var task, void *callbackState);
-        typedef void (CALLBACK *HostPromiseRejectionTrackerCallback)(Var promise, Var reason, bool handled, void *callbackState);
 
         Var GetUndeclBlockVar() const { return undeclBlockVarSentinel; }
         bool IsUndeclBlockVar(Var var) const { return var == undeclBlockVarSentinel; }
@@ -456,9 +455,6 @@ namespace Js
 
         FieldNoBarrier(PromiseContinuationCallback) nativeHostPromiseContinuationFunction;
         Field(void *) nativeHostPromiseContinuationFunctionState;
-
-        FieldNoBarrier(HostPromiseRejectionTrackerCallback) nativeHostPromiseRejectionTracker = nullptr;
-        Field(void *) nativeHostPromiseRejectionTrackerState;
 
         typedef SList<Js::FunctionProxy*, Recycler> FunctionReferenceList;
         typedef JsUtil::WeakReferenceDictionary<uintptr_t, DynamicType, DictionarySizePolicy<PowerOf2Policy, 1>> JsrtExternalTypesCache;
@@ -818,7 +814,7 @@ namespace Js
         JavascriptFunction* GetThrowerFunction() const { return throwerFunction; }
 
         void SetNativeHostPromiseContinuationFunction(PromiseContinuationCallback function, void *state);
-        void SetNativeHostPromiseRejectionTrackerCallback(HostPromiseRejectionTrackerCallback function, void *state);
+
         void CallNativeHostPromiseRejectionTracker(Var promise, Var reason, bool handled);
 
         void SetJsrtContext(FinalizableObject* jsrtContext);

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -16,6 +16,7 @@ namespace Js
     {
         friend class JavascriptLibrary;
         friend class ScriptSite;
+
     public:
         JavascriptLibraryBase(GlobalObject* globalObject):
             globalObject(globalObject)
@@ -297,6 +298,19 @@ namespace Js
         Field(JavascriptSymbol*) symbolToPrimitive;
         Field(JavascriptSymbol*) symbolToStringTag;
         Field(JavascriptSymbol*) symbolUnscopables;
+
+    public:
+        typedef void (CALLBACK *HostPromiseRejectionTrackerCallback)(Var promise, Var reason, bool handled, void *callbackState);
+
+        void SetNativeHostPromiseRejectionTrackerCallback(HostPromiseRejectionTrackerCallback function, void *state)
+        {
+            this->nativeHostPromiseRejectionTracker = function;
+            this->nativeHostPromiseRejectionTrackerState = state;
+        }
+
+    private:
+        FieldNoBarrier(HostPromiseRejectionTrackerCallback) nativeHostPromiseRejectionTracker = nullptr;
+        Field(void *) nativeHostPromiseRejectionTrackerState = nullptr;
 
     public:
         Field(ScriptContext*) scriptContext;


### PR DESCRIPTION
Fix to correctly use `nativeHostPromiseRejectionTrackerState` and move implementation to `JavascriptLibraryBase` (with `Set` defined in header for static lib linkage).