### PR TITLE
A few small improvements to JSON serialization speed

### DIFF
--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -33,7 +33,7 @@ namespace Js
         Assert(IsPolymorphicInlineCacheAvailable == !!propertyValueInfo->GetPolymorphicInlineCache());
         Assert(!ReturnOperationInfo || operationInfo);
 
-        if(CheckLocal || CheckProto || CheckAccessor)
+        if(CheckLocal || CheckProto || CheckAccessor || CheckMissing)
         {
             InlineCache *const inlineCache = IsInlineCacheAvailable ? propertyValueInfo->GetInlineCache() : nullptr;
             if(IsInlineCacheAvailable)

--- a/lib/Runtime/Language/InlineCache.inl
+++ b/lib/Runtime/Language/InlineCache.inl
@@ -20,7 +20,7 @@ namespace Js
         ScriptContext *const requestContext,
         PropertyCacheOperationInfo *const operationInfo)
     {
-        CompileAssert(CheckLocal || CheckProto || CheckAccessor);
+        CompileAssert(CheckLocal || CheckProto || CheckAccessor || CheckMissing);
         Assert(!ReturnOperationInfo || operationInfo);
         CompileAssert(!ReturnOperationInfo || (CheckLocal && CheckProto && CheckAccessor));
         Assert(instance);

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -32,6 +32,11 @@ namespace Js
         {
             return false;
         }
+        return IsCallable(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    bool JavascriptConversion::IsCallable(_In_ RecyclableObject* aValue)
+    {
         JavascriptMethod entryPoint = RecyclableObject::UnsafeFromVar(aValue)->GetEntryPoint();
         return RecyclableObject::DefaultEntryPoint != entryPoint;
     }

--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -71,6 +71,7 @@ namespace Js {
         static bool SameValue(Var aValue, Var bValue);
         static bool SameValueZero(Var aValue, Var bValue);
         static bool IsCallable(Var aValue);
+        static bool IsCallable(_In_ RecyclableObject* aValue);
 
         static BOOL ToInt32Finite(Var aValue, ScriptContext* scriptContext, int32* result);
 

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4965,9 +4965,9 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
         return RecyclableObject::FromVar(aValue)->GetRemoteTypeId(typeId);
     }
 
-    BOOL JavascriptOperators::IsJsNativeObject(Var aValue)
+    BOOL JavascriptOperators::IsJsNativeType(TypeId type)
     {
-        switch(GetTypeId(aValue))
+        switch(type)
         {
             case TypeIds_Object:
             case TypeIds_Function:
@@ -5007,6 +5007,16 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
             default:
                 return false;
         }
+    }
+
+    BOOL JavascriptOperators::IsJsNativeObject(Var instance)
+    {
+        return IsJsNativeType(GetTypeId(instance));
+    }
+
+    BOOL JavascriptOperators::IsJsNativeObject(_In_ RecyclableObject* instance)
+    {
+        return IsJsNativeType(GetTypeId(instance));
     }
 
     bool JavascriptOperators::CanShortcutOnUnknownPropertyName(RecyclableObject *instance)

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1737,26 +1737,8 @@ CommonNumber:
                 Output::Print(_u("MissingPropertyCaching: Missing property %d on slow path.\n"), propertyId);
             }
 
-            // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers and DictionaryTypeHandlers, because only these types have the right behavior
-            // when the missing property is later added: path types guarantee a type change, and DictionaryTypeHandlerBase::AddProperty explicitly invalidates all prototype caches for the
-            // property.  (We don't support other types only because we haven't needed to yet; we do not anticipate any difficulties in adding the cache-invalidation logic there if that changes.)
-            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) &&
-                (DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler() || DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsDictionaryTypeHandler()))
-            {
-#ifdef MISSING_PROPERTY_STATS
-                if (PHASE_STATS1(MissingPropertyCachePhase))
-                {
-                    requestContext->RecordMissingPropertyCacheAttempt();
-                }
-#endif
-                if (PHASE_TRACE1(MissingPropertyCachePhase))
-                {
-                    Output::Print(_u("MissingPropertyCache: Caching missing property for property %d.\n"), propertyId);
-                }
+            TryCacheMissingProperty(instance, propertyObject, isRoot, propertyId, requestContext, info);
 
-                PropertyValueInfo::Set(info, requestContext->GetLibrary()->GetMissingPropertyHolder(), 0);
-                CacheOperators::CachePropertyRead(propertyObject, requestContext->GetLibrary()->GetMissingPropertyHolder(), isRoot, propertyId, true, info, requestContext);
-            }
 #if defined(TELEMETRY_JSO) || defined(TELEMETRY_AddToCache) // enabled for `TELEMETRY_AddToCache`, because this is the property-not-found codepath where the normal TELEMETRY_AddToCache code wouldn't be executed.
             if (TELEMETRY_PROPERTY_OPCODE_FILTER(propertyId))
             {
@@ -1769,6 +1751,40 @@ CommonNumber:
             *value = requestContext->GetMissingPropertyResult();
             return FALSE;
         }
+    }
+
+    // If the given instance is a type where we can cache missing properties, then cache that the given property ID is missing.
+    // cacheInstance is used as startingObject in CachePropertyRead, and might be instance's proto if we are fetching a super property (see #3064).
+    void JavascriptOperators::TryCacheMissingProperty(Var instance, Var cacheInstance, bool isRoot, PropertyId propertyId, ScriptContext* requestContext, _Inout_ PropertyValueInfo * info)
+    {
+        if (PHASE_OFF1(MissingPropertyCachePhase) || isRoot || !DynamicType::Is(GetTypeId(instance)))
+        {
+            return;
+        }
+
+        DynamicTypeHandler* handler = DynamicObject::UnsafeFromVar(instance)->GetDynamicType()->GetTypeHandler();
+
+        // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers and DictionaryTypeHandlers, because only these types have the right behavior
+        // when the missing property is later added: path types guarantee a type change, and DictionaryTypeHandlerBase::AddProperty explicitly invalidates all prototype caches for the
+        // property.  (We don't support other types only because we haven't needed to yet; we do not anticipate any difficulties in adding the cache-invalidation logic there if that changes.)
+        if (!handler->IsPathTypeHandler() && !handler->IsDictionaryTypeHandler())
+        {
+            return;
+        }
+
+#ifdef MISSING_PROPERTY_STATS
+        if (PHASE_STATS1(MissingPropertyCachePhase))
+        {
+            requestContext->RecordMissingPropertyCacheAttempt();
+        }
+#endif
+        if (PHASE_TRACE1(MissingPropertyCachePhase))
+        {
+            Output::Print(_u("MissingPropertyCache: Caching missing property for property %d.\n"), propertyId);
+        }
+
+        PropertyValueInfo::Set(info, requestContext->GetLibrary()->GetMissingPropertyHolder(), 0);
+        CacheOperators::CachePropertyRead(cacheInstance, requestContext->GetLibrary()->GetMissingPropertyHolder(), isRoot, propertyId, true /*isMissing*/, info, requestContext);
     }
 
     template<typename PropertyKeyType>
@@ -1793,10 +1809,9 @@ CommonNumber:
             }
             object = JavascriptOperators::GetPrototypeNoTrap(object);
         }
-        if (!PHASE_OFF1(MissingPropertyCachePhase) && info->GetPropertyRecordUsageCache() && DynamicObject::Is(instance) && ((DynamicObject*)instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler())
+        if (info->GetPropertyRecordUsageCache())
         {
-            PropertyValueInfo::Set(info, requestContext->GetLibrary()->GetMissingPropertyHolder(), 0);
-            CacheOperators::CachePropertyRead(instance, requestContext->GetLibrary()->GetMissingPropertyHolder(), false, info->GetPropertyRecordUsageCache()->GetPropertyRecord()->GetPropertyId(), true, info, requestContext);
+            TryCacheMissingProperty(instance, instance, false /*isRoot*/, info->GetPropertyRecordUsageCache()->GetPropertyRecord()->GetPropertyId(), requestContext, info);
         }
 
         *value = requestContext->GetMissingPropertyResult();

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -668,6 +668,8 @@ namespace Js
         template <bool unscopables>
         static BOOL GetProperty_Internal(Var instance, RecyclableObject* propertyObject, const bool isRoot, PropertyId propertyId, Var* value, ScriptContext* requestContext, PropertyValueInfo* info);
 
+        static void TryCacheMissingProperty(Var instance, Var cacheInstance, bool isRoot, PropertyId propertyId, ScriptContext* requestContext, _Inout_ PropertyValueInfo * info);
+
         static RecyclableObject* GetPrototypeNoTrap(RecyclableObject* instance);
 
         static BOOL GetPropertyReference_Internal(Var instance, RecyclableObject* propertyObject, const bool isRoot, PropertyId propertyId, Var* value,ScriptContext* requestContext, PropertyValueInfo* info);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -239,7 +239,9 @@ namespace Js
         static BOOL IsNull(Var instance);
         static BOOL IsNull(RecyclableObject* instance);
         static BOOL IsSpecialObjectType(TypeId typeId);
+        static BOOL IsJsNativeType(TypeId typeId);
         static BOOL IsJsNativeObject(Var instance);
+        static BOOL IsJsNativeObject(_In_ RecyclableObject* instance);
         static BOOL IsUndefinedObject(Var instance);
         static BOOL IsAnyNumberValue(Var instance);
         static BOOL IsClassConstructor(Var instance);

--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -775,7 +775,7 @@ JSONStringifier::ReadProperty(
     bool isObject = false;
     if (valueObj)
     {
-        isObject = JavascriptOperators::IsObject(value) != FALSE;
+        isObject = JavascriptOperators::IsObject(valueObj) != FALSE;
         if (isObject)
         {
             // If value is an object, we must first check if it has a ToJSON method
@@ -800,7 +800,7 @@ JSONStringifier::ReadProperty(
         // Callable JS objects are undefined, but we still stringify callable host objects
         // Host object case is for compat with old implementation, but isn't defined in the
         // spec, so we should consider removing it
-        if (JavascriptConversion::IsCallable(valueObj) && JavascriptOperators::IsJsNativeObject(value))
+        if (JavascriptConversion::IsCallable(valueObj) && JavascriptOperators::IsJsNativeObject(valueObj))
         {
             prop->type = JSONContentType::Undefined;
             return;


### PR DESCRIPTION
1. Avoid casting our RecyclableObject instance back to Var unnecessarily. Benefit of this change is minimal if any, but risk is low too.
2. When searching for `toJSON`, prioritize the missing property cache ahead of the other types because it's likely to hit.
3. Allow subclasses of DynamicObject, such as arrays, to participate in the missing property cache so we don't have to search the type for `toJSON` every time. This part is a pretty generic improvement that might help in other unrelated code paths too, but I'd appreciate any feedback from those who know the type system better regarding whether we expect this change to be valid in all cases.