### PR TITLE
profile elem accesses and emit fastpaths for cache types we've seen

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -15695,9 +15695,7 @@ Lowerer::GenerateFastElemISymbolOrStringIndexCommon(
 }
 
 // Look up a value from the polymorphic inline cache on a PropertyString or Symbol. Offsets are relative to indexOpnd.
-// Currently only checks the local cache (not proto, accessor, or missing); we could consider generating extra checks
-// for those cases if we have some data indicating that they might be relevant at this instruction. If the property
-// is not found, jump to the helper.
+// Checks local and/or proto caches based on profile data. If the property is not found, jump to the helper.
 // opndSlotArray is optional; if provided, it will receive the base address of the slot array that contains the property.
 // opndSlotIndex is optional; if provided, it will receive the index of the match within the slot array.
 void

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -409,23 +409,24 @@ public:
     }
 
 private:
-    IR::IndirOpnd * GenerateFastElemICommon(
-        IR::Instr * ldElem,
-        bool isStore,
-        IR::IndirOpnd * indirOpnd,
-        IR::LabelInstr * labelHelper,
-        IR::LabelInstr * labelCantUseArray,
-        IR::LabelInstr *labelFallthrough,
-        bool * pIsTypedArrayElement,
-        bool * pIsStringIndex,
-        bool *emitBailoutRef,
-        IR::Opnd** maskOpnd,
-        IR::LabelInstr **pLabelSegmentLengthIncreased = nullptr,
-        bool checkArrayLengthOverflow = true,
-        bool forceGenerateFastPath = false,
-        bool returnLength = false,
-        IR::LabelInstr *bailOutLabelInstr = nullptr,
-        bool * indirOpndOverflowed = nullptr);
+    IR::IndirOpnd* GenerateFastElemICommon(
+        _In_ IR::Instr* elemInstr,
+        _In_ bool isStore,
+        _In_ IR::IndirOpnd* indirOpnd,
+        _In_ IR::LabelInstr* labelHelper,
+        _In_ IR::LabelInstr* labelCantUseArray,
+        _In_opt_ IR::LabelInstr* labelFallthrough,
+        _Out_ bool* pIsTypedArrayElement,
+        _Out_ bool* pIsStringIndex,
+        _Out_opt_ bool* emitBailoutRef,
+        _Outptr_opt_result_maybenull_ IR::Opnd** maskOpnd,
+        _Outptr_opt_result_maybenull_ IR::LabelInstr** pLabelSegmentLengthIncreased = nullptr,
+        _In_ bool checkArrayLengthOverflow = true,
+        _In_ bool forceGenerateFastPath = false,
+        _In_ bool returnLength = false,
+        _In_opt_ IR::LabelInstr* bailOutLabelInstr = nullptr,
+        _Out_opt_ bool* indirOpndOverflowed = nullptr,
+        _In_ Js::FldInfoFlags flags = Js::FldInfo_NoInfo);
 
     IR::IndirOpnd * GenerateFastElemIIntIndexCommon(
         IR::Instr * ldElem,
@@ -444,11 +445,55 @@ private:
         IR::LabelInstr *bailOutLabelInstr = nullptr,
         bool * indirOpndOverflowed = nullptr);
 
-    IR::IndirOpnd * GenerateFastElemIStringIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
-    IR::IndirOpnd * GenerateFastElemISymbolIndexCommon(IR::Instr * ldElem, bool isStore, IR::IndirOpnd * indirOpnd, IR::LabelInstr * labelHelper);
+    IR::IndirOpnd* GenerateFastElemIStringIndexCommon(
+        _In_ IR::Instr* elemInstr,
+        _In_ bool isStore,
+        _In_ IR::IndirOpnd* indirOpnd,
+        _In_ IR::LabelInstr* labelHelper,
+        _In_ Js::FldInfoFlags flags);
+
+    IR::IndirOpnd* GenerateFastElemISymbolIndexCommon(
+        _In_ IR::Instr* elemInstr,
+        _In_ bool isStore,
+        _In_ IR::IndirOpnd* indirOpnd,
+        _In_ IR::LabelInstr* labelHelper,
+        _In_ Js::FldInfoFlags flags);
+
+    IR::IndirOpnd* GenerateFastElemISymbolOrStringIndexCommon(
+        _In_ IR::Instr* instrInsert,
+        _In_ IR::RegOpnd* indexOpnd,
+        _In_ IR::RegOpnd* baseOpnd,
+        _In_ const uint32 inlineCacheOffset,
+        _In_ const uint32 hitRateOffset,
+        _In_ IR::LabelInstr* labelHelper,
+        _In_ Js::FldInfoFlags flags);
+
+    void GenerateLookUpInIndexCache(
+        _In_ IR::Instr* instrInsert,
+        _In_ IR::RegOpnd* indexOpnd,
+        _In_ IR::RegOpnd* baseOpnd,
+        _In_opt_ IR::RegOpnd* opndSlotArray,
+        _In_opt_ IR::RegOpnd* opndSlotIndex,
+        _In_ const uint32 inlineCacheOffset,
+        _In_ const uint32 hitRateOffset,
+        _In_ IR::LabelInstr* labelHelper,
+        _In_ Js::FldInfoFlags flags = Js::FldInfo_NoInfo);
+
+    template <bool CheckLocal, bool CheckInlineSlot, bool DoAdd>
+    void GenerateLookUpInIndexCacheHelper(
+        _In_ IR::Instr* instrInsert,
+        _In_ IR::RegOpnd* baseOpnd,
+        _In_opt_ IR::RegOpnd* opndSlotArray,
+        _In_opt_ IR::RegOpnd* opndSlotIndex,
+        _In_ IR::RegOpnd* objectTypeOpnd,
+        _In_ IR::RegOpnd* inlineCacheOpnd,
+        _In_ IR::LabelInstr* doneLabel,
+        _In_ IR::LabelInstr* helperLabel,
+        _Outptr_ IR::LabelInstr** nextLabel,
+        _Outptr_ IR::BranchInstr** branchToPatch,
+        _Inout_ IR::RegOpnd** taggedTypeOpnd);
+
     void            GenerateFastIsInSymbolOrStringIndex(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, IR::Opnd *dest, uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone);
-    IR::IndirOpnd * GenerateFastElemISymbolOrStringIndexCommon(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, const uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper);
-    void            GenerateLookUpInIndexCache(IR::Instr * instrInsert, IR::RegOpnd *indexOpnd, IR::RegOpnd *baseOpnd, IR::RegOpnd *opndSlotArray, IR::RegOpnd *opndSlotIndex, const uint32 inlineCacheOffset, const uint32 hitRateOffset, IR::LabelInstr * labelHelper);
     bool            GenerateFastLdElemI(IR::Instr *& ldElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastStElemI(IR::Instr *& StElem, bool *instrIsInHelperBlockRef);
     bool            GenerateFastLdLen(IR::Instr *ldLen, bool *instrIsInHelperBlockRef);

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -251,15 +251,15 @@ typedef struct LdElemIDL
 {
     unsigned short arrayType;
     unsigned short elemType;
+    byte flags;
     byte bits;
-    IDL_PAD1(0)
 } LdElemIDL;
 
 typedef struct StElemIDL
 {
     unsigned short arrayType;
+    byte flags;
     byte bits;
-    IDL_PAD1(0)
 } StElemIDL;
 
 typedef struct ProfileDataIDL

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -161,10 +161,12 @@ namespace Js
         {
             ldElemInfo[i].arrayType = ValueType::Uninitialized;
             ldElemInfo[i].elemType = ValueType::Uninitialized;
+            ldElemInfo[i].flags = Js::FldInfo_NoInfo;
         }
         for (ProfileId i = 0; i < functionBody->GetProfiledStElemCount(); ++i)
         {
             stElemInfo[i].arrayType = ValueType::Uninitialized;
+            stElemInfo[i].flags = Js::FldInfo_NoInfo;
         }
         for (uint i = 0; i < functionBody->GetProfiledFldCount(); ++i)
         {

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -986,6 +986,21 @@ namespace Js
         stElemInfo[stElemId].wasProfiled = true;
     }
 
+    void LdElemInfo::Merge(const LdElemInfo &other)
+    {
+        arrayType = arrayType.Merge(other.arrayType);
+        elemType = elemType.Merge(other.elemType);
+        flags = DynamicProfileInfo::MergeFldInfoFlags(flags, other.flags);
+        bits |= other.bits;
+    }
+
+    void StElemInfo::Merge(const StElemInfo &other)
+    {
+        arrayType = arrayType.Merge(other.arrayType);
+        flags = DynamicProfileInfo::MergeFldInfoFlags(flags, other.flags);
+        bits |= other.bits;
+    }
+
     ArrayCallSiteInfo * DynamicProfileInfo::GetArrayCallSiteInfo(FunctionBody *functionBody, ProfileId index) const
     {
         Assert(index < functionBody->GetProfiledArrayCallSiteCount());

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -218,6 +218,7 @@ namespace Js
     {
         ValueType arrayType;
         ValueType elemType;
+        FldInfoFlags flags;
 
         union
         {
@@ -230,17 +231,12 @@ namespace Js
             byte bits;
         };
 
-        LdElemInfo() : bits(0)
+        LdElemInfo() : bits(0), flags(FldInfo_NoInfo)
         {
             wasProfiled = true;
         }
 
-        void Merge(const LdElemInfo &other)
-        {
-            arrayType = arrayType.Merge(other.arrayType);
-            elemType = elemType.Merge(other.elemType);
-            bits |= other.bits;
-        }
+        void Merge(const LdElemInfo &other);
 
         ValueType GetArrayType() const
         {
@@ -271,6 +267,7 @@ namespace Js
     struct StElemInfo
     {
         ValueType arrayType;
+        FldInfoFlags flags;
 
         union
         {
@@ -287,16 +284,12 @@ namespace Js
             byte bits;
         };
 
-        StElemInfo() : bits(0)
+        StElemInfo() : bits(0), flags(FldInfo_NoInfo)
         {
             wasProfiled = true;
         }
 
-        void Merge(const StElemInfo &other)
-        {
-            arrayType = arrayType.Merge(other.arrayType);
-            bits |= other.bits;
-        }
+        void Merge(const StElemInfo &other);
 
         ValueType GetArrayType() const
         {

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -105,7 +105,22 @@ namespace Js
             }
         } while(false);
 
-        const Var element = JavascriptOperators::OP_GetElementI(base, varIndex, functionBody->GetScriptContext());
+        ScriptContext* scriptContext = functionBody->GetScriptContext();
+        RecyclableObject* cacheOwner;
+        PropertyRecordUsageCache* propertyRecordUsageCache;
+        Var element = nullptr;
+        if (JavascriptOperators::GetPropertyRecordUsageCache(varIndex, scriptContext, &propertyRecordUsageCache, &cacheOwner))
+        {
+            PropertyCacheOperationInfo operationInfo;
+            element = JavascriptOperators::GetElementIWithCache<true /* ReturnOperationInfo */>(base, cacheOwner, propertyRecordUsageCache, scriptContext, &operationInfo);
+
+            ldElemInfo.flags = DynamicProfileInfo::FldInfoFlagsFromCacheType(operationInfo.cacheType);
+            ldElemInfo.flags = DynamicProfileInfo::MergeFldInfoFlags(ldElemInfo.flags, DynamicProfileInfo::FldInfoFlagsFromSlotType(operationInfo.slotType));
+        }
+        else
+        {
+            element = JavascriptOperators::OP_GetElementI(base, varIndex, scriptContext);
+        }
 
         const ValueType arrayType(ldElemInfo.GetArrayType());
         if(!arrayType.IsUninitialized())
@@ -119,6 +134,7 @@ namespace Js
             }
 
             ldElemInfo.elemType = ValueType::Uninitialized.Merge(element);
+
             functionBody->GetDynamicProfileInfo()->RecordElementLoad(functionBody, profileId, ldElemInfo);
             return element;
         }
@@ -337,7 +353,26 @@ namespace Js
             }
         } while(false);
 
-        JavascriptOperators::OP_SetElementI(base, varIndex, value, scriptContext, flags);
+        RecyclableObject* cacheOwner;
+        PropertyRecordUsageCache* propertyRecordUsageCache;
+        TypeId instanceType = JavascriptOperators::GetTypeId(base);
+        bool isTypedArray = (instanceType >= TypeIds_Int8Array && instanceType <= TypeIds_Float64Array);
+        if (!isTypedArray && JavascriptOperators::GetPropertyRecordUsageCache(varIndex, scriptContext, &propertyRecordUsageCache, &cacheOwner))
+        {
+            RecyclableObject* object = nullptr;
+            bool result = JavascriptOperators::GetPropertyObjectForSetElementI(base, cacheOwner, scriptContext, &object);
+            Assert(result);
+
+            PropertyCacheOperationInfo operationInfo;
+            JavascriptOperators::SetElementIWithCache<true /* ReturnOperationInfo */>(base, object, cacheOwner, value, propertyRecordUsageCache, scriptContext, flags, &operationInfo);
+
+            stElemInfo.flags = DynamicProfileInfo::FldInfoFlagsFromCacheType(operationInfo.cacheType);
+            stElemInfo.flags = DynamicProfileInfo::MergeFldInfoFlags(stElemInfo.flags, DynamicProfileInfo::FldInfoFlagsFromSlotType(operationInfo.slotType));
+        }
+        else
+        {
+            JavascriptOperators::OP_SetElementI(base, varIndex, value, scriptContext, flags);
+        }
 
         if(!stElemInfo.GetArrayType().IsUninitialized())
         {
@@ -345,6 +380,7 @@ namespace Js
             {
                 stElemInfo.createdMissingValue &= !array->HasNoMissingValues();
             }
+
             functionBody->GetDynamicProfileInfo()->RecordElementStore(functionBody, profileId, stElemInfo);
             return;
         }

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -123,7 +123,7 @@ namespace Js
         }
 
         const ValueType arrayType(ldElemInfo.GetArrayType());
-        if(!arrayType.IsUninitialized())
+        if(!arrayType.IsUninitialized() || ldElemInfo.flags != Js::FldInfo_NoInfo)
         {
             if(array && arrayType.IsLikelyObject() && arrayType.GetObjectType() == ObjectType::Array && !arrayType.HasIntElements())
             {
@@ -374,7 +374,7 @@ namespace Js
             JavascriptOperators::OP_SetElementI(base, varIndex, value, scriptContext, flags);
         }
 
-        if(!stElemInfo.GetArrayType().IsUninitialized())
+        if(!stElemInfo.GetArrayType().IsUninitialized() || stElemInfo.flags != Js::FldInfo_NoInfo)
         {
             if(array)
             {

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -12265,6 +12265,20 @@ Case0:
         return DynamicObject::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);
     }
 
+#if ENABLE_COPYONACCESS_ARRAY
+    PropertyQueryFlags JavascriptCopyOnAccessNativeIntArray::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
+    {
+        this->ConvertCopyOnAccessSegment();
+        return JavascriptArray::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext);
+    }
+
+    PropertyQueryFlags JavascriptCopyOnAccessNativeIntArray::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
+    {
+        this->ConvertCopyOnAccessSegment();
+        return JavascriptArray::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);
+    }
+#endif
+
     BOOL JavascriptArray::GetPropertyBuiltIns(PropertyId propertyId, Var* value)
     {
         //

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -12234,6 +12234,9 @@ Case0:
 
     PropertyQueryFlags JavascriptArray::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
+#endif
         if (GetPropertyBuiltIns(propertyId, value))
         {
             return PropertyQueryFlags::Property_Found;
@@ -12251,6 +12254,9 @@ Case0:
 
     PropertyQueryFlags JavascriptArray::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
+#endif
         AssertMsg(!PropertyRecord::IsPropertyNameNumeric(propertyNameString->GetString(), propertyNameString->GetLength()),
             "Numeric property names should have been converted to uint or PropertyRecord*");
 
@@ -12264,20 +12270,6 @@ Case0:
 
         return DynamicObject::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);
     }
-
-#if ENABLE_COPYONACCESS_ARRAY
-    PropertyQueryFlags JavascriptCopyOnAccessNativeIntArray::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
-    {
-        this->ConvertCopyOnAccessSegment();
-        return JavascriptArray::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext);
-    }
-
-    PropertyQueryFlags JavascriptCopyOnAccessNativeIntArray::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
-    {
-        this->ConvertCopyOnAccessSegment();
-        return JavascriptArray::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);
-    }
-#endif
 
     BOOL JavascriptArray::GetPropertyBuiltIns(PropertyId propertyId, Var* value)
     {

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -1137,8 +1137,6 @@ namespace Js
         uint32 GetNextIndex(uint32 index) const;
         BOOL DirectGetItemAt(uint32 index, int* outVal);
 
-        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
-        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         static VTableValue VtableHelper()
         {
             return VTableValue::VtableCopyOnAccessNativeIntArray;

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -1137,6 +1137,8 @@ namespace Js
         uint32 GetNextIndex(uint32 index) const;
         BOOL DirectGetItemAt(uint32 index, int* outVal);
 
+        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
+        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         static VTableValue VtableHelper()
         {
             return VTableValue::VtableCopyOnAccessNativeIntArray;

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -67,7 +67,7 @@ namespace Js
         const PropertyOperationFlags propertyOperationFlags,
         _Inout_ PropertyValueInfo *const propertyValueInfo)
     {
-        return this->propertyRecordUsageCache.TrySetPropertyFromCache(object, propertyValue, requestContext, propertyOperationFlags, propertyValueInfo, this);
+        return this->propertyRecordUsageCache.TrySetPropertyFromCache<false /* ReturnOperationInfo */>(object, propertyValue, requestContext, propertyOperationFlags, propertyValueInfo, this, nullptr);
     }
 
     RecyclableObject * PropertyString::CloneToScriptContext(ScriptContext* requestContext)

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -40,14 +40,14 @@ public:
     template <
         bool OwnPropertyOnly,
         bool OutputExistence /*When set, propertyValue represents whether the property exists on the instance, not its actual value*/>
-    inline bool TryGetPropertyFromCache(
+    bool TryGetPropertyFromCache(
         Var const instance,
         RecyclableObject *const object,
         Var *const propertyValue,
         ScriptContext *const requestContext,
         PropertyValueInfo *const propertyValueInfo)
     {
-        return this->propertyRecordUsageCache.TryGetPropertyFromCache<OwnPropertyOnly, OutputExistence>(instance, object, propertyValue, requestContext, propertyValueInfo, this);
+        return this->propertyRecordUsageCache.TryGetPropertyFromCache<OwnPropertyOnly, OutputExistence, false /* ReturnOperationInfo */>(instance, object, propertyValue, requestContext, propertyValueInfo, this, nullptr);
     }
 
     static PropertyString* New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler);


### PR DESCRIPTION
Perf runs have shown a few scattered improvements of 2-4% across different Speedometer 2 tests (overall improves by ~0.8%). Also looks like it improves ARES-6 ML and Air tests by about 5% each.