### PR TITLE
ensure JIT try blocks have enough stack to bailout to the interpeter

### DIFF
--- a/lib/Runtime/Base/Constants.h
+++ b/lib/Runtime/Base/Constants.h
@@ -122,6 +122,8 @@ namespace Js
         static const unsigned MaxProcessJITCodeHeapSize = 1024 * 1024 * 1024;
 #endif
 
+        static const unsigned MinStackJitEHBailout = MinStackInterpreter + MinStackDefault;
+
         static const size_t StackLimitForScriptInterrupt;
 
 

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -96,7 +96,7 @@ namespace Js
         void *tryCatchFrameAddr = nullptr;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)frame + hasBailedOutOffset));
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + spillSize + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + spillSize + argsSize);
         {
             Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, frame);
             try
@@ -161,7 +161,7 @@ namespace Js
         JavascriptExceptionObject *exception           = nullptr;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)frame + hasBailedOutOffset));
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + spillSize + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + spillSize + argsSize);
 
         try
         {
@@ -214,7 +214,7 @@ namespace Js
         void                      *finallyContinuation = nullptr;
         JavascriptExceptionObject *exception           = nullptr;
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + spillSize + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + spillSize + argsSize);
         try
         {
             tryContinuation = amd64_CallWithFakeFrame(tryAddr, frame, spillSize, argsSize);
@@ -260,7 +260,7 @@ namespace Js
         void * tryCatchFrameAddr = nullptr;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)localsPtr + hasBailedOutOffset));
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + argsSize);
         {
             Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
 
@@ -334,7 +334,7 @@ namespace Js
         JavascriptExceptionObject *exception           = nullptr;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)localsPtr + hasBailedOutOffset));
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + argsSize);
         try
         {
 #if defined(_M_ARM)
@@ -396,7 +396,7 @@ namespace Js
         void                      *finallyContinuation = nullptr;
         JavascriptExceptionObject *exception = nullptr;
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault + argsSize);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + argsSize);
 
         try
         {
@@ -446,7 +446,7 @@ namespace Js
         void *tryCatchFrameAddr = nullptr;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)framePtr + hasBailedOutOffset));
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout);
         {
             Js::JavascriptExceptionOperators::TryCatchFrameAddrStack tryCatchFrameAddrStack(scriptContext, framePtr);
 
@@ -608,7 +608,7 @@ namespace Js
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
         void* continuationAddr = NULL;
         scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)framePtr + hasBailedOutOffset));
-        PROBE_STACK(scriptContext, Constants::MinStackDefault);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout);
 
         try
         {
@@ -764,7 +764,7 @@ namespace Js
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
         void* continuationAddr = NULL;
 
-        PROBE_STACK(scriptContext, Constants::MinStackDefault);
+        PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout);
 
         try
         {

--- a/test/EH/StackOverflow.js
+++ b/test/EH/StackOverflow.js
@@ -1,0 +1,15 @@
+// //-------------------------------------------------------------------------------------------------------
+// // Copyright (C) Microsoft. All rights reserved.
+// // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// //-------------------------------------------------------------------------------------------------------
+
+function foo(a)
+{ 
+    try { a[0] } finally {}
+    try { foo(0) } catch(e) {}
+    try { foo() } catch(e) {}
+}
+
+foo(0)
+
+WScript.Echo("PASS");

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -180,6 +180,11 @@
     <default>
        <files>hasBailedOutBug.js</files>
        <baseline>hasBailedOutBug.baseline</baseline>
-  </default>
+    </default>
+  </test>
+  <test>
+    <default>
+       <files>StackOverflow.js</files>
+    </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
exceptions in JIT result in bailouts, and BailOutHelper does a stack probe before going to the interpreter. If that stack probe fails, a stack overflow would be thrown before the original exception was handled, and the top level catch/finally was not executed.

This commit ensures there is enough stack space to bail out to the interpreter to handle and exception if one is thrown.
