### PR TITLE
`JsDiagStopDebugging` should allow `nullptr`

### DIFF
--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -154,7 +154,7 @@ typedef unsigned __int32 uint32_t;
     CHAKRA_API
         JsDiagStopDebugging(
             _In_ JsRuntimeHandle runtimeHandle,
-            _Out_ void** callbackState);
+            _Out_opt_ void** callbackState);
 
     /// <summary>
     ///     Request the runtime to break on next JavaScript statement.

--- a/lib/Jsrt/JsrtDiag.cpp
+++ b/lib/Jsrt/JsrtDiag.cpp
@@ -115,7 +115,7 @@ CHAKRA_API JsDiagStartDebugging(
 
 CHAKRA_API JsDiagStopDebugging(
     _In_ JsRuntimeHandle runtimeHandle,
-    _Out_ void** callbackState)
+    _Out_opt_ void** callbackState)
 {
 #ifndef ENABLE_SCRIPT_DEBUGGING
     return JsErrorCategoryUsage;
@@ -124,9 +124,10 @@ CHAKRA_API JsDiagStopDebugging(
 
         VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
 
-        PARAM_NOT_NULL(callbackState);
-
-        *callbackState = nullptr;
+        if (callbackState != nullptr)
+        {
+            *callbackState = nullptr;
+        }
 
         JsrtRuntime * runtime = JsrtRuntime::FromHandle(runtimeHandle);
         ThreadContext * threadContext = runtime->GetThreadContext();
@@ -159,7 +160,12 @@ CHAKRA_API JsDiagStopDebugging(
             jsrtDebugManager->ClearBreakpointDebugDocumentDictionary();
         }
 
-        *callbackState = jsrtDebugManager->GetAndClearCallbackState();
+        void* cbState = jsrtDebugManager->GetAndClearCallbackState();
+
+        if (callbackState != nullptr)
+        {
+            *callbackState = cbState;
+        }
 
         return JsNoError;
     });


### PR DESCRIPTION
The `JsDiagStopDebugging` call currently requires a non-null
`callbackState` argument even if the caller doesn't want or need that
value.
