### PR TITLE
[MSFT 16526077] When branching a type path, only copy setter indices that refer to the initialized part of the path

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -174,6 +174,9 @@ namespace Js
         virtual DynamicTypeHandler* ConvertToTypeWithItemAttributes(DynamicObject* instance) override;
         virtual BOOL AllPropertiesAreEnumerable() override { return true; }
         virtual BOOL IsPathTypeHandler() const { return TRUE; }
+#if DBG
+        virtual bool IsPathTypeHandlerWithAttr() const { return false; }
+#endif
 
         virtual void ShrinkSlotAndInlineSlotCapacity() override;
         virtual void LockInlineSlotCapacity() override;
@@ -434,6 +437,8 @@ namespace Js
 
     class PathTypeHandlerNoAttr : public PathTypeHandlerBase
     {
+        friend class PathTypeHandlerBase;
+
     public:
         DEFINE_GETCPPNAME();
 
@@ -450,6 +455,8 @@ namespace Js
 
     class PathTypeHandlerWithAttr : public PathTypeHandlerNoAttr
     {
+        friend class PathTypeHandlerBase;
+
     private:
         Field(ObjectSlotAttributes *) attributes;
         Field(PathTypeSetterSlotIndex *) setters;
@@ -478,6 +485,16 @@ namespace Js
         static PathTypeHandlerWithAttr * New(ScriptContext * scriptContext, TypePath * typePath, ObjectSlotAttributes * attributes, PathTypeSetterSlotIndex * setters, PathTypeSetterSlotIndex setterCount, uint16 pathLength, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static PathTypeHandlerWithAttr * New(ScriptContext * scriptContext, TypePath * typePath, ObjectSlotAttributes * attributes, PathTypeSetterSlotIndex * setters, PathTypeSetterSlotIndex setterCount, uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static PathTypeHandlerWithAttr * New(ScriptContext * scriptContext, PathTypeHandlerWithAttr * typeHandler, bool isLocked, bool isShared);
+
+        static PathTypeHandlerWithAttr * FromPathTypeHandler(PathTypeHandlerBase * typeHandler)
+        {
+            Assert(typeHandler->IsPathTypeHandlerWithAttr());
+            return static_cast<PathTypeHandlerWithAttr*>(typeHandler);
+        }
+
+#if DBG
+        virtual bool IsPathTypeHandlerWithAttr() const override { return true; }
+#endif
 
         virtual BOOL IsEnumerable(DynamicObject* instance, PropertyId propertyId) override;
         virtual BOOL IsWritable(DynamicObject* instance, PropertyId propertyId) override;

--- a/test/es5/objlitgetset2.js
+++ b/test/es5/objlitgetset2.js
@@ -34,3 +34,13 @@ function __getRandomProperty(obj, seed) {
       if (__v_13862.q !== 0) WScript.Echo(__v_13862.q);
   })();
   __v_13851[__getRandomProperty(__v_13851, 483779)] = __getRandomObject();
+
+let o = {get a(){},x:0};
+if (o.x !== 0) WScript.Echo('fail x0');
+Object.defineProperty(o, 'x', {configurable:true,enumerable:true,get:function(){return 'x1'}});
+if (o.x !== 'x1') WScript.Echo('fail x1');
+let p = {get a(){},x:0};
+p.y = 'y';
+Object.defineProperty(p, 'x', {configurable:true,enumerable:true,get:function(){return 'x2'}});
+if (p.x !== 'x2') WScript.Echo('fail x2');
+if (p.y !== 'y') WScript.Echo('fail y');


### PR DESCRIPTION
Otherwise, wait for the correct index, which may be different on this branch of the path, to be set when the setter property is added to the handler.