### PR TITLE
handle ERROR_COMMITMENT_LIMIT from oopjit call as an OOM

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3745,6 +3745,7 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
         return true;
     case E_ABORT:
         throw Js::OperationAbortedException();
+    case HRESULT_FROM_WIN32(ERROR_COMMITMENT_LIMIT): 
     case E_OUTOFMEMORY:
         if (callType == RemoteCallType::MemFree)
         {


### PR DESCRIPTION
current behavior is failfast, but this will improve error messaging