### PR TITLE
Consolidate MSBuild properties for ICU

### DIFF
--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -25,14 +25,7 @@
     <!-- ARM does not support ICU until we figure out how to link icudtXXl.dat without genccode.exe -->
     <ChakraICU Condition="'$(Platform)'=='ARM'">false</ChakraICU>
 
-    <WindowsICU Condition="'$(WindowsICU)'==''">false</WindowsICU>
-
-    <UseICU Condition="'$(UseICU)'==''">false</UseICU>
-    <UseICU Condition="'$(BuildLite)'=='true'">false</UseICU>
-    <UseICU Condition="'$(ChakraICU)'!='false' OR '$(WindowsICU)'=='true'">true</UseICU>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(WindowsICU)'=='true'">
-    <IcuLibraryDependencies>icuuc.lib;icuin.lib</IcuLibraryDependencies>
+    <IcuLibraryDependencies Condition="'$(ChakraICU)'=='windows'">icuuc.lib;icuin.lib</IcuLibraryDependencies>
   </PropertyGroup>
   <Import Condition="'$(ChakraICU)'!='false' AND exists('$(ChakraCoreRootDirectory)deps\Chakra.ICU\Chakra.ICU.props')" Project="$(ChakraCoreRootDirectory)deps\Chakra.ICU\Chakra.ICU.props" />
   <ItemDefinitionGroup>
@@ -56,12 +49,12 @@
         %(PreprocessorDefinitions);
         CHAKRACORE_LITE
       </PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(UseICU)'=='true'">
+      <PreprocessorDefinitions Condition="'$(ChakraICU)'!='false'">
         %(PreprocessorDefinitions);
         HAS_ICU;
         U_DISABLE_RENAMING=1; <!-- Disable renaming to maintain compatibility with Windows Kit ICU's icuuc/icuin.lib -->
       </PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(EnableIntl)'=='true' AND '$(UseICU)'=='true'">
+      <PreprocessorDefinitions Condition="'$(EnableIntl)'=='true' AND '$(ChakraICU)'!='false'">
         %(PreprocessorDefinitions);
         INTL_ICU=1
       </PreprocessorDefinitions>
@@ -69,11 +62,11 @@
         %(PreprocessorDefinitions);
         U_STATIC_IMPLEMENTATION=1
       </PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(WindowsICU)'=='true'">
+      <PreprocessorDefinitions Condition="'$(ChakraICU)'=='windows'">
         %(PreprocessorDefinitions);
         WINDOWS10_ICU
       </PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(WindowsICU)'=='false'">
+      <PreprocessorDefinitions Condition="'$(ChakraICU)'!='windows' AND '$(ChakraICU)'!='false'">
         %(PreprocessorDefinitions);
         ICU_VERSION=$(IcuVersionMajor)
       </PreprocessorDefinitions>

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -106,7 +106,7 @@
     <ChakraCommonLinkDependencies>
         oleaut32.lib;
         version.lib;
-	bcrypt.lib
+        bcrypt.lib
     </ChakraCommonLinkDependencies>
     <RLCommonLinkDependencies>
         kernel32.lib;

--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -50,7 +50,7 @@
         advapi32.lib;
         ole32.lib;
         Rpcrt4.lib;
-	bcrypt.lib;
+        bcrypt.lib;
         $(ChakraCommonLinkDependencies)
       </AdditionalDependencies>
       <AdditionalDependencies Condition="'$(ChakraICU)'!='false' AND '$(IcuLibraryDependencies)'!=''">

--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -53,7 +53,7 @@
 	bcrypt.lib;
         $(ChakraCommonLinkDependencies)
       </AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(UseICU)'=='true' AND '$(ChakraICU)'=='false'">
+      <AdditionalDependencies Condition="'$(ChakraICU)'!='false' AND '$(IcuLibraryDependencies)'!=''">
         $(IcuLibraryDependencies);
         %(AdditionalDependencies)
       </AdditionalDependencies>
@@ -173,13 +173,13 @@
     <ProjectReference Include="..\..\lib\Runtime\Types\Chakra.Runtime.Types.vcxproj">
       <Project>{706083f7-6aa4-4558-a153-6352ef9110f6}</Project>
     </ProjectReference>
-    <ProjectReference Condition="'$(ChakraICU)'!='false'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Common.vcxproj">
+    <ProjectReference Condition="'$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Common.vcxproj">
       <Project>{EE2A3111-4D85-427C-B0AB-E6B0EA7FFB44}</Project>
     </ProjectReference>
-    <ProjectReference Condition="'$(ChakraICU)'!='false'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.i18n.vcxproj">
+    <ProjectReference Condition="'$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.i18n.vcxproj">
       <Project>{0494C753-5BB9-45AA-874E-E61B9922E88F}</Project>
     </ProjectReference>
-    <ProjectReference Condition="'$(ChakraICU)'!='false'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Data.vcxproj">
+    <ProjectReference Condition="'$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Data.vcxproj">
       <Project>{347824B1-7100-4EE6-8A6B-4FF64E66B0C0}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/bin/ch/ch.vcxproj
+++ b/bin/ch/ch.vcxproj
@@ -43,7 +43,7 @@
         kernel32.lib;
         Rpcrt4.lib;
         version.lib;
-	bcrypt.lib;
+        bcrypt.lib;
       </AdditionalDependencies>
       <AdditionalDependencies Condition="'$(ChakraICU)'!='false' AND '$(IcuLibraryDependencies)'!=''">
         $(IcuLibraryDependencies);

--- a/bin/ch/ch.vcxproj
+++ b/bin/ch/ch.vcxproj
@@ -28,7 +28,7 @@
         %(AdditionalIncludeDirectories);
       </AdditionalIncludeDirectories>
       <!-- For ChakraICU.h -->
-      <AdditionalIncludeDirectories Condition="'$(UseICU)'=='true'">
+      <AdditionalIncludeDirectories Condition="'$(ChakraICU)'!='false'">
         $(ChakraCoreRootDirectory)lib\Runtime;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
@@ -45,7 +45,7 @@
         version.lib;
 	bcrypt.lib;
       </AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(UseICU)'=='true' AND '$(ChakraICU)'=='false'">
+      <AdditionalDependencies Condition="'$(ChakraICU)'!='false' AND '$(IcuLibraryDependencies)'!=''">
         $(IcuLibraryDependencies);
         %(AdditionalDependencies)
       </AdditionalDependencies>
@@ -99,7 +99,7 @@
       <Project>{EA882C8D-81FC-42FE-ABD5-2666DB933FDB}</Project>
     </ProjectReference>
     <!-- for u_getVersion() referenced in PlatformAgnostic::ICUHelpers::GetICUMajorVersion -->
-    <ProjectReference Condition="'$(ChakraICU)'!='false'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Common.vcxproj">
+    <ProjectReference Condition="'$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared'" Include="..\..\deps\Chakra.ICU\Chakra.ICU.Common.vcxproj">
       <Project>{EE2A3111-4D85-427C-B0AB-E6B0EA7FFB44}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/deps/Chakra.ICU/Chakra.ICU.Build.props
+++ b/deps/Chakra.ICU/Chakra.ICU.Build.props
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildLocalICU>false</BuildLocalICU>
+    <BuildLocalICU Condition="'$(ChakraICU)'=='static' OR '$(ChakraICU)'=='shared'">true</BuildLocalICU>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <!-- ICU warning output is exceptionally noisy -->

--- a/deps/Chakra.ICU/Chakra.ICU.Common.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Common.vcxproj
@@ -31,7 +31,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <ClCompile Include="$(IcuCommonSources)" />
     <ClInclude Include="$(IcuCommonHeaders)" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)Chakra.ICU.Stubdata.vcxproj">

--- a/deps/Chakra.ICU/Chakra.ICU.Data.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Data.vcxproj
@@ -27,7 +27,7 @@
       <NoEntryPoint>true</NoEntryPoint>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <None Include="$(IntDir)icudt$(IcuVersionMajor)l_dat.obj" /> <!-- forces the automagic build system to create a lib from the obj -->
     <CustomBuild Include="$(MSBuildThisFileDirectory)source\data\in\icudt$(IcuVersionMajor)l.dat">
       <Command>$(GenCCodePath) --object --destdir $(IntDir) --entrypoint icudt$(IcuVersionMajor) $(IcuSourceDirectory)\data\in\icudt$(IcuVersionMajor)l.dat</Command>

--- a/deps/Chakra.ICU/Chakra.ICU.GenCCode.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.GenCCode.vcxproj
@@ -33,7 +33,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <ClCompile Include="$(IcuGenccodeSources)" />
     <ClInclude Include="$(IcuGenccodeHeaders)" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)Chakra.ICU.Common.vcxproj">

--- a/deps/Chakra.ICU/Chakra.ICU.Stubdata.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Stubdata.vcxproj
@@ -39,7 +39,7 @@
       <ImportLibrary>$(OutDir)\Chakra.ICU.Data.lib</ImportLibrary>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <ClCompile Include="$(IcuStubdataSources)" />
     <ClInclude Include="$(IcuStubdataHeaders)" />
   </ItemGroup>

--- a/deps/Chakra.ICU/Chakra.ICU.Toolutil.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.Toolutil.vcxproj
@@ -33,7 +33,7 @@
       </AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <ClCompile Include="$(IcuToolutilSources)" />
     <ClInclude Include="$(IcuToolutilHeaders)" />
   </ItemGroup>

--- a/deps/Chakra.ICU/Chakra.ICU.i18n.vcxproj
+++ b/deps/Chakra.ICU/Chakra.ICU.i18n.vcxproj
@@ -39,7 +39,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
-  <ItemGroup Condition="'$(ChakraICU)'!='false'">
+  <ItemGroup Condition="'$(BuildLocalICU)'=='true'">
     <ClCompile Include="$(IcuI18nSources)" />
     <ClInclude Include="$(IcuI18nHeaders)" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)Chakra.ICU.Stubdata.vcxproj">

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -50,7 +50,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\Thread.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\PerfTrace.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Common\UnicodeText.Common.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Common\UnicodeText.ICU.cpp" Condition="'$(UseICU)'=='true'" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Common\UnicodeText.ICU.cpp" Condition="'$(ChakraICU)'!='false'" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ChakraPlatform.h" />


### PR DESCRIPTION
This PR eliminates some of the messiness around having multiple properties controlling ICU build conditions on Windows, in preparation for turning ICU on by default in ChakraFull. As of this PR, the following options control ICU-ness:

```
/p:ChakraICU=false (default) // Do not use ICU
/p:ChakraICU=static // Statically link against ICU located at deps/Chakra.ICU/icu
/p:ChakraICU=shared // Dynamically link against ICU located at deps/Chakra.ICU/icu
/p:ChakraICU=windows // Link against Windows Kit ICU (WARNING - binaries produced with this can only run on RS2+)
```

[Companion ChakraFull PR](https://devdiv.visualstudio.com/DevDiv/Chakra/_git/Chakra/pullrequest/115767?_a=overview
), even though ChakraFull#master can't build with ICU for other reasons.