### PR TITLE
Remove redundent flags for jsbuiltin in ScriptFunction

### DIFF
--- a/lib/Backend/BackendOpCodeList.h
+++ b/lib/Backend/BackendOpCodeList.h
@@ -12,14 +12,14 @@
 
 // -----------------------------------------------------------------------------------------------
 // Additional machine independent opcode used byte backend
-#define MACRO_BACKEND_ONLY(opcode, layout, attr) \
-    DEF_OP(opcode, layout, OpBackEndOnly|attr)
+#define MACRO_BACKEND_ONLY_WITH_DBG_ATTR(opcode, layout, attr, dbgAttrib) \
+    DEF_OP(opcode, layout, attr, OpDbgAttr_BackEndOnly|dbgAttrib)
 
 #include "ByteCode/OpCodes.h"
 
-DEF_OP(MDStart, Empty, None)
+DEF_OP(MDStart, Empty, None, OpDbgAttr_BackEndOnly)
 
-#define MACRO DEF_OP
+#define MACRO(opcode, layout, attr, ...) DEF_OP(opcode, layout, attr, OpDbgAttr_BackEndOnly)
 
 #ifdef _M_AMD64
     #include "../../Backend/amd64/MdOpCodes.h"

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1316,11 +1316,6 @@ namespace Js
         bool IsJsBuiltInCode() const { return m_isJsBuiltInCode; }
 
 #if DBG
-        void SetIsJsBuiltInInitCode() { m_isJsBuiltInInitCode = true; }
-        bool IsJsBuiltInInitCode() { return m_isJsBuiltInInitCode; }
-#endif
-
-#if DBG
         bool HasValidEntryPoint() const;
 #if defined(ENABLE_SCRIPT_PROFILING) || defined(ENABLE_SCRIPT_DEBUGGING)
         bool HasValidProfileEntryPoint() const;

--- a/lib/Runtime/ByteCode/BackendOpCodeAttr.h
+++ b/lib/Runtime/ByteCode/BackendOpCodeAttr.h
@@ -38,8 +38,6 @@ namespace OpCodeAttr
     bool BailOutRec(Js::OpCode opcode);
     // True if the opcode can only appear in the byte code
     bool ByteCodeOnly(Js::OpCode opcode);
-    // True if the opcode can only appear in the back end
-    bool BackEndOnly(Js::OpCode opcode);
     // True if the opcode does not transfer value from src to dst (only some opcode are marked property)
     bool DoNotTransfer(Js::OpCode opcode);
     // True if the opcode may have implicit call
@@ -70,4 +68,10 @@ namespace OpCodeAttr
     bool HasDeadFallThrough(Js::OpCode opcode);
     // True if the opcode can use fixed fields
     bool CanLoadFixedFields(Js::OpCode opcode);
+#if DBG
+    // True if the opcode can only appear in the back end
+    bool BackEndOnly(Js::OpCode opcode);
+    // True if the opcode load the global object
+    bool LoadRoot(Js::OpCode opcode);
+#endif
 };

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -312,6 +312,8 @@ namespace Js
         AssertMsg(!OpCodeAttr::BackEndOnly(op), "Can't write back end only OpCode");
 #endif
         AssertMsg(OpCodeUtil::GetOpCodeLayout(op) == layoutType, "Ensure correct layout for OpCode");
+
+        AssertMsg(!CONFIG_FLAG(LdChakraLib) || !OpCodeAttr::LoadRoot(op), "JsBuiltIn code shouldn't touch the global");
     }
 
     void ByteCodeWriter::CheckLabel(ByteCodeLabel labelID)

--- a/lib/Runtime/ByteCode/ExtendedOpCodeList.h
+++ b/lib/Runtime/ByteCode/ExtendedOpCodeList.h
@@ -12,6 +12,7 @@
 
 // Define the extended byte code opcode range
 
-#define MACRO_EXTEND(opcode, layout, attr) DEF_OP(opcode, layout, attr)
-#define MACRO_EXTEND_WMS(opcode, layout, attr) DEF_OP(opcode, layout, OpHasMultiSizeLayout|attr )
+#define MACRO_EXTEND_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) DEF_OP(opcode, layout, attr, dbgAttr)
+#define MACRO_EXTEND_WMS_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) DEF_OP(opcode, layout, OpHasMultiSizeLayout|attr, dbgAttr)
 #include "OpCodes.h"
+

--- a/lib/Runtime/ByteCode/OpCodeList.h
+++ b/lib/Runtime/ByteCode/OpCodeList.h
@@ -12,6 +12,6 @@
 
 // Define the basic byte code opcode range
 
-#define MACRO(opcode, layout, attr) DEF_OP(opcode, layout, attr)
-#define MACRO_WMS(opcode, layout, attr) DEF_OP(opcode, layout, OpHasMultiSizeLayout|attr )
+#define MACRO_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) DEF_OP(opcode, layout, attr, dbgAttr)
+#define MACRO_WMS_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) DEF_OP(opcode, layout, OpHasMultiSizeLayout|attr, dbgAttr)
 #include "OpCodes.h"

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -3,25 +3,78 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 // Default all macro to nothing
+#ifndef MACRO_WITH_DBG_ATTR
+#ifdef MACRO
+#define MACRO_WITH_DBG_ATTR(opcode, layout, attr, ...) MACRO(opcode, layout, attr)
+#else
+#define MACRO_WITH_DBG_ATTR(...)
+#endif
+#endif
+
+#ifndef MACRO_WMS_WITH_DBG_ATTR
+#ifdef MACRO_WMS
+#define MACRO_WMS_WITH_DBG_ATTR(opcode, layout, attr, ...) MACRO_WMS(opcode, layout, attr)
+#else
+#define MACRO_WMS_WITH_DBG_ATTR(...)
+#endif
+#endif
+
+#ifndef MACRO_EXTEND_WITH_DBG_ATTR
+#ifdef MACRO_EXTEND
+#define MACRO_EXTEND_WITH_DBG_ATTR(opcode, layout, attr, ...) MACRO_EXTEND(opcode, layout, attr)
+#else
+#define MACRO_EXTEND_WITH_DBG_ATTR(...)
+#endif
+#endif
+
+#ifndef MACRO_EXTEND_WMS_WITH_DBG_ATTR
+#ifdef MACRO_EXTEND_WMS
+#define MACRO_EXTEND_WMS_WITH_DBG_ATTR(opcode, layout, attr, ...) MACRO_EXTEND_WMS(opcode, layout, attr)
+#else
+#define MACRO_EXTEND_WMS_WITH_DBG_ATTR(...)
+#endif
+#endif
+
+#ifndef MACRO_BACKEND_ONLY_WITH_DBG_ATTR
+#ifdef MACRO_BACKEND_ONLY
+#define MACRO_BACKEND_ONLY_WITH_DBG_ATTR(opcode, layout, attr, ...) MACRO_BACKEND_ONLY(opcode, layout, attr)
+#else
+#define MACRO_BACKEND_ONLY_WITH_DBG_ATTR(...)
+#endif
+#endif
+
+// Default the debug attributes to OpDbgAttr_None
 #ifndef MACRO
-#define MACRO( opcode, layout, attr)
+#define MACRO(opcode, layout, attr) MACRO_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
 #endif
 
 #ifndef MACRO_WMS
-#define MACRO_WMS(opcode, layout, attr)
+#define MACRO_WMS(opcode, layout, attr) MACRO_WMS_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
 #endif
 
 #ifndef MACRO_EXTEND
-#define MACRO_EXTEND(opcode, layout, attr)
+#define MACRO_EXTEND(opcode, layout, attr) MACRO_EXTEND_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
 #endif
 
 #ifndef MACRO_EXTEND_WMS
-#define MACRO_EXTEND_WMS(opcode, layout, attr)
+#define MACRO_EXTEND_WMS(opcode, layout, attr) MACRO_EXTEND_WMS_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
 #endif
 
 #ifndef MACRO_BACKEND_ONLY
-#define MACRO_BACKEND_ONLY(opcode, layout, attr)
+#define MACRO_BACKEND_ONLY(opcode, layout, attr) MACRO_BACKEND_ONLY_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
 #endif
+
+#define MACRO_ROOT(opcode, layout, attr) \
+    MACRO_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
+
+#define MACRO_WMS_ROOT(opcode, layout, attr) \
+    MACRO_WMS_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
+
+#define MACRO_EXTENDED_ROOT(opcode, layout, attr) \
+    MACRO_EXTENDED_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
+
+#define MACRO_EXTEND_WMS_ROOT(opcode, layout, attr) \
+    MACRO_EXTENDED_WMS_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
 
 #define MACRO_WMS_PROFILED( opcode, layout, attr) \
     MACRO_WMS(opcode, layout, OpHasProfiled|attr) \
@@ -36,13 +89,27 @@
     MACRO_WMS(Profiled##opcode, Profiled##layout, OpByteCodeOnly|OpProfiled|attr) \
     MACRO_WMS(Profiled##opcode##WithICIndex, Profiled##layout##WithICIndex, OpByteCodeOnly|OpProfiledWithICIndex|attr) \
 
-#define MACRO_WMS_PROFILED_OP(  opcode, layout, attr) \
-    MACRO_WMS(opcode, layout, OpHasProfiled|attr) \
-    MACRO_WMS(Profiled##opcode, layout, OpByteCodeOnly|OpProfiled|attr) \
+
+#define MACRO_WMS_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) \
+    MACRO_WMS_WITH_DBG_ATTR(opcode, layout, OpHasProfiled|attr, dbgAttr) \
+    MACRO_WMS_WITH_DBG_ATTR(Profiled##opcode, layout, OpByteCodeOnly|OpProfiled|attr, dbgAttr) \
+
+#define MACRO_WMS_PROFILED_OP(opcode, layout, attr) \
+    MACRO_WMS_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
+
+#define MACRO_WMS_PROFILED_OP_ROOT(opcode, layout, attr) \
+    MACRO_WMS_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
+
+
+#define MACRO_EXTEND_WMS_AND_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, dbgAttr) \
+    MACRO_EXTEND_WMS_WITH_DBG_ATTR(opcode, layout, OpHasProfiled | attr, dbgAttr) \
+    MACRO_EXTEND_WMS_WITH_DBG_ATTR(Profiled##opcode, layout, OpByteCodeOnly | OpProfiled | attr, dbgAttr) \
 
 #define MACRO_EXTEND_WMS_AND_PROFILED_OP(opcode, layout, attr) \
-    MACRO_EXTEND_WMS(opcode, layout, OpHasProfiled | attr) \
-    MACRO_EXTEND_WMS(Profiled##opcode, layout, OpByteCodeOnly | OpProfiled | attr) \
+    MACRO_EXTEND_WMS_AND_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_None)
+
+#define MACRO_EXTEND_WMS_AND_PROFILED_OP_ROOT(opcode, layout, attr) \
+    MACRO_EXTEND_WMS_AND_PROFILED_OP_WITH_DBG_ATTR(opcode, layout, attr, OpDbgAttr_LoadRoot)
 
 #define MACRO_PROFILED(opcode, layout, attr) \
     MACRO(opcode, layout, OpHasProfiled|attr) \
@@ -284,18 +351,18 @@ MACRO_BACKEND_ONLY(     LdIndir,            Empty,          OpTempNumberSources|
 
 MACRO_WMS(              ChkUndecl,                  Reg1,           OpSideEffect)
 
-MACRO_WMS(              EnsureNoRootFld,            ElementRootU,   OpSideEffect)
-MACRO_WMS(              EnsureNoRootRedeclFld,      ElementRootU,   OpSideEffect)
+MACRO_WMS_ROOT(         EnsureNoRootFld,            ElementRootU,   OpSideEffect)
+MACRO_WMS_ROOT(         EnsureNoRootRedeclFld,      ElementRootU,   OpSideEffect)
 MACRO_WMS(              ScopedEnsureNoRedeclFld,    ElementScopedC, OpSideEffect)
 
 MACRO_WMS(              InitUndecl,                 Reg1,           OpCanCSE)
 // TODO: Change InitUndeclLetFld and InitUndeclConstFld to ElementU layouts since they do not use their inline cache
 MACRO_WMS(              InitUndeclLetFld,           ElementPIndexed,OpByteCodeOnly|OpSideEffect)
 MACRO_EXTEND_WMS(       InitUndeclLocalLetFld,      ElementP,       OpByteCodeOnly|OpSideEffect)
-MACRO_WMS(              InitUndeclRootLetFld,       ElementRootU,   OpSideEffect)
+MACRO_WMS_ROOT(         InitUndeclRootLetFld,       ElementRootU,   OpSideEffect)
 MACRO_WMS(              InitUndeclConstFld,         ElementPIndexed,OpByteCodeOnly|OpSideEffect)
 MACRO_EXTEND_WMS(       InitUndeclLocalConstFld,    ElementP,       OpByteCodeOnly|OpSideEffect)
-MACRO_WMS(              InitUndeclRootConstFld,     ElementRootU,   OpSideEffect)
+MACRO_WMS_ROOT(         InitUndeclRootConstFld,     ElementRootU,   OpSideEffect)
 MACRO_EXTEND_WMS(       InitUndeclConsoleLetFld,    ElementScopedU, OpSideEffect)
 MACRO_EXTEND_WMS(       InitUndeclConsoleConstFld,  ElementScopedU, OpSideEffect)
 MACRO_WMS(              InitConst,                  Reg2,           OpTempNumberTransfer|OpTempObjectTransfer|OpNonIntTransfer|OpCanCSE)    // Create and initialize 'const' as property of global object
@@ -304,9 +371,9 @@ MACRO_WMS(              InitConstSlot,              ElementSlot,    None)
 // Re-evaluate following 4 opcodes and InitInnerLetFld for obj type spec and inline cache lookup when we add sharing of types having properties with non-default
 // attributes. Currently, these opcodes are used to set properties on scope objects, whose types we do not share as all their properties are non-configurable
 MACRO_WMS(              InitLetFld,                 ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
-MACRO_WMS(              InitRootLetFld,             ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
+MACRO_WMS_ROOT(         InitRootLetFld,             ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
 MACRO_WMS(              InitConstFld,               ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
-MACRO_WMS(              InitRootConstFld,           ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
+MACRO_WMS_ROOT(         InitRootConstFld,           ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
 
 MACRO_WMS(              InitClassMember,            ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)                  // Class member
 MACRO_EXTEND_WMS(       InitClassMemberComputedName,ElementI,       OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)                  // Class member with computed property name
@@ -338,38 +405,38 @@ MACRO_WMS_PROFILED_OP(  LdLocalFld,           ElementP,       OpSideEffect|OpOpn
 MACRO_WMS(              LdEnvObj,             ElementSlotI1,  OpTempNumberSources)
 MACRO_EXTEND_WMS_AND_PROFILED_OP(LdSuperFld,  ElementC2,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)    // Load from ScriptObject super instance's direct field
 MACRO_WMS_PROFILED_OP(  LdFldForTypeOf,       ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)
-MACRO_EXTEND_WMS_AND_PROFILED_OP(LdRootFldForTypeOf, ElementRootCP, OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)
+MACRO_EXTEND_WMS_AND_PROFILED_OP_ROOT(LdRootFldForTypeOf, ElementRootCP, OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)
 
 MACRO_WMS_PROFILED_OP(  LdFldForCallApplyTarget,  ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)
-MACRO_WMS_PROFILED_OP(LdRootFld,              ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)    // Load from ScriptObject instance's direct field (access to let/const on root object)
+MACRO_WMS_PROFILED_OP_ROOT(LdRootFld,         ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)    // Load from ScriptObject instance's direct field (access to let/const on root object)
 MACRO_WMS_PROFILED_OP(LdMethodFld,            ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)    // Load call target from ScriptObject instance's direct field
 MACRO_EXTEND_WMS_AND_PROFILED_OP(LdLocalMethodFld, ElementP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut|OpCanLoadFixedFields)    // Load call target from ScriptObject instance's direct field
 MACRO_BACKEND_ONLY(     LdMethodFldPolyInlineMiss, ElementCP, OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)                        // Load call target from ScriptObject instance's direct field, when the call target is neither of
                                                                                                                                                         // the ones we inlined using fixed methods, at a polymorphic call site,
                                                                                                                                                         // but don't allow it to participate in any obj type spec optimizations,
                                                                                                                                                         // as it will always result in a helper call.
-MACRO_WMS_PROFILED_OP(  LdRootMethodFld,      ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Load call target from ScriptObject instance's direct field (access to let/const on root object)
+MACRO_WMS_PROFILED_OP_ROOT(LdRootMethodFld,   ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Load call target from ScriptObject instance's direct field (access to let/const on root object)
 MACRO_WMS_PROFILED_OP(  StFld,                ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field
 MACRO_EXTEND_WMS_AND_PROFILED_OP(StSuperFld,  ElementC2,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject super instance's direct field
-MACRO_WMS_PROFILED_OP(  StRootFld,            ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field (access to let/const on root object)
+MACRO_WMS_PROFILED_OP_ROOT(StRootFld,         ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field (access to let/const on root object)
 MACRO_WMS_PROFILED_OP(  StLocalFld,           ElementP,       OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into local activation object
 MACRO_WMS_PROFILED_OP(  StFldStrict,          ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field (strict mode, a.x = ...)
-MACRO_WMS_PROFILED_OP(  StRootFldStrict,      ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field (strict mode, x = ..., access to let/const on root object)
+MACRO_WMS_PROFILED_OP_ROOT(StRootFldStrict,   ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Store into ScriptObject instance's direct field (strict mode, x = ..., access to let/const on root object)
 MACRO_WMS_PROFILED_OP(  InitFld,              ElementCP,      OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Declare a property with an initial value
 MACRO_WMS_PROFILED_OP(  InitLocalFld,         ElementP,       OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Declare a property with an initial value
 MACRO_EXTEND_WMS(       InitLocalLetFld,      ElementP,       OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)   // Declare a property with an initial value
 MACRO_EXTEND_WMS(       InitInnerFld,         ElementPIndexed,OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Declare a property with an initial value
 MACRO_EXTEND_WMS(       InitInnerLetFld,      ElementPIndexed,OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)                  // Declare a property with an initial value
-MACRO_WMS_PROFILED_OP(  InitRootFld,          ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Declare a property with an initial value
-MACRO_BACKEND_ONLY(     LdMethodFromFlags,          ElementCP,      OpFastFldInstr|OpCanCSE)
+MACRO_WMS_PROFILED_OP_ROOT(InitRootFld,       ElementRootCP,  OpSideEffect|OpOpndHasImplicitCall|OpFastFldInstr|OpPostOpDbgBailOut)   // Declare a property with an initial value
+MACRO_BACKEND_ONLY(     LdMethodFromFlags,    ElementCP,      OpFastFldInstr|OpCanCSE)
 
 MACRO_WMS(              DeleteFld,                  ElementC,       OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property
 MACRO_EXTEND_WMS(       DeleteLocalFld,             ElementU,       OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property
-MACRO_WMS(              DeleteRootFld,              ElementC,       OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property (access to let/const on root object)
+MACRO_WMS_ROOT(         DeleteRootFld,              ElementC,       OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property (access to let/const on root object)
 MACRO_WMS(              DeleteFldStrict,            ElementC,       OpSideEffect|OpOpndHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property in strict mode
-MACRO_WMS(              DeleteRootFldStrict,        ElementC,       OpSideEffect|OpHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property in strict mode (access to let/const on root object)
+MACRO_WMS_ROOT(         DeleteRootFldStrict,        ElementC,       OpSideEffect|OpHasImplicitCall|OpDoNotTransfer|OpPostOpDbgBailOut)  // Remove a property in strict mode (access to let/const on root object)
 MACRO_WMS(              ScopedLdFld,                ElementP,       OpSideEffect|OpHasImplicitCall|OpPostOpDbgBailOut)                  // Load from function's scope stack
-MACRO_EXTEND_WMS(       ScopedLdFldForTypeOf,       ElementP,       OpSideEffect|OpHasImplicitCall| OpPostOpDbgBailOut)                 // Load from function's scope stack for Typeof of a property
+MACRO_EXTEND_WMS(       ScopedLdFldForTypeOf,       ElementP,       OpSideEffect|OpHasImplicitCall|OpPostOpDbgBailOut)                  // Load from function's scope stack for Typeof of a property
 MACRO_WMS(              ScopedLdMethodFld,          ElementCP,      OpSideEffect|OpHasImplicitCall|OpPostOpDbgBailOut)                  // Load call target from ScriptObject instance's direct field, but either scope object or root load from root object
 MACRO_WMS(              ScopedLdInst,               ElementScopedC2,OpSideEffect|OpHasImplicitCall)                                     // Load owning instance from function's scope stack (NOTE: HasProperty may call DOM)
 MACRO_WMS(              ScopedInitFunc,             ElementScopedC, OpSideEffect|OpHasImplicitCall|OpPostOpDbgBailOut)                  // Init on instance on scope stack
@@ -488,7 +555,7 @@ MACRO_WMS(              LdIndexedFrameDisplay,Reg2Int1,         None)        // 
 MACRO_WMS(              LdIndexedFrameDisplayNoParent,Reg1Unsigned1, None)        // Set up a frame display for this function and its parent frames -- this is for an inner scope, not the function-level scope
 MACRO_WMS(              LdFuncExprFrameDisplay,Reg2,        None)
 MACRO_BACKEND_ONLY(     NewStackFrameDisplay,Reg3,          None)           // Set up a frame display allocated on the stack
-    MACRO_WMS(              IsIn,               Reg3,           OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)        // "x in y"  (NOTE: calls valueOf for the index
+MACRO_WMS(              IsIn,               Reg3,           OpSideEffect|OpOpndHasImplicitCall|OpPostOpDbgBailOut)        // "x in y"  (NOTE: calls valueOf for the index
 MACRO_WMS(              LdArgumentsFromFrame,Reg1,          None)           // Load the argument object from frame
 MACRO_WMS(              LdElemUndef,        ElementU,       OpSideEffect)   // Load 'undefined' to instance.property if not already present
 MACRO_EXTEND_WMS(       LdLocalElemUndef,   ElementRootU,   OpSideEffect)   // Load 'undefined' to instance.property if not already present
@@ -778,3 +845,8 @@ MACRO_BACKEND_ONLY(     TrapIfUnalignedAccess, Reg3,        OpSideEffect)
 #undef MACRO_EXTEND
 #undef MACRO_EXTEND_WMS
 #undef MACRO_BACKEND_ONLY
+#undef MACRO_WITH_DBG_ATTR
+#undef MACRO_WMS_WITH_DBG_ATTR
+#undef MACRO_EXTEND_WITH_DBG_ATTR
+#undef MACRO_EXTEND_WMS_WITH_DBG_ATTR
+#undef MACRO_BACKEND_ONLY_WITH_DBG_ATTR

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -2563,7 +2563,7 @@ namespace Js
                                         InsertItem(originalObject, object, propertyId, isConst, isUnscoped, &pMethodsGroupWalker);
                                     }
                                 }
-                                else if ((jsFunction->IsScriptFunction() && !jsFunction->IsJsBuiltIn()) || jsFunction->IsBoundFunction())
+                                else if ((jsFunction->IsScriptFunction() && !jsFunction->GetFunctionProxy()->IsJsBuiltInCode()) || jsFunction->IsBoundFunction())
                                 {
                                     // Adding special property length for the ScriptFunction, like it is done in JavascriptFunction::GetSpecialNonEnumerablePropertyName
                                     InsertItem(originalObject, object, PropertyIds::length, true/*not editable*/, false /*isUnscoped*/, &pMethodsGroupWalker);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -8203,7 +8203,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(uint loopId)
 
     Var InterpreterStackFrame::GetRootObject() const
     {
-        Assert(!this->GetFunctionBody()->IsJsBuiltInInitCode());
+        Assert(!this->GetFunctionBody()->IsJsBuiltInCode());
         Var rootObject = GetReg(Js::FunctionBody::RootObjectRegSlot);
         Assert(rootObject == this->GetFunctionBody()->LoadRootObject());
         return rootObject;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -33,9 +33,6 @@ namespace Js
         : DynamicObject(type), functionInfo(nullptr), constructorCache(&ConstructorCache::DefaultInstance)
     {
         Assert(this->constructorCache != nullptr);
-#if DBG
-        isJsBuiltInInitCode = false;
-#endif
     }
 
 
@@ -52,9 +49,6 @@ namespace Js
             // GetScriptContext()->InvalidateStoreFieldCaches(PropertyIds::length);
             GetLibrary()->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
         }
-#if DBG
-        isJsBuiltInInitCode = false;
-#endif
     }
 
     JavascriptFunction::JavascriptFunction(DynamicType * type, FunctionInfo * functionInfo, ConstructorCache* cache)
@@ -70,9 +64,6 @@ namespace Js
             // GetScriptContext()->InvalidateStoreFieldCaches(PropertyIds::length);
             GetLibrary()->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
         }
-#if DBG
-        isJsBuiltInInitCode = false;
-#endif
     }
 
     FunctionProxy *JavascriptFunction::GetFunctionProxy() const
@@ -2476,16 +2467,6 @@ LABEL1:
             this->IsLibraryCode() || // JS-defined built-in library functions
             this == this->GetLibrary()->GetFunctionPrototype() // the intrinsic %FunctionPrototype% (original value of Function.prototype)
             );
-    }
-
-    void JavascriptFunction::SetIsJsBuiltInCode()
-    {
-        isJsBuiltInCode = true;
-    }
-
-    bool JavascriptFunction::IsJsBuiltIn()
-    {
-        return isJsBuiltInCode;
     }
 
     PropertyQueryFlags JavascriptFunction::HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info)

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -41,15 +41,8 @@ namespace Js
 
         // Need a constructor cache on every function (script and native) to avoid extra checks on the fast path, if the function isn't fixed.
         Field(ConstructorCache*) constructorCache;
-
-        Field(bool) isJsBuiltInCode;
-#if DBG
-        Field(bool) isJsBuiltInInitCode;
-#endif
     protected:
-
         Field(FunctionInfo *) functionInfo;  // Underlying function
-
 
         DEFINE_VTABLE_CTOR(JavascriptFunction, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptFunction);
@@ -191,9 +184,6 @@ namespace Js
         BOOL IsLambda() const;
         virtual inline BOOL IsConstructor() const;
         bool HasRestrictedProperties() const;
-
-        void SetIsJsBuiltInCode();
-        bool IsJsBuiltIn();
 
         ConstructorCache* GetConstructorCache() { Assert(this->constructorCache != nullptr); return this->constructorCache; }
         ConstructorCache* EnsureValidConstructorCache();

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1537,8 +1537,12 @@ namespace Js
 #ifdef ENABLE_JS_BUILTINS
         if (scriptContext->IsJsBuiltInEnabled())
         {
-            scriptContext->GetLibrary()->EnsureBuiltInEngineIsReady();
-            return JavascriptFunction::Is(function) && JavascriptFunction::FromVar(function)->IsJsBuiltIn();
+            ScriptFunction * scriptFunction = JavascriptOperators::TryFromVar<ScriptFunction>(function);
+            if (scriptFunction)
+            {
+                scriptContext->GetLibrary()->EnsureBuiltInEngineIsReady();
+                return scriptFunction->GetFunctionProxy()->IsJsBuiltInCode();
+            }
         }
 #endif
         JavascriptMethod method = function->GetEntryPoint();

--- a/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
@@ -109,9 +109,6 @@ namespace Js
             // so marshalling will inadvertantly transition the entrypoint of the prototype to a crosssite entrypoint
             // So we set the prototype to null here
             functionGlobal->SetPrototype(scriptContext->GetLibrary()->nullValue);
-#if DBG
-            functionGlobal->GetFunctionProxy()->SetIsJsBuiltInInitCode();
-#endif
 
 #ifdef ENABLE_SCRIPT_PROFILING
             // If we are profiling, we need to register the script to the profiler callback, so the script compiled event will be sent.
@@ -138,9 +135,6 @@ namespace Js
 
             Js::ScriptFunction *functionBuiltins = scriptContext->GetLibrary()->CreateScriptFunction(jsBuiltInByteCode->GetNestedFunctionForExecution(0));
             functionBuiltins->SetPrototype(scriptContext->GetLibrary()->nullValue);
-#if DBG
-            functionBuiltins->GetFunctionProxy()->SetIsJsBuiltInInitCode();
-#endif
 
             // Clear disable implicit call bit as initialization code doesn't have any side effect
             saveImplicitCallFlags = scriptContext->GetThreadContext()->GetImplicitCallFlags();
@@ -279,7 +273,6 @@ namespace Js
 
         // Link the function to __chakraLibrary.
         ScriptFunction* scriptFunction = library->CreateScriptFunction(func->GetFunctionProxy());
-        scriptFunction->SetIsJsBuiltInCode();
         scriptFunction->GetFunctionProxy()->SetIsJsBuiltInCode();
 
         Assert(scriptFunction->HasFunctionBody());
@@ -336,7 +329,6 @@ namespace Js
 
         // Link the function to the prototype.
         ScriptFunction* scriptFunction = library->CreateScriptFunction(func->GetFunctionProxy());
-        scriptFunction->SetIsJsBuiltInCode();
         scriptFunction->GetFunctionProxy()->SetIsJsBuiltInCode();
 
         if (forceInline)

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -175,7 +175,7 @@ namespace Js
 
     bool ScriptFunction::Is(Var func)
     {
-        return JavascriptFunction::Is(func) && JavascriptFunction::UnsafeFromVar(func)->GetFunctionInfo()->HasBody();
+        return JavascriptFunction::Is(func) && JavascriptFunction::UnsafeFromVar(func)->IsScriptFunction();
     }
 
     ScriptFunction * ScriptFunction::FromVar(Var func)

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -46,7 +46,7 @@ namespace Js
     public:
         ScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType);
         static bool Is(Var func);
-        inline static BOOL Test(JavascriptFunction *func) { return func->GetFunctionInfo()->HasBody(); }
+        inline static BOOL Test(JavascriptFunction *func) { return func->IsScriptFunction(); }
         static ScriptFunction * FromVar(Var func);
         static ScriptFunction * UnsafeFromVar(Var func);
         static ScriptFunction * OP_NewScFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);


### PR DESCRIPTION
Just use the flags on the FunctionProxy
Add assert to not emit opcode that access the global when using LdChakraLib for JsBuiltIns
Add debug attributes for opcodes to mark opcode that would load root
Move backend only attribute to debug attributes.
