### PR TITLE
[MSFT 16567550] Disable aux slot pointer opt by default

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4456,7 +4456,7 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
 #endif
 
         bucket->AddToGuardedPropertyOps(opnd->GetObjTypeSpecFldId());
-        auxSlotPtrUpwardExposed = opnd->UsesAuxSlot() && !opnd->IsLoadedFromProto() && opnd->IsTypeChecked() && !PHASE_OFF(Js::ReuseAuxSlotPtrPhase, this->func);
+        auxSlotPtrUpwardExposed = PHASE_ON(Js::ReuseAuxSlotPtrPhase, this->func) && opnd->UsesAuxSlot() && !opnd->IsLoadedFromProto() && opnd->IsTypeChecked();
 
         if (opnd->NeedsMonoCheck())
         {


### PR DESCRIPTION
The optimization requires more dataflow work for functional correctness.