### PR TITLE
Check that PropertyValueInfo refers to correct PolymorphicInlineCache when resizing

### DIFF
--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -447,6 +447,7 @@ namespace Js
                 {
                     if (info->GetFunctionBody())
                     {
+                        Assert(polymorphicInlineCache == info->GetFunctionBody()->GetPolymorphicInlineCache(info->GetInlineCacheIndex()));
                         polymorphicInlineCache =
                             info->GetFunctionBody()->CreateBiggerPolymorphicInlineCache(
                                 info->GetInlineCacheIndex(),
@@ -455,6 +456,7 @@ namespace Js
                     else
                     {
                         Assert(!info->GetFunctionBody());
+                        Assert(polymorphicInlineCache == (IsRead ? info->GetPropertyRecordUsageCache()->GetLdElemInlineCache() : info->GetPropertyRecordUsageCache()->GetStElemInlineCache()));
                         polymorphicInlineCache = info->GetPropertyRecordUsageCache()->CreateBiggerPolymorphicInlineCache(IsRead);
                     }
                 }


### PR DESCRIPTION
A previous bug (which is already fixed) could lead to a case where we attempted to resize the wrong PolymorphicInlineCache instance. These new assertions make our assumptions more clear, and would have caught the problem upon first resize rather than only after the cache size passed its maximum.

Fixes OS:16712443
