### PR TITLE
Add CollectGarbage to the global object only in chakracore builds and only if requested

### DIFF
--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -298,8 +298,6 @@ namespace Js
 #undef FLAG
 #undef FORWARD_THREAD_CONFIG
 
-        bool SupportsCollectGarbage() const { return true; }
-
         void ForceNoDynamicThunks() { this->NoDynamicThunks = true; }
         bool IsNoDynamicThunks() const { return this->NoDynamicThunks; }
 

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1116,12 +1116,15 @@ namespace Js
         AddFunctionToLibraryObject(globalObject, PropertyIds::escape, &GlobalObject::EntryInfo::Escape, 1);
         AddFunctionToLibraryObject(globalObject, PropertyIds::unescape, &GlobalObject::EntryInfo::UnEscape, 1);
 
-        if (scriptContext->GetConfig()->SupportsCollectGarbage()
+// for backward compat reasons in non-core builds add CollectGarbage function even if it would do nothing later
+#ifdef _CHAKRACOREBUILD
+        if (scriptContext->GetConfig()->IsCollectGarbageEnabled()
 #ifdef ENABLE_PROJECTION
             || scriptContext->GetConfig()->GetHostType() == HostType::HostTypeApplication
             || scriptContext->GetConfig()->GetHostType() == HostType::HostTypeWebview
 #endif
             )
+#endif
         {
             AddFunctionToLibraryObject(globalObject, PropertyIds::CollectGarbage, &GlobalObject::EntryInfo::CollectGarbage, 0);
         }
@@ -6855,11 +6858,7 @@ namespace Js
         REG_GLOBAL_LIB_FUNC(escape, GlobalObject::EntryEscape);
         REG_GLOBAL_LIB_FUNC(unescape, GlobalObject::EntryUnEscape);
 
-        ScriptConfiguration const& config = *(scriptContext->GetConfig());
-        if (config.SupportsCollectGarbage())
-        {
-            REG_GLOBAL_LIB_FUNC(CollectGarbage, GlobalObject::EntryCollectGarbage);
-        }
+        REG_GLOBAL_LIB_FUNC(CollectGarbage, GlobalObject::EntryCollectGarbage);
 
         // Register constructors, prototypes and objects in global
         REGISTER_OBJECT(Object);
@@ -6887,6 +6886,8 @@ namespace Js
         REGISTER_OBJECT(StringIterator);
 
         REGISTER_OBJECT(TypedArray);
+
+        ScriptConfiguration const& config = *(scriptContext->GetConfig());
 
         if (config.IsES6PromiseEnabled())
         {

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -55,13 +55,13 @@
     <default>
       <files>randombug.js</files>
       <baseline>randombug.baseline</baseline>
-      <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
+      <compile-flags>-CollectGarbage -ExtendedErrorStackForTestHost</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>blue_532460.js</files>
-      <compile-flags>-MaxinterpretCount:1 -MaxSimpleJITRunCount:0 -loopinterpretcount:1 -force:deferparse</compile-flags>
+      <compile-flags>-CollectGarbage -MaxinterpretCount:1 -MaxSimpleJITRunCount:0 -loopinterpretcount:1 -force:deferparse</compile-flags>
     </default>
   </test>
   <test>

--- a/test/ControlFlow/rlexe.xml
+++ b/test/ControlFlow/rlexe.xml
@@ -51,6 +51,7 @@
   <test>
     <default>
       <files>forInMisc.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>forInMisc.baseline</baseline>
     </default>
   </test>

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -456,7 +456,7 @@
   <test>
     <default>
       <files>attachWithDeferParse.js</files>
-      <compile-flags>-force:deferparse -dbgbaseline:attachWithDeferParse.js.dbg.baseline</compile-flags>
+      <compile-flags>-CollectGarbage -force:deferparse -dbgbaseline:attachWithDeferParse.js.dbg.baseline</compile-flags>
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
@@ -1208,7 +1208,7 @@
   <test>
     <default>
       <files>bug_261867.js</files>
-      <compile-flags>-debuglaunch -maxinterpretcount:1 -dbgbaseline:bug_261867.js.dbg.baseline</compile-flags>
+      <compile-flags>-CollectGarbage -debuglaunch -maxinterpretcount:1 -dbgbaseline:bug_261867.js.dbg.baseline</compile-flags>
       <tags>exclude_dynapogo,exclude_serialized</tags>
     </default>
   </test>

--- a/test/DynamicCode/rlexe.xml
+++ b/test/DynamicCode/rlexe.xml
@@ -4,7 +4,7 @@
     <default>
       <tags>exclude_test,Slow</tags>
       <files>eval-nativecodedata.js</files>
-      <compile-flags>-force:fieldhoist</compile-flags>
+      <compile-flags>-CollectGarbage -force:fieldhoist</compile-flags>
       <baseline />
     </default>
   </test>
@@ -12,6 +12,7 @@
     <default>
       <tags>exclude_test,Slow</tags>
       <files>eval-nativenumber.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <timeout>300</timeout>
     </default>
   </test>
@@ -19,7 +20,7 @@
     <default>
       <tags>exclude_test,exclude_dynapogo</tags>
       <files>eval-nativenumber.js</files>
-      <compile-flags>-maxinterpretcount:1 -off:simpleJit</compile-flags>
+      <compile-flags>-CollectGarbage -maxinterpretcount:1 -off:simpleJit</compile-flags>
     </default>
   </test>
 </regress-exe>

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -153,6 +153,7 @@
   <test>
     <default>
       <files>asyncintrystackwalkbug.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
     </default>
   </test>
   <test>

--- a/test/FixedFields/rlexe.xml
+++ b/test/FixedFields/rlexe.xml
@@ -96,7 +96,7 @@
   <test>
     <default>
       <files>fixedmethods_polyInlining.js</files>
-      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:2</compile-flags>
+      <compile-flags>-CollectGarbage -maxinterpretcount:1 -maxsimplejitruncount:2</compile-flags>
     </default>
   </test>
   <test>

--- a/test/Generated/rlexe.xml
+++ b/test/Generated/rlexe.xml
@@ -645,12 +645,14 @@
   <test>
     <default>
       <files>B9AA6BBF.0.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>B9AA6BBF.0.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
       <files>6E55FA7A.0.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>6E55FA7A.0.baseline</baseline>
     </default>
   </test>

--- a/test/Miscellaneous/rlexe.xml
+++ b/test/Miscellaneous/rlexe.xml
@@ -77,6 +77,7 @@
   <test>
     <default>
       <files>HasOnlyWritableDataPropertiesCache.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>HasOnlyWritableDataPropertiesCache.baseline</baseline>
     </default>
   </test>

--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -229,6 +229,7 @@
   <test>
     <default>
       <files>propertyStrings.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
     </default>
   </test>
   <test>

--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -144,7 +144,7 @@
     <default>
       <files>substring.js</files>
       <baseline>substring.baseline</baseline>
-      <compile-flags>-Intl-</compile-flags>
+      <compile-flags>-CollectGarbage -Intl-</compile-flags>
     </default>
   </test>
   <test>

--- a/test/UnifiedRegex/rlexe.xml
+++ b/test/UnifiedRegex/rlexe.xml
@@ -135,12 +135,13 @@
   <test>
     <default>
       <files>propertyString.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>propertyString.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <compile-flags>-Serialized</compile-flags>
+      <compile-flags>-CollectGarbage -Serialized</compile-flags>
       <files>propertyString.js</files>
       <baseline>propertyString.baseline</baseline>
       <tags>exclude_forceserialized</tags>
@@ -155,6 +156,7 @@
   <test>
     <default>
       <files>mru.js</files>
+      <compile-flags>-CollectGarbage</compile-flags>
       <baseline>mru.baseline</baseline>
     </default>
   </test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -452,7 +452,7 @@
   <test>
     <default>
       <files>ES6TypedArrayExtensions.js</files>
-      <compile-flags>-ES6ObjectLiterals -ES6Species -ESSharedArrayBuffer -args summary -endargs</compile-flags>
+      <compile-flags>-CollectGarbage -ES6ObjectLiterals -ES6Species -ESSharedArrayBuffer -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -476,7 +476,7 @@
   <test>
     <default>
       <files>ES6Symbol.js</files>
-      <compile-flags>-ES6ObjectLiterals -ES6Species -ES6RegExSymbols -args summary -endargs</compile-flags>
+      <compile-flags>-CollectGarbage -ES6ObjectLiterals -ES6Species -ES6RegExSymbols -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -689,7 +689,7 @@
   <test>
     <default>
       <files>ES6Species-bugs.js</files>
-      <compile-flags>-ES6 -ES6Species -args summary -endargs</compile-flags>
+      <compile-flags>-CollectGarbage -ES6 -ES6Species -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -15,7 +15,7 @@
   <test>
     <default>
       <files>equiv-mismatch.js</files>
-      <compile-flags>-maxsimplejitruncount:2</compile-flags>
+      <compile-flags>-CollectGarbage -maxsimplejitruncount:2</compile-flags>
       <baseline>equiv-mismatch.baseline</baseline>
     </default>
   </test>


### PR DESCRIPTION
Fixes https://github.com/nodejs/node-chakracore/issues/499

IsCollectGarbageEnabled relies on "CollectGarbage" flag which can be set through jscript.config or passed to ch.exe. 