### PR TITLE
Check buffer length in FNonZeroFiniteDblToStr

### DIFF
--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2506,6 +2506,10 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
     // handle negative number
     if (0x80000000 & Js::NumberUtilities::LuHiDbl(dbl))
     {
+        if (len < 2)
+        {
+            return FALSE;
+        }
         *ppsz++ = '-';
         len--;
         Js::NumberUtilities::LuHiDbl(dbl) &= 0x7FFFFFFF;


### PR DESCRIPTION
For the function `Js::NumberUtilities::FNonZeroFiniteDblToStr` (in `NumberUtilities_strtod.cpp`), if the input double value `dbl` is negative and `nDstBufSize` is zero, there's a buffer overflow. The buffer length is not checked before the buffer `ppsz` is written.

This is not currently triggerable, since all callers pass a 256 byte buffer. But I think it's good to check the length here just in case.