### PR TITLE
Don't cache missing properties from CustomExternalObjects

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1758,7 +1758,10 @@ CommonNumber:
     // cacheInstance is used as startingObject in CachePropertyRead, and might be instance's proto if we are fetching a super property (see #3064).
     void JavascriptOperators::TryCacheMissingProperty(Var instance, Var cacheInstance, bool isRoot, PropertyId propertyId, ScriptContext* requestContext, _Inout_ PropertyValueInfo * info)
     {
-        if (PHASE_OFF1(MissingPropertyCachePhase) || isRoot || !DynamicType::Is(GetTypeId(instance)))
+        // Here, any well-behaved subclasses of DynamicObject can opt in to getting included in the missing property cache.
+        // For now, we only include basic objects and arrays. CustomExternalObject in particular is problematic because in
+        // some cases it can add new properties without transitioning its type handler.
+        if (PHASE_OFF1(MissingPropertyCachePhase) || isRoot || !(DynamicObject::Is(instance) || DynamicObject::IsAnyArray(instance)))
         {
             return;
         }


### PR DESCRIPTION
I recently made a change to allow caching data about missing properties on any DynamicObject subclass, rather than just DynamicObject itself. It didn't happen to hit problems in a private crawler run, but is now causing problems because some types can add properties without invalidating the missing-property cache. A minimal repro of the problem is the following:

```javascript
var div = document.querySelectorAll("div")[0];
"something" in div.dataset; // false, add to missing-prop cache
div.setAttribute("data-something", "true");
"something" in div.dataset; // still false but should be true
```

This change allows DynamicObject or any array types into the missing property cache, which is a bit more permissive than the original but much stricter than the problematic version.

Fixes OS:16711773
