### PR TITLE
Array Constructor fastpath with definitive non-ints

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -5223,11 +5223,10 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
     IR::Opnd *opndOfArrayCtor = argInstr->GetSrc1();
     const uint16 upperBoundValue = 8;
     // Generate fast path only if it meets all the conditions:
-    // 1. It is the only parameter
+    // 1. It is the only parameter and it is a likely int
     // 2a. If 1st parameter is a variable, emit fast path with checks
     // 2b. If 1st parameter is a constant, it is in range 0 and upperBoundValue (inclusive)
-    if (opndOfArrayCtor->IsAddrOpnd() || opndOfArrayCtor->IsRegOpnd()) // #1
-
+    if (opndOfArrayCtor->GetValueType().IsLikelyInt() && (opndOfArrayCtor->IsAddrOpnd() || opndOfArrayCtor->IsRegOpnd())) // #1
     {
         if ((linkSym->GetArgSlotNum() == 2)) // 1. It is the only parameter
         {
@@ -18419,7 +18418,7 @@ Lowerer::GenerateFastInlineStringFromCodePoint(IR::Instr* instr)
     Assert(argInstr->m_opcode == Js::OpCode::ArgOut_A);
     IR::Opnd *src1 = argInstr->GetSrc1();
 
-    if (src1->GetValueType().IsLikelyNumber())
+    if (src1->GetValueType().IsLikelyInt())
     {
         //Trying to generate this code
         //      MOV resultOpnd, dst
@@ -18494,7 +18493,7 @@ Lowerer::GenerateFastInlineStringFromCharCode(IR::Instr* instr)
     Assert(argInstr->m_opcode == Js::OpCode::ArgOut_A);
     IR::Opnd *src1 = argInstr->GetSrc1();
 
-    if (src1->GetValueType().IsLikelyNumber())
+    if (src1->GetValueType().IsLikelyInt())
     {
         //Trying to generate this code
         //      MOV resultOpnd, dst

--- a/test/Array/constructor_fastpath.js
+++ b/test/Array/constructor_fastpath.js
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function makeArray() {
+  return [new Array(true), new Array("some string")];
+}
+
+for (let i = 0; i < 100; ++i) {
+  makeArray();
+}
+
+console.log("pass");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -759,4 +759,9 @@
       <files>bug12340575.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>constructor_fastpath.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Check if the Array constructor opnd is a likely int to do the fast path.
If the opnd is a definite bool or string, we know the fast path won't work and we'll always go to helper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4890)
<!-- Reviewable:end -->
