### PR TITLE
Cache property enumeration in JSON.stringify like we do for Object.assign

### DIFF
--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -548,7 +548,8 @@ JSONStringifier::ReadObject(_In_ RecyclableObject* obj, _In_ JSONObjectStack* ob
         else
         {
             JavascriptStaticEnumerator enumerator;
-            if (obj->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EphemeralReference, this->scriptContext))
+            EnumeratorCache* cache = this->scriptContext->GetLibrary()->GetStringifyCache(obj->GetType());
+            if (obj->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EphemeralReference | EnumeratorFlags::UseCache, this->scriptContext, cache))
             {
                 JavascriptString* propertyName = nullptr;
                 PropertyId nextKey = Constants::NoProperty;

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6375,7 +6375,7 @@ namespace Js
         return GetEnumeratorCache<Cache::StringifyCacheSize>(type, &this->cache.stringifyCache);
     }
 
-    template<uint cacheSlotCount> EnumeratorCache* JavascriptLibrary::GetEnumeratorCache(Type* type, EnumeratorCache** cacheSlots)
+    template<uint cacheSlotCount> EnumeratorCache* JavascriptLibrary::GetEnumeratorCache(Type* type, Field(EnumeratorCache*)* cacheSlots)
     {
         // Size must be power of 2 for cache indexing to work
         CompileAssert((cacheSlotCount & (cacheSlotCount - 1)) == 0);

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6367,14 +6367,24 @@ namespace Js
 
     EnumeratorCache* JavascriptLibrary::GetObjectAssignCache(Type* type)
     {
-        // Size must be power of 2 for cache indexing to work
-        CompileAssert((Cache::AssignCacheSize & (Cache::AssignCacheSize - 1)) == 0);
+        return GetEnumeratorCache<Cache::AssignCacheSize>(type, &this->cache.assignCache);
+    }
 
-        if (this->cache.assignCache == nullptr)
+    EnumeratorCache* JavascriptLibrary::GetStringifyCache(Type* type)
+    {
+        return GetEnumeratorCache<Cache::StringifyCacheSize>(type, &this->cache.stringifyCache);
+    }
+
+    template<uint cacheSlotCount> EnumeratorCache* JavascriptLibrary::GetEnumeratorCache(Type* type, EnumeratorCache** cacheSlots)
+    {
+        // Size must be power of 2 for cache indexing to work
+        CompileAssert((cacheSlotCount & (cacheSlotCount - 1)) == 0);
+
+        if (*cacheSlots == nullptr)
         {
-            this->cache.assignCache = AllocatorNewArrayZ(CacheAllocator, scriptContext->GetEnumeratorAllocator(), EnumeratorCache, Cache::AssignCacheSize);
+            *cacheSlots = AllocatorNewArrayZ(CacheAllocator, scriptContext->GetEnumeratorAllocator(), EnumeratorCache, cacheSlotCount);
         }
-        return &this->cache.assignCache[(((uintptr_t)type) >> PolymorphicInlineCacheShift) & (Cache::AssignCacheSize - 1)];
+        return &(*cacheSlots)[(((uintptr_t)type) >> PolymorphicInlineCacheShift) & (cacheSlotCount - 1)];
     }
 
     SymbolCacheMap* JavascriptLibrary::EnsureSymbolMap()

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -70,6 +70,7 @@ namespace Js
     struct Cache
     {
         static const uint AssignCacheSize = 16;
+        static const uint StringifyCacheSize = 16;
 
         Field(PropertyStringMap*) propertyStrings[80];
         Field(JavascriptString *) lastNumberToStringRadix10String;
@@ -89,12 +90,13 @@ namespace Js
         Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
         Field(ScriptContextPolymorphicInlineCache*) toJSONCache;
         Field(EnumeratorCache*) assignCache;
+        Field(EnumeratorCache*) stringifyCache;
 #if ENABLE_PROFILE_INFO
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
         Field(DynamicProfileInfoList*) profileInfoList;
 #endif
 #endif
-        Cache() : toStringTagCache(nullptr), toJSONCache(nullptr), assignCache(nullptr) { }
+        Cache() : toStringTagCache(nullptr), toJSONCache(nullptr), assignCache(nullptr), stringifyCache(nullptr) { }
     };
 
     class MissingPropertyTypeHandler;
@@ -1176,6 +1178,7 @@ namespace Js
         }
 
         EnumeratorCache* GetObjectAssignCache(Type* type);
+        EnumeratorCache* GetStringifyCache(Type* type);
 
         bool GetArrayObjectHasUserDefinedSpecies() const { return arrayObjectHasUserDefinedSpecies; }
         void SetArrayObjectHasUserDefinedSpecies(bool val) { arrayObjectHasUserDefinedSpecies = val; }
@@ -1296,6 +1299,7 @@ namespace Js
         void AddMember(DynamicObject* object, PropertyId propertyId, Var value, PropertyAttributes attributes);
         JavascriptString* CreateEmptyString();
 
+        template<uint cacheSlotCount> EnumeratorCache* GetEnumeratorCache(Type* type, EnumeratorCache** cacheSlots);
 
         static bool __cdecl InitializeGeneratorFunction(DynamicObject* function, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
 

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1299,7 +1299,7 @@ namespace Js
         void AddMember(DynamicObject* object, PropertyId propertyId, Var value, PropertyAttributes attributes);
         JavascriptString* CreateEmptyString();
 
-        template<uint cacheSlotCount> EnumeratorCache* GetEnumeratorCache(Type* type, EnumeratorCache** cacheSlots);
+        template<uint cacheSlotCount> EnumeratorCache* GetEnumeratorCache(Type* type, Field(EnumeratorCache*)* cacheSlots);
 
         static bool __cdecl InitializeGeneratorFunction(DynamicObject* function, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
 


### PR DESCRIPTION
JSON payloads tend to be relatively repetitive, so we can save a lot on large serializations by reusing object property iteration. On a microbenchmark that serializes and parses a repetitive piece of data that I found in Speedometer, I see a 35% improvement.