### PR TITLE
Make JsSerialize to work with strings

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -2664,4 +2664,87 @@ namespace JsRTApiTest
     {
         JsRTApiTest::RunWithAttributes(JsRTApiTest::JsCreateStringTest);
     }
+
+    void ApiTest_JsSerializeArrayTest(JsRuntimeAttributes /*attributes*/, JsRuntimeHandle /*runtime*/)
+    {
+        LPCSTR raw_script = "(function (){return true;})();";
+        LPCWSTR raw_wscript = L"(function (){return true;})();";
+
+        // JsSerializeScript has good test coverage and can be used as an oracle for JsSerialize
+        unsigned int bcBufferSize_Expected = 0;
+        REQUIRE(JsSerializeScript(raw_wscript, nullptr, &bcBufferSize_Expected) == JsNoError);
+        BYTE *bcBuffer_Expected = new BYTE[bcBufferSize_Expected];
+        REQUIRE(JsSerializeScript(raw_wscript, bcBuffer_Expected, &bcBufferSize_Expected) == JsNoError);
+        REQUIRE(bcBuffer_Expected != nullptr);
+
+        // JsSerialize from an external array
+        JsValueRef scriptSource = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateExternalArrayBuffer(
+            (void*)raw_script, (unsigned int)strlen(raw_script), nullptr, (void*)raw_script, &scriptSource) == JsNoError);
+
+        JsValueRef buffer = JS_INVALID_REFERENCE;
+        REQUIRE(JsSerialize(scriptSource, &buffer, JsParseScriptAttributeNone) == JsNoError);
+
+        BYTE *bcBuffer = nullptr;
+        unsigned int bcBufferSize = 0;
+        REQUIRE(JsGetArrayBufferStorage(buffer, &bcBuffer, &bcBufferSize) == JsNoError);
+
+        REQUIRE(bcBufferSize_Expected == bcBufferSize);
+        CHECK(memcmp(bcBuffer_Expected, bcBuffer, bcBufferSize_Expected) == 0);
+    }
+
+    TEST_CASE("ApiTest_JsSerialize_Array", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ApiTest_JsSerializeArrayTest);
+    }
+
+    void ApiTest_JsSerializeStringTest(JsRuntimeAttributes /*attributes*/, JsRuntimeHandle /*runtime*/)
+    {
+        LPCSTR raw_script = "(function (){return true;})();";
+        LPCWSTR raw_wscript = L"(function (){return true;})();";
+
+        // JsSerializeScript has good test coverage and can be used as an oracle for JsSerialize
+        unsigned int bcBufferSize_Expected = 0;
+        REQUIRE(JsSerializeScript(raw_wscript, nullptr, &bcBufferSize_Expected) == JsNoError);
+        BYTE* bcBuffer_Expected = new BYTE[bcBufferSize_Expected];
+        REQUIRE(JsSerializeScript(raw_wscript, bcBuffer_Expected, &bcBufferSize_Expected) == JsNoError);
+        REQUIRE(bcBuffer_Expected != nullptr);
+
+        // JsSerialize from a string
+        JsValueRef script = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateString(raw_script, static_cast<size_t>(-1), &script) == JsNoError);
+
+        JsValueRef buffer = JS_INVALID_REFERENCE;
+        REQUIRE(JsSerialize(script, &buffer, JsParseScriptAttributeNone) == JsNoError);
+
+        BYTE *bcBuffer = nullptr;
+        unsigned int bcBufferSize = 0;
+        REQUIRE(JsGetArrayBufferStorage(buffer, &bcBuffer, &bcBufferSize) == JsNoError);
+
+        REQUIRE(bcBufferSize_Expected == bcBufferSize);
+        CHECK(memcmp(bcBuffer_Expected, bcBuffer, bcBufferSize_Expected) == 0);
+
+        delete[] bcBuffer_Expected;
+    }
+
+    TEST_CASE("ApiTest_JsSerialize_String", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ApiTest_JsSerializeStringTest);
+    }
+
+    void ApiTest_JsSerializeParseErrorTest(JsRuntimeAttributes /*attributes*/, JsRuntimeHandle /*runtime*/)
+    {
+        LPCSTR raw_script = "(function (){return true;})(;";
+
+        JsValueRef script = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateString(raw_script, static_cast<size_t>(-1), &script) == JsNoError);
+
+        JsValueRef buffer = JS_INVALID_REFERENCE;
+        CHECK(JsSerialize(script, &buffer, JsParseScriptAttributeNone) == JsErrorScriptCompile);
+    }
+
+    TEST_CASE("ApiTest_JsSerialize_FailParse", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::ApiTest_JsSerializeParseErrorTest);
+    }
 }

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -4971,17 +4971,13 @@ CHAKRA_API JsSerialize(
 
     *bufferVal = nullptr;
 
-    bool isExternalArray = Js::ExternalArrayBuffer::Is(scriptVal),
-         isString = false;
-    bool isUtf8   = !(parseAttributes & JsParseScriptAttributeArrayBufferIsUtf16Encoded);
-    if (!isExternalArray)
+    const bool isExternalArray = Js::ExternalArrayBuffer::Is(scriptVal);
+    const bool isString = !isExternalArray && Js::JavascriptString::Is(scriptVal);
+    if (!isExternalArray && !isString)
     {
-        isString = Js::JavascriptString::Is(scriptVal);
-        if (!isString)
-        {
-            return JsErrorInvalidArgument;
-        }
+        return JsErrorInvalidArgument;
     }
+    const bool isUtf8 = !isString && !(parseAttributes & JsParseScriptAttributeArrayBufferIsUtf16Encoded);
 
     LoadScriptFlag scriptFlag;
     const byte* script = isExternalArray ?
@@ -4989,7 +4985,7 @@ CHAKRA_API JsSerialize(
         (const byte*)((Js::JavascriptString*)(scriptVal))->GetSz();
     const size_t cb = isExternalArray ?
         ((Js::ExternalArrayBuffer*)(scriptVal))->GetByteLength() :
-        ((Js::JavascriptString*)(scriptVal))->GetLength();
+        ((Js::JavascriptString*)(scriptVal))->GetSizeInBytes();
 
     if (isExternalArray && isUtf8)
     {

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -53,7 +53,12 @@ namespace Js
         virtual void GetPropertyRecord(_Out_ PropertyRecord const** propertyRecord, bool dontLookupFromDictionary = false);
 
         _Ret_range_(m_charLength, m_charLength) charcount_t GetLength() const;
+
+        // Non-finalized strings haven't allocated buffers yet, but
+        // it always makes sense to talk about string's size in bytes.
+        charcount_t GetSizeInBytes() const { return GetLength() * sizeof(char16); };
         virtual size_t GetAllocatedByteCount() const;
+
         virtual bool IsSubstring() const;
         int GetLengthAsSignedInt() const;
         const char16* UnsafeGetBuffer() const;


### PR DESCRIPTION
Fixes #4824:
- treat strings as wide
- get the buffer lengh in bytes (not chars)

Added UTs for both array and string call patterns.