### PR TITLE
Class extension of proxy without construct trap fix #4729

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -2136,8 +2136,15 @@ namespace Js
                 {
                     JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedFunction, _u("construct"));
                 }
-                newThisObject = JavascriptOperators::NewScObjectNoCtor(targetObj, scriptContext);
-                args.Values[0] = newThisObject;
+                if (!isCtorSuperCall)
+                {
+                    newThisObject = JavascriptOperators::NewScObjectNoCtor(targetObj, scriptContext);
+                    args.Values[0] = newThisObject;
+                }
+                else
+                {
+                    newThisObject = args.Values[0];
+                }
             }
 
             ushort newCount = (ushort)args.Info.Count;

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -383,6 +383,52 @@ var tests = [
             assert.isTrue(trapCalled);
         }
     },
+    {
+        name: "Extending a proxy with an es6 class",
+        body() {
+            function parent() { this.noTrap = true; }
+            var proxyNoTrap = new Proxy(parent, {});
+            var handler = {
+                construct : function () {
+                    this.other = true;
+                    return { trap: true };
+                }
+            }
+            var proxyWithTrap = new Proxy(parent, handler );
+
+            class NoTrap extends proxyNoTrap
+            {
+                constructor()
+                {
+                    super();
+                    this.own = true;
+                }
+                a () { return true; }
+            }
+
+            class WithTrap extends proxyWithTrap
+            {
+                constructor()
+                {
+                    super();
+                    this.own = true;
+                }
+                a () { return true; }
+            }
+            
+            var notrap = new NoTrap();
+            assert.isTrue(notrap.own);
+            assert.isTrue(notrap.a());
+            assert.isTrue(notrap.noTrap);
+            
+            var withtrap = new WithTrap();
+            assert.isTrue(withtrap.own);
+            assert.isUndefined(withtrap.a);
+            assert.isTrue(withtrap.trap);
+            assert.isUndefined(withtrap.other);
+            assert.isUndefined(withtrap.noTrap);
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Proxy trap function when there's no construct trap was always making a new object as the "this" to use - in the case of a super call this would break the class inheritance chain.

Currently CC's behaviour on this differers from jsc, v8 and sm. This fix brings CC into line with the others.

Should fix #4729 