### PR TITLE
Add edge from catch block to enclosing finally block in jitloopbodies

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -490,6 +490,8 @@ FlowGraph::Build(void)
             }
             else if (instr->m_opcode == Js::OpCode::Leave)
             {
+                Assert(currentLabel != nullptr);
+                __analysis_assume(currentLabel != nullptr);
                 if (createNonExceptionFinally)
                 {
                     IR::LabelInstr *branchTarget = instr->AsBranchInstr()->GetTarget();
@@ -498,8 +500,7 @@ FlowGraph::Build(void)
                     // When there is an early exit within a try finally, we have to execute finally code
                     // Currently we bailout on early exits
                     // For all such edges add edge from eh region -> finally and finally -> earlyexit
-                    Assert(currentLabel != nullptr);
-                    if (currentLabel && CheckIfEarlyExitAndAddEdgeToFinally(instr->AsBranchInstr(), currentLabel->GetRegion(), branchTarget->GetRegion(), instrNext, exitLabel))
+                    if (CheckIfEarlyExitAndAddEdgeToFinally(instr->AsBranchInstr(), currentLabel->GetRegion(), branchTarget->GetRegion(), instrNext, exitLabel))
                     {
                         Assert(exitLabel);
                         IR::Instr * bailOnEarlyExit = IR::BailOutInstr::New(Js::OpCode::BailOnEarlyExit, IR::BailOutOnEarlyExit, instr, instr->m_func);

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -391,7 +391,9 @@ IRBuilder::Build()
     Func * topFunc = this->m_func->GetTopFunc();
     if (topFunc->HasTry() &&
         ((!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryCatchPhase, topFunc)) ||
-        (topFunc->IsSimpleJit() && topFunc->GetJITFunctionBody()->DoJITLoopBody()))) // should be relaxed as more bailouts are added in Simple Jit
+        (!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryFinallyPhase, topFunc) ||
+        (topFunc->IsSimpleJit() && topFunc->GetJITFunctionBody()->DoJITLoopBody()) ||  // should be relaxed as more bailouts are added in Simple Jit
+        (topFunc->IsLoopBodyInTryFinally() && topFunc->GetJITFunctionBody()->DoJITLoopBody())))) // We need accurate flow when we are full jitting loop bodies which have try finally
     {
         this->handlerOffsetStack = JitAnew(m_tempAlloc, SList<handlerStackElementType>, m_tempAlloc);
     }

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -391,9 +391,9 @@ IRBuilder::Build()
     Func * topFunc = this->m_func->GetTopFunc();
     if (topFunc->HasTry() &&
         ((!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryCatchPhase, topFunc)) ||
-        (!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryFinallyPhase, topFunc) ||
+        (!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryFinallyPhase, topFunc)) ||
         (topFunc->IsSimpleJit() && topFunc->GetJITFunctionBody()->DoJITLoopBody()) ||  // should be relaxed as more bailouts are added in Simple Jit
-        (topFunc->IsLoopBodyInTryFinally() && topFunc->GetJITFunctionBody()->DoJITLoopBody())))) // We need accurate flow when we are full jitting loop bodies which have try finally
+        (topFunc->IsLoopBodyInTryFinally() && topFunc->GetJITFunctionBody()->DoJITLoopBody()))) // We need accurate flow when we are full jitting loop bodies which have try finally
     {
         this->handlerOffsetStack = JitAnew(m_tempAlloc, SList<handlerStackElementType>, m_tempAlloc);
     }

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -391,9 +391,9 @@ IRBuilder::Build()
     Func * topFunc = this->m_func->GetTopFunc();
     if (topFunc->HasTry() &&
         ((!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryCatchPhase, topFunc)) ||
-        (!topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryFinallyPhase, topFunc)) ||
+        (topFunc->HasFinally() && !topFunc->IsLoopBody() && !PHASE_OFF(Js::OptimizeTryFinallyPhase, topFunc)) ||
         (topFunc->IsSimpleJit() && topFunc->GetJITFunctionBody()->DoJITLoopBody()) ||  // should be relaxed as more bailouts are added in Simple Jit
-        (topFunc->IsLoopBodyInTryFinally() && topFunc->GetJITFunctionBody()->DoJITLoopBody()))) // We need accurate flow when we are full jitting loop bodies which have try finally
+        topFunc->IsLoopBodyInTryFinally())) // We need accurate flow when we are full jitting loop bodies which have try finally
     {
         this->handlerOffsetStack = JitAnew(m_tempAlloc, SList<handlerStackElementType>, m_tempAlloc);
     }

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -193,4 +193,9 @@
        <files>tfjitlooparmbug.js</files>
   </default>
   </test>
+  <test>
+    <default>
+       <files>tfjitloopbug.js</files>
+  </default>
+  </test>
 </regress-exe>

--- a/test/EH/tfjitloopbug.js
+++ b/test/EH/tfjitloopbug.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0(x) {
+  var obj1 = {};
+  var func3 = function () {
+  };
+  obj1.method1 = func3;
+  var i8 = new Int8Array(256);
+  var IntArr0 = [];
+  var protoObj1 = Object(obj1);
+  for (var _strvar1 of i8) {
+    for (; protoObj1.method1(); d) {
+      if (x) {	    
+      return 2491902987445170000;
+      }
+      else {
+       return 1;
+      }
+    }
+    for (var _strvar1 of IntArr0) {
+    }
+  }
+}
+test0(1);
+test0(0);
+test0(1);
+print("Passed\n");


### PR DESCRIPTION
We can have BailOutOnEarlyExit which necessitates accurate flow.
This change adds a BrOnException fake flow edge from catch block's end to  finally block enclosing it.

Fixes OS#16673022