### PR TITLE
Fixing crash when converting very small or large numbers to base 2

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -921,7 +921,8 @@ namespace Js
         }
     }
 
-    static const int bufSize = 256;
+    // The largest string representing a number is the base 2 representation of -Math.pow(2,-1073), at 1076 characters.
+    static const int bufSize = 1280;
 
     JavascriptString* JavascriptNumber::ToString(double value, ScriptContext* scriptContext)
     {


### PR DESCRIPTION
It is possible to generate numbers which have very large string representations, up to 1076 characters. This change provides sufficiently large buffers to deal with those cases.