### PR TITLE
Parser Refactor: Use different ParseNode kind for knopStr and knopName and enforce child node type for some operations

### DIFF
--- a/lib/Parser/FormalsUtil.h
+++ b/lib/Parser/FormalsUtil.h
@@ -4,34 +4,34 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 template <class Fn, bool mapRest>
-void MapFormalsImpl(ParseNode *pnodeFunc, Fn fn)
+void MapFormalsImpl(ParseNodeFnc *pnodeFunc, Fn fn)
 {
-    for (ParseNode *pnode = pnodeFunc->AsParseNodeFnc()->pnodeParams; pnode != nullptr; pnode = pnode->GetFormalNext())
+    for (ParseNode *pnode = pnodeFunc->pnodeParams; pnode != nullptr; pnode = pnode->GetFormalNext())
     {
         fn(pnode);
     }
-    if (mapRest && pnodeFunc->AsParseNodeFnc()->pnodeRest != nullptr)
+    if (mapRest && pnodeFunc->pnodeRest != nullptr)
     {
-        fn(pnodeFunc->AsParseNodeFnc()->pnodeRest);
+        fn(pnodeFunc->pnodeRest);
     }
 }
 
 template <class Fn>
-void MapFormalsWithoutRest(ParseNode *pnodeFunc, Fn fn)
+void MapFormalsWithoutRest(ParseNodeFnc *pnodeFunc, Fn fn)
 {
     return MapFormalsImpl<Fn, false>(pnodeFunc, fn);
 }
 
 template <class Fn>
-void MapFormals(ParseNode *pnodeFunc, Fn fn)
+void MapFormals(ParseNodeFnc *pnodeFunc, Fn fn)
 {
     return MapFormalsImpl<Fn, true>(pnodeFunc, fn);
 }
 
 template <class Fn>
-void MapFormalsFromPattern(ParseNode *pnodeFunc, Fn fn)
+void MapFormalsFromPattern(ParseNodeFnc *pnodeFunc, Fn fn)
 {
-    for (ParseNode *pnode = pnodeFunc->AsParseNodeFnc()->pnodeParams; pnode != nullptr; pnode = pnode->GetFormalNext())
+    for (ParseNode *pnode = pnodeFunc->pnodeParams; pnode != nullptr; pnode = pnode->GetFormalNext())
     {
         if (pnode->nop == knopParamPattern)
         {

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -210,7 +210,7 @@ void Ident::TrySetIsUsedInLdElem(ParseNode * pnode)
 {
     if (pnode && pnode->nop == knopStr)
     {
-        pnode->AsParseNodePid()->pid->SetIsUsedInLdElem(true);
+        pnode->AsParseNodeStr()->pid->SetIsUsedInLdElem(true);
     }
 }
 

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -129,9 +129,7 @@ public:
     void SetIsInParsingArgList(bool set) { m_isInParsingArgList = set; }
 
     bool GetHasDestructuringPattern() const { return m_hasDestructuringPattern; }
-    void SetHasDestructuringPattern(bool set) { m_hasDestructuringPattern = set; }
-
-    static IdentPtr PidFromNode(ParseNodePtr pnode);
+    void SetHasDestructuringPattern(bool set) { m_hasDestructuringPattern = set; }    
 
     ParseNode* CopyPnode(ParseNode* pnode);
 
@@ -268,9 +266,9 @@ private:
     ParseNodeVar * CreateDeclNode(OpCode nop, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl = true);
 
     ParseNodeInt * CreateIntNode(int32 lw);
-    ParseNodePid * CreateStrNode(IdentPtr pid);
-    ParseNodePid * CreateNameNode(IdentPtr pid);
-    ParseNodePid * CreateNameNode(IdentPtr pid, PidRefStack * ref, charcount_t ichMin, charcount_t ichLim);
+    ParseNodeStr * CreateStrNode(IdentPtr pid);
+    ParseNodeName * CreateNameNode(IdentPtr pid);
+    ParseNodeName * CreateNameNode(IdentPtr pid, PidRefStack * ref, charcount_t ichMin, charcount_t ichLim);
     ParseNodeSpecialName * CreateSpecialNameNode(IdentPtr pid, PidRefStack * ref, charcount_t ichMin, charcount_t ichLim);
     ParseNodeSuperReference * CreateSuperReferenceNode(OpCode nop, ParseNodeSpecialName * pnode1, ParseNodePtr pnode2);
     ParseNodeProg * CreateProgNode(bool isModuleSource, ULONG lineNumber);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -154,27 +154,27 @@ public:
     // the UTF-16 characters pre-canonicalization. Converting this UTF-16 with invalid sequences to valid UTF-8 and back would cause
     // all invalid UTF-16 sequences to be replaced by one or more Unicode replacement characters (0xFFFD), losing the original
     // invalid sequences.
-    HRESULT ParseCesu8Source(__out ParseNodePtr* parseTree, LPCUTF8 pSrc, size_t length, ULONG grfsrc, CompileScriptException *pse,
+    HRESULT ParseCesu8Source(__out ParseNodeProg ** parseTree, LPCUTF8 pSrc, size_t length, ULONG grfsrc, CompileScriptException *pse,
         Js::LocalFunctionId * nextFunctionId, SourceContextInfo * sourceContextInfo);
 
     // Should be called when the source is UTF-8 and invalid UTF-8 sequences should be replaced with the unicode replacement character
     // (0xFFFD). Security concerns require externally produced UTF-8 only allow valid UTF-8 otherwise an attacker could use invalid
     // UTF-8 sequences to fool a filter and cause Javascript to be executed that might otherwise have been rejected.
-    HRESULT ParseUtf8Source(__out ParseNodePtr* parseTree, LPCUTF8 pSrc, size_t length, ULONG grfsrc, CompileScriptException *pse,
+    HRESULT ParseUtf8Source(__out ParseNodeProg ** parseTree, LPCUTF8 pSrc, size_t length, ULONG grfsrc, CompileScriptException *pse,
         Js::LocalFunctionId * nextFunctionId, SourceContextInfo * sourceContextInfo);
 
     // Used by deferred parsing to parse a deferred function.
-    HRESULT ParseSourceWithOffset(__out ParseNodePtr* parseTree, LPCUTF8 pSrc, size_t offset, size_t cbLength, charcount_t cchOffset,
+    HRESULT ParseSourceWithOffset(__out ParseNodeProg ** parseTree, LPCUTF8 pSrc, size_t offset, size_t cbLength, charcount_t cchOffset,
         bool isCesu8, ULONG grfscr, CompileScriptException *pse, Js::LocalFunctionId * nextFunctionId, ULONG lineNumber,
         SourceContextInfo * sourceContextInfo, Js::ParseableFunctionInfo* functionInfo);
 
 protected:
     HRESULT ParseSourceInternal(
-        __out ParseNodePtr* parseTree, LPCUTF8 pszSrc, size_t offsetInBytes,
+        __out ParseNodeProg ** parseTree, LPCUTF8 pszSrc, size_t offsetInBytes,
         size_t lengthInCodePoints, charcount_t offsetInChars, bool isUtf8,
         ULONG grfscr, CompileScriptException *pse, Js::LocalFunctionId * nextFunctionId, ULONG lineNumber, SourceContextInfo * sourceContextInfo);
 
-    ParseNodePtr Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcount_t charOffset, bool isUtf8, ULONG grfscr, ULONG lineNumber,
+    ParseNodeProg * Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcount_t charOffset, bool isUtf8, ULONG grfscr, ULONG lineNumber,
         Js::LocalFunctionId * nextFunctionId, CompileScriptException *pse);
 
 private:

--- a/lib/Parser/ParseTreeComparer.h
+++ b/lib/Parser/ParseTreeComparer.h
@@ -172,8 +172,10 @@ namespace Js
             switch (left->nop)
             {
             case knopName:
+                return ComputeDistance(left->AsParseNodeName()->pid, right->AsParseNodeName()->pid);
+
             case knopStr:
-                return ComputeDistance(left->AsParseNodePid()->pid, right->AsParseNodePid()->pid);
+                return ComputeDistance(left->AsParseNodeStr()->pid, right->AsParseNodeStr()->pid);
 
             case knopInt:
                 return left->AsParseNodeInt()->lw == right->AsParseNodeInt()->lw ? ExactMatchDistance : 1.0;
@@ -181,7 +183,7 @@ namespace Js
             case knopFlt:
                 return left->AsParseNodeFloat()->dbl == right->AsParseNodeFloat()->dbl ? ExactMatchDistance : 1.0;
 
-            case knopRegExp: //TODO: AsParseNodePid()->regexPattern
+            case knopRegExp: //TODO: AsParseNodeRegExp()->regexPattern
                 break;
             }
 
@@ -406,8 +408,10 @@ namespace Js
             switch (left->nop)
             {
             case knopName:
+                return AreEquivalent(left->AsParseNodeName()->pid, right->AsParseNodeName()->pid);
+
             case knopStr:
-                return AreEquivalent(left->AsParseNodePid()->pid, right->AsParseNodePid()->pid);
+                return AreEquivalent(left->AsParseNodeStr()->pid, right->AsParseNodeStr()->pid);
 
             case knopInt:
                 return left->AsParseNodeInt()->lw == right->AsParseNodeInt()->lw;

--- a/lib/Parser/pnodewalk.h
+++ b/lib/Parser/pnodewalk.h
@@ -367,7 +367,7 @@ private:
 
     ResultType WalkCatch(ParseNodeCatch *pnode, Context context)
     {
-        ResultType result = WalkFirstChild(pnode->pnodeParam, context);
+        ResultType result = WalkFirstChild(pnode->GetParam(), context);
         if (ContinueWalk(result))
         {
             result = WalkNode(pnode, context);

--- a/lib/Parser/ptlist.h
+++ b/lib/Parser/ptlist.h
@@ -21,11 +21,11 @@ PTNODE(knopNone       , "<none>"           , Nop      , None        , fnopNone  
 /***************************************************************************
     Leaf nodes.
 ***************************************************************************/
-PTNODE(knopName       , "name"             , Nop      , Pid         , fnopLeaf|fnopAllowDefer, "NameExpr"                       )
+PTNODE(knopName       , "name"             , Nop      , Name        , fnopLeaf|fnopAllowDefer, "NameExpr"                       )
 PTNODE(knopInt        , "int const"        , Nop      , Int         , fnopLeaf|fnopConst    , "NumberLit"                      )
 PTNODE(knopImport     , "import"           , Nop      , None        , fnopLeaf              , "ImportExpr"                     )
 PTNODE(knopFlt        , "flt const"        , Nop      , Float       , fnopLeaf|fnopConst    , "NumberLit"                      )
-PTNODE(knopStr        , "str const"        , Nop      , Pid         , fnopLeaf|fnopConst    , "StringLit"                      )
+PTNODE(knopStr        , "str const"        , Nop      , Str         , fnopLeaf|fnopConst    , "StringLit"                      )
 PTNODE(knopRegExp     , "reg expr"         , Nop      , RegExp      , fnopLeaf|fnopConst    , "RegExprLit"                     )
 PTNODE(knopNull       , "null"             , Nop      , None        , fnopLeaf              , "NullLit"                        )
 PTNODE(knopFalse      , "false"            , Nop      , None        , fnopLeaf              , "FalseLit"                       )

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -727,7 +727,7 @@ class ParseNodeStmt : public ParseNode
 public:
     ParseNodeStmt(OpCode nop, charcount_t ichMin, charcount_t ichLim);
 
-    ParseNodePtr pnodeOuter;
+    ParseNodeStmt * pnodeOuter;
 
     // Set by parsing code, used by code gen.
     uint grfnop;

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -74,7 +74,8 @@ class ParseNodeTri;
 class ParseNodeInt;
 class ParseNodeFloat;
 class ParseNodeRegExp;
-class ParseNodePid;
+class ParseNodeStr;
+class ParseNodeName;
 class ParseNodeVar;
 class ParseNodeCall;
 class ParseNodeSuperCall;
@@ -120,7 +121,8 @@ public:
     ParseNodeFloat * AsParseNodeFloat();
     ParseNodeRegExp * AsParseNodeRegExp();
     ParseNodeVar * AsParseNodeVar();
-    ParseNodePid * AsParseNodePid();
+    ParseNodeStr * AsParseNodeStr();
+    ParseNodeName * AsParseNodeName();
 
     ParseNodeSpecialName * AsParseNodeSpecialName();
     ParseNodeExportDefault * AsParseNodeExportDefault();
@@ -323,24 +325,39 @@ public:
 };
 
 // identifier or string
-class Symbol;
-struct PidRefStack;
-class ParseNodePid : public ParseNode
+
+class ParseNodeStr : public ParseNode
 {
 public:
-    ParseNodePid(OpCode nop, charcount_t ichMin, charcount_t ichLim, IdentPtr pid);
+    ParseNodeStr(charcount_t ichMin, charcount_t ichLim, IdentPtr pid);
 
-    IdentPtr pid;
+    IdentPtr const pid;
+
+    DISABLE_SELF_CAST(ParseNodeStr);
+
+};
+
+class Symbol;
+struct PidRefStack;
+class ParseNodeName : public ParseNode
+{
+public:
+    ParseNodeName(charcount_t ichMin, charcount_t ichLim, IdentPtr pid);
+
+    IdentPtr const pid;
+private:
     Symbol **symRef;
+public:
     Symbol *sym;
 
     void SetSymRef(PidRefStack *ref);
+    void ClearSymRef() { symRef = nullptr; }
     Symbol **GetSymRef() const { return symRef; }
     Js::PropertyId PropertyIdFromNameNode() const;
 
     bool IsSpecialName() { return isSpecialName; }
 
-    DISABLE_SELF_CAST(ParseNodePid);
+    DISABLE_SELF_CAST(ParseNodeName);
 
 protected:
     void SetIsSpecialName() { isSpecialName = true; }
@@ -356,7 +373,7 @@ public:
     ParseNodeVar(OpCode nop, charcount_t ichMin, charcount_t ichLim, IdentPtr name);
 
     ParseNodePtr pnodeNext;
-    IdentPtr pid;
+    IdentPtr const pid;
     Symbol *sym;
     Symbol **symRef;
     ParseNodePtr pnodeInit;
@@ -962,8 +979,15 @@ class ParseNodeCatch : public ParseNodeStmt
 public:
     ParseNodeCatch(OpCode nop, charcount_t ichMin, charcount_t ichLim);
 
+    ParseNodePtr GetParam() { return pnodeParam; }
+    void SetParam(ParseNodeName * pnode) { pnodeParam = pnode;  }
+    void SetParam(ParseNodeParamPattern * pnode) { pnodeParam = pnode; }    
+
     ParseNodePtr pnodeNext;
-    ParseNodePtr pnodeParam;
+
+private:
+    ParseNode *  pnodeParam;   // Name or ParamPattern
+public:
     ParseNodePtr pnodeBody;
     ParseNodePtr pnodeScopes;
     Scope        *scope;
@@ -983,7 +1007,7 @@ public:
 };
 
 // special name like 'this'
-class ParseNodeSpecialName : public ParseNodePid
+class ParseNodeSpecialName : public ParseNodeName
 {
 public:
     ParseNodeSpecialName(charcount_t ichMin, charcount_t ichLim, IdentPtr pid);

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2380,7 +2380,7 @@ namespace Js
                     {
                         CompileScriptException se;
                         Parser ps(m_scriptContext, funcBody->GetIsStrictMode() ? TRUE : FALSE);
-                        ParseNodePtr parseTree = nullptr;
+                        ParseNodeProg * parseTree = nullptr;
 
                         uint nextFunctionId = funcBody->GetLocalFunctionId();
                         hrParser = ps.ParseSourceWithOffset(&parseTree, pszStart, offset, length, charOffset, isCesu8, grfscr, &se,
@@ -2487,7 +2487,7 @@ namespace Js
     }
 
 #ifdef ASMJS_PLAT
-    FunctionBody* ParseableFunctionInfo::ParseAsmJs(Parser * ps, __out CompileScriptException * se, __out ParseNodePtr * parseTree)
+    FunctionBody* ParseableFunctionInfo::ParseAsmJs(Parser * ps, __out CompileScriptException * se, __out ParseNodeProg ** parseTree)
     {
         Assert(IsDeferredParseFunction());
         Assert(m_isAsmjsMode);

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1704,7 +1704,7 @@ namespace Js
         DEFINE_VTABLE_CTOR_NO_REGISTER(ParseableFunctionInfo, FunctionProxy);
         FunctionBody* Parse(ScriptFunction ** functionRef = nullptr, bool isByteCodeDeserialization = false);
 #ifdef ASMJS_PLAT
-        FunctionBody* ParseAsmJs(Parser * p, __out CompileScriptException * se, __out ParseNodePtr * ptree);
+        FunctionBody* ParseAsmJs(Parser * p, __out CompileScriptException * se, __out ParseNodeProg ** ptree);
 #endif
 
         FunctionBodyFlags GetFlags() const { return flags; }

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1909,7 +1909,7 @@ namespace Js
         Js::JavascriptError::MapAndThrowError(this, E_FAIL);
     }
 
-    ParseNode* ScriptContext::ParseScript(Parser* parser,
+    ParseNodeProg * ScriptContext::ParseScript(Parser* parser,
         const byte* script,
         size_t cb,
         SRCINFO const * pSrcInfo,
@@ -2033,7 +2033,7 @@ namespace Js
             grfscr |= fscrIsLibraryCode;
         }
 
-        ParseNodePtr parseTree;
+        ParseNodeProg * parseTree;
         if((loadScriptFlag & LoadScriptFlag_Utf8Source) == LoadScriptFlag_Utf8Source)
         {
             hr = parser->ParseUtf8Source(&parseTree, script, cb, grfscr, pse,
@@ -2082,7 +2082,7 @@ namespace Js
             uint sourceIndex;
             JavascriptFunction * pFunction = nullptr;
 
-            ParseNodePtr parseTree = ParseScript(&parser, script, cb, pSrcInfo,
+            ParseNodeProg * parseTree = ParseScript(&parser, script, cb, pSrcInfo,
                 pse, ppSourceInfo, rootDisplayName, loadScriptFlag,
                 &sourceIndex, scriptSource);
 
@@ -2124,7 +2124,7 @@ namespace Js
         return nullptr;
     }
 
-    JavascriptFunction* ScriptContext::GenerateRootFunction(ParseNodePtr parseTree, uint sourceIndex, Parser* parser, uint32 grfscr, CompileScriptException * pse, const char16 *rootDisplayName)
+    JavascriptFunction* ScriptContext::GenerateRootFunction(ParseNodeProg * parseTree, uint sourceIndex, Parser* parser, uint32 grfscr, CompileScriptException * pse, const char16 *rootDisplayName)
     {
         HRESULT hr;
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -555,7 +555,7 @@ namespace Js
 
     private:
 
-        JavascriptFunction* GenerateRootFunction(ParseNodePtr parseTree, uint sourceIndex, Parser* parser, uint32 grfscr, CompileScriptException * pse, const char16 *rootDisplayName);
+        JavascriptFunction* GenerateRootFunction(ParseNodeProg * parseTree, uint sourceIndex, Parser* parser, uint32 grfscr, CompileScriptException * pse, const char16 *rootDisplayName);
 
         typedef void (*EventHandler)(ScriptContext *);
         ScriptContext ** registeredPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext;
@@ -1258,7 +1258,7 @@ private:
         bool IsWellKnownHostType(Js::TypeId typeId) { return threadContext->IsWellKnownHostType<wellKnownType>(typeId); }
         void SetWellKnownHostTypeId(WellKnownHostType wellKnownType, Js::TypeId typeId) { threadContext->SetWellKnownHostTypeId(wellKnownType, typeId); }
 
-        ParseNodePtr ParseScript(Parser* parser, const byte* script,
+        ParseNodeProg * ParseScript(Parser* parser, const byte* script,
             size_t cb, SRCINFO const * pSrcInfo,
             CompileScriptException * pse, Utf8SourceInfo** ppSourceInfo,
             const char16 *rootDisplayName, LoadScriptFlag loadScriptFlag,

--- a/lib/Runtime/ByteCode/ByteCodeApi.h
+++ b/lib/Runtime/ByteCode/ByteCodeApi.h
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-HRESULT GenerateByteCode(__in ParseNode *pnode, __in uint32 grfscr, __in Js::ScriptContext* scriptContext, __inout Js::ParseableFunctionInfo ** ppRootFunc,
+HRESULT GenerateByteCode(__in ParseNodeProg *pnode, __in uint32 grfscr, __in Js::ScriptContext* scriptContext, __inout Js::ParseableFunctionInfo ** ppRootFunc,
                          __in uint sourceIndex, __in bool forceNoNative, __in Parser* parser, __in CompileScriptException *pse, Js::ScopeInfo* parentScopeInfo = nullptr,
                          Js::ScriptFunction ** functionRef = nullptr);
 

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -308,7 +308,7 @@ public:
 
     bool ShouldLoadConstThis(FuncInfo* funcInfo);
 
-    void EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pnode, FuncInfo *funcInfo, bool chkUndecl);
+    void EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNodeSpecialName *pnode, FuncInfo *funcInfo, bool chkUndecl);
     void EmitPropStoreForSpecialSymbol(Js::RegSlot rhsLocation, Symbol *sym, IdentPtr pid, FuncInfo *funcInfo, bool init);
 
     void EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot *pThisLocation, Js::RegSlot *pTargetLocation, FuncInfo *funcInfo);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -231,8 +231,8 @@ public:
     void StartBindCatch(ParseNode *pnode);
 
     // Block scopes related functions
-    template<class Fn> void IterateBlockScopedVariables(ParseNode *pnodeBlock, Fn fn);
-    void InitBlockScopedContent(ParseNode *pnodeBlock, Js::DebuggerScope *debuggerScope, FuncInfo *funcInfo);
+    template<class Fn> void IterateBlockScopedVariables(ParseNodeBlock *pnodeBlock, Fn fn);
+    void InitBlockScopedContent(ParseNodeBlock *pnodeBlock, Js::DebuggerScope *debuggerScope, FuncInfo *funcInfo);
 
     Js::DebuggerScope* RecordStartScopeObject(ParseNode *pnodeBlock, Js::DiagExtraScopesType scopeType, Js::RegSlot scopeLocation = Js::Constants::NoRegister, int* index = nullptr);
     void RecordEndScopeObject(ParseNode *pnodeBlock);
@@ -242,8 +242,8 @@ public:
     void EndEmitFunction(ParseNodeFnc *pnodeFnc);
     void StartEmitBlock(ParseNodeBlock *pnodeBlock);
     void EndEmitBlock(ParseNodeBlock *pnodeBlock);
-    void StartEmitCatch(ParseNode *pnodeCatch);
-    void EndEmitCatch(ParseNode *pnodeCatch);
+    void StartEmitCatch(ParseNodeCatch *pnodeCatch);
+    void EndEmitCatch(ParseNodeCatch *pnodeCatch);
     void StartEmitWith(ParseNode *pnodeWith);
     void EndEmitWith(ParseNode *pnodeWith);
     void EnsureFncScopeSlots(ParseNode *pnode, FuncInfo *funcInfo);
@@ -291,12 +291,12 @@ public:
     void EmitLoadFormalIntoRegister(ParseNode *pnodeFormal, Js::RegSlot pos, FuncInfo *funcInfo);
     void HomeArguments(FuncInfo *funcInfo);
 
-    void EnsureNoRedeclarations(ParseNode *pnodeBlock, FuncInfo *funcInfo);
+    void EnsureNoRedeclarations(ParseNodeBlock *pnodeBlock, FuncInfo *funcInfo);
 
     void DefineLabels(FuncInfo *funcInfo);
-    void EmitProgram(ParseNode *pnodeProg);
+    void EmitProgram(ParseNodeProg *pnodeProg);
     void EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodyScopeNode = nullptr);
-    void EmitDefaultArgs(FuncInfo *funcInfo, ParseNode *pnode);
+    void EmitDefaultArgs(FuncInfo *funcInfo, ParseNodeFnc *pnode);
     void EmitOneFunction(ParseNodeFnc *pnodeFnc);
     void EmitGlobalFncDeclInit(Js::RegSlot rhsLocation, Js::PropertyId propertyId, FuncInfo * funcInfo);
     void EmitLocalPropInit(Js::RegSlot rhsLocation, Symbol *sym, FuncInfo *funcInfo);
@@ -354,7 +354,7 @@ public:
 
     bool DoJitLoopBodies(FuncInfo *funcInfo) const;
 
-    static void Generate(__in ParseNode *pnode, uint32 grfscr, __in ByteCodeGenerator* byteCodeGenerator, __inout Js::ParseableFunctionInfo ** ppRootFunc, __in uint sourceIndex, __in bool forceNoNative, __in Parser* parser, Js::ScriptFunction ** functionRef);
+    static void Generate(__in ParseNodeProg *pnode, uint32 grfscr, __in ByteCodeGenerator* byteCodeGenerator, __inout Js::ParseableFunctionInfo ** ppRootFunc, __in uint sourceIndex, __in bool forceNoNative, __in Parser* parser, Js::ScriptFunction ** functionRef);
     void Begin(
         __in ArenaAllocator *alloc,
         __in uint32 grfscr,
@@ -386,7 +386,7 @@ public:
     void TrackFunctionDeclarationPropertyForDebugger(Symbol *functionDeclarationSymbol, FuncInfo *funcInfoParent);
     void UpdateDebuggerPropertyInitializationOffset(Js::RegSlot location, Js::PropertyId propertyId, bool shouldConsumeRegister = true);
 
-    void PopulateFormalsScope(uint beginOffset, FuncInfo *funcInfo, ParseNode *pnode);
+    void PopulateFormalsScope(uint beginOffset, FuncInfo *funcInfo, ParseNodeFnc *pnodeFnc);
     void InsertPropertyToDebuggerScope(FuncInfo* funcInfo, Js::DebuggerScope* debuggerScope, Symbol* sym);
     FuncInfo *FindEnclosingNonLambda();
 
@@ -413,10 +413,10 @@ private:
     Js::OpCode ToChkUndeclOp(Js::OpCode op) const;
 };
 
-template<class Fn> void ByteCodeGenerator::IterateBlockScopedVariables(ParseNode *pnodeBlock, Fn fn)
+template<class Fn> void ByteCodeGenerator::IterateBlockScopedVariables(ParseNodeBlock *pnodeBlock, Fn fn)
 {
     Assert(pnodeBlock->nop == knopBlock);
-    for (auto lexvar = pnodeBlock->AsParseNodeBlock()->pnodeLexVars; lexvar; lexvar = lexvar->AsParseNodeVar()->pnodeNext)
+    for (auto lexvar = pnodeBlock->pnodeLexVars; lexvar; lexvar = lexvar->AsParseNodeVar()->pnodeNext)
     {
         fn(lexvar);
     }

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -562,7 +562,7 @@ namespace Js
         PageAllocator tempPageAlloc(NULL, Js::Configuration::Global.flags);
         Parser ps(GetScriptContext(), FALSE, &tempPageAlloc);
         FunctionBody * funcBody;
-        ParseNodePtr parseTree;
+        ParseNodeProg * parseTree;
 
         CompileScriptException se;
         funcBody = deferParseFunction->ParseAsmJs(&ps, &se, &parseTree);
@@ -571,7 +571,7 @@ namespace Js
         TRACE_BYTECODE(_u("\nDeferred parse %s\n"), funcBody->GetDisplayName());
         if (parseTree && parseTree->nop == knopProg)
         {
-            auto body = parseTree->AsParseNodeProg()->pnodeBody;
+            auto body = parseTree->pnodeBody;
             if (body && body->nop == knopList)
             {
                 auto fncDecl = body->AsParseNodeBin()->pnode1;

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -121,7 +121,7 @@ namespace Js
         Field(bool) parentsNotified;
         Field(bool) isRootModule;
         Field(bool) hadNotifyHostReady;
-        Field(ParseNodePtr) parseTree;
+        Field(ParseNodeProg *) parseTree;
         Field(Utf8SourceInfo*) pSourceInfo;
         Field(uint) sourceIndex;
         FieldNoBarrier(Parser*) parser;  // we'll need to keep the parser around till we are done with bytecode gen.

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -897,7 +897,7 @@ namespace Js
             Parser parser(scriptContext, strictMode);
             bool forceNoNative = false;
 
-            ParseNodePtr parseTree = nullptr;
+            ParseNodeProg * parseTree = nullptr;
 
             SourceContextInfo * sourceContextInfo = pSrcInfo->sourceContextInfo;
             ULONG deferParseThreshold = Parser::GetDeferralThreshold(sourceContextInfo->IsSourceProfileLoaded());
@@ -926,7 +926,7 @@ namespace Js
                 // TODO: Handle strict mode.
                 if (isIndirect &&
                     !strictMode &&
-                    !parseTree->AsParseNodeFnc()->GetStrictMode())
+                    !parseTree->GetStrictMode())
                 {
                     grfscr &= ~fscrEval;
                 }

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5279,7 +5279,7 @@ namespace Js
             Assert(x->nop == knopList);
             Assert(x->AsParseNodeBin()->pnode1->nop == knopStr);
 
-            pid = x->AsParseNodeBin()->pnode1->AsParseNodePid()->pid;
+            pid = x->AsParseNodeBin()->pnode1->AsParseNodeStr()->pid;
 
             // If strings have different length, they aren't equal
             if (pid->Cch() != str->GetLength())
@@ -5303,7 +5303,7 @@ namespace Js
         str = Js::JavascriptString::FromVar(element);
 
         Assert(x->nop == knopStr);
-        pid = x->AsParseNodePid()->pid;
+        pid = x->AsParseNodeStr()->pid;
 
         // If strings have different length, they aren't equal
         if (pid->Cch() != str->GetLength())
@@ -5355,8 +5355,8 @@ namespace Js
             Assert(x->AsParseNodeBin()->pnode1->nop == knopStr);
             Assert(y->AsParseNodeBin()->pnode1->nop == knopStr);
 
-            pid_x = x->AsParseNodeBin()->pnode1->AsParseNodePid()->pid->Psz();
-            pid_y = y->AsParseNodeBin()->pnode1->AsParseNodePid()->pid->Psz();
+            pid_x = x->AsParseNodeBin()->pnode1->AsParseNodeStr()->pid->Psz();
+            pid_y = y->AsParseNodeBin()->pnode1->AsParseNodeStr()->pid->Psz();
 
             // If the pid values of each raw string don't match each other, these are different.
             if (!DefaultComparer<const char16*>::Equals(pid_x, pid_y))
@@ -5376,8 +5376,8 @@ namespace Js
 
         Assert(x->nop == knopStr);
 
-        pid_x = x->AsParseNodePid()->pid->Psz();
-        pid_y = y->AsParseNodePid()->pid->Psz();
+        pid_x = x->AsParseNodeStr()->pid->Psz();
+        pid_y = y->AsParseNodeStr()->pid->Psz();
 
         // This is the final string in the raw literals list. Return true if they are equal.
         return DefaultComparer<const char16*>::Equals(pid_x, pid_y);
@@ -5398,7 +5398,7 @@ namespace Js
         {
             Assert(i->AsParseNodeBin()->pnode1->nop == knopStr);
 
-            pid = i->AsParseNodeBin()->pnode1->AsParseNodePid()->pid->Psz();
+            pid = i->AsParseNodeBin()->pnode1->AsParseNodeStr()->pid->Psz();
 
             hash ^= DefaultComparer<const char16*>::GetHashCode(pid);
             hash ^= DefaultComparer<const char16*>::GetHashCode(_u("${}"));
@@ -5408,7 +5408,7 @@ namespace Js
 
         Assert(i->nop == knopStr);
 
-        pid = i->AsParseNodePid()->pid->Psz();
+        pid = i->AsParseNodeStr()->pid->Psz();
 
         hash ^= DefaultComparer<const char16*>::GetHashCode(pid);
 


### PR DESCRIPTION
And even more use stronger type instead of casting from ParseNode
