### PR TITLE
Making object pointer copy-prop (slightly) more agressive in loop prepass

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -1547,6 +1547,12 @@ BackwardPass::ProcessLoop(BasicBlock * lastBlock)
     Assert(!this->IsPrePass());
     this->currentPrePassLoop = loop;
 
+    if (tag == Js::BackwardPhase)
+    {
+        Assert(loop->symsAssignedToInLoop == nullptr);
+        loop->symsAssignedToInLoop = JitAnew(this->globOpt->alloc, BVSparse<JitArenaAllocator>, this->globOpt->alloc);
+    }
+
     FOREACH_BLOCK_BACKWARD_IN_RANGE_DEAD_OR_ALIVE(block, lastBlock, nullptr)
     {
         this->ProcessBlock(block);
@@ -6507,6 +6513,10 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
         if (!IsCollectionPass())
         {
             this->InvalidateCloneStrCandidate(opnd);
+            if ((tag == Js::BackwardPhase) && IsPrePass())
+            {
+                this->currentPrePassLoop->symsAssignedToInLoop->Set(sym->m_id);
+            }
         }
     }
     else if (opnd->IsSymOpnd())

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3645,6 +3645,26 @@ Loop::SetLoopTopInstr(IR::LabelInstr * loopTop)
     this->loopTopLabel = loopTop;
 }
 
+bool
+Loop::IsSymAssignedToInSelfOrParents(StackSym * const sym) const
+{
+    if (!this->symsAssignedToInLoop->Test(sym->m_id))
+    {
+        for (Loop* curLoop = this->parent; curLoop != nullptr; curLoop = curLoop->parent)
+        {
+            if (curLoop->symsAssignedToInLoop->Test(sym->m_id))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
 #if DBG_DUMP
 uint
 Loop::GetLoopNumber() const

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3648,21 +3648,14 @@ Loop::SetLoopTopInstr(IR::LabelInstr * loopTop)
 bool
 Loop::IsSymAssignedToInSelfOrParents(StackSym * const sym) const
 {
-    if (!this->symsAssignedToInLoop->Test(sym->m_id))
+    for (const Loop* curLoop = this; curLoop != nullptr; curLoop = curLoop->parent)
     {
-        for (Loop* curLoop = this->parent; curLoop != nullptr; curLoop = curLoop->parent)
+        if (curLoop->symsAssignedToInLoop->Test(sym->m_id))
         {
-            if (curLoop->symsAssignedToInLoop->Test(sym->m_id))
-            {
-                return true;
-            }
+            return true;
         }
-        return false;
     }
-    else
-    {
-        return true;
-    }
+    return false;
 }
 
 #if DBG_DUMP

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -578,6 +578,11 @@ public:
     BVSparse<JitArenaAllocator> *forceFloat64SymsOnEntry;
 
     BVSparse<JitArenaAllocator> *symsDefInLoop;
+    // This is different from symsDefInLoop which only captures syms that survived IR 
+    // cleanup in PreOptPeep in the pre-pass of a loop. For aggressively transferring
+    // values in prepass, we need to know if a source sym was ever assigned to in a loop.
+    BVSparse<JitArenaAllocator> *symsAssignedToInLoop;
+
     BailOutInfo *       bailOutInfo;
     IR::BailOutInstr *  toPrimitiveSideEffectCheck;
     BVSparse<JitArenaAllocator> * fieldHoistCandidates;
@@ -719,6 +724,7 @@ public:
         likelyNumberSymsUsedBeforeDefined(nullptr),
         forceFloat64SymsOnEntry(nullptr),
         symsDefInLoop(nullptr),
+        symsAssignedToInLoop(nullptr),
         fieldHoistCandidateTypes(nullptr),
         fieldHoistSymMap(alloc),
         needImplicitCallBailoutChecksForJsArrayCheckHoist(false),
@@ -752,6 +758,7 @@ public:
     IR::LabelInstr *    GetLoopTopInstr() const;
     void                SetLoopTopInstr(IR::LabelInstr * loopTop);
     Func *              GetFunc() const { return GetLoopTopInstr()->m_func; }
+    bool                IsSymAssignedToInSelfOrParents(StackSym * const sym) const;
 #if DBG_DUMP
     bool                GetHasCall() const { return hasCall; }
     uint                GetLoopNumber() const;

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -562,6 +562,7 @@ private:
     Value *                 ValueNumberLdElemDst(IR::Instr **pInstr, Value *srcVal);
     ValueType               GetPrepassValueTypeForDst(const ValueType desiredValueType, IR::Instr *const instr, Value *const src1Value, Value *const src2Value, bool *const isValueInfoPreciseRef = nullptr) const;
     bool                    IsPrepassSrcValueInfoPrecise(IR::Opnd *const src, Value *const srcValue) const;
+    bool                    IsSafeToTransferInPrepass(StackSym * const sym, ValueInfo *const srcValueInfo) const;
     Value *                 CreateDstUntransferredIntValue(const int32 min, const int32 max, IR::Instr *const instr, Value *const src1Value, Value *const src2Value);
     Value *                 CreateDstUntransferredValue(const ValueType desiredValueType, IR::Instr *const instr, Value *const src1Value, Value *const src2Value);
     Value *                 ValueNumberTransferDst(IR::Instr *const instr, Value *src1Val);

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -3106,7 +3106,8 @@ GlobOpt::CopyPropPropertySymObj(IR::SymOpnd *symOpnd, IR::Instr *instr)
             PropertySym *newProp = PropertySym::FindOrCreate(
                 copySym->m_id, propertySym->m_propertyId, propertySym->GetPropertyIdIndex(), propertySym->GetInlineCacheIndex(), propertySym->m_fieldKind, this->func);
 
-            if (!this->IsLoopPrePass() || (objSym->IsSingleDef() && copySym->IsSingleDef()))
+            if (!this->IsLoopPrePass() || 
+                 (IsSafeToTransferInPrepass(objSym, val->GetValueInfo()) && IsSafeToTransferInPrepass(copySym, val->GetValueInfo())))
             {
 #if DBG_DUMP
                 if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::GlobOptPhase, this->func->GetSourceContextId(), this->func->GetLocalFunctionId()))


### PR DESCRIPTION
Object pointer copy prop in pre-pass will only kick in if both the object sym and its copy prop sym are single-def. I'm changing it such that the we'll do the optimization in prepass if - 

both object sym and copy sym should not be live on back-edge, if they are then they should not be assigned to inside the current loop or any of its parent loops.
