### PR TITLE
Block level Bytecode upward expose verification

### DIFF
--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -389,6 +389,7 @@ public:
     TempObjectTracker *                     tempObjectTracker;
 #if DBG
     BVSparse<JitArenaAllocator> *           trackingByteCodeUpwardExposedUsed = nullptr;
+    BVSparse<JitArenaAllocator> *           excludeByteCodeUpwardExposedTracking = nullptr;
     TempObjectVerifyTracker *               tempObjectVerifyTracker;
 #endif
     HashTable<AddPropertyCacheBucket> *     stackSymToFinalType;

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -388,6 +388,7 @@ public:
     TempNumberTracker *                     tempNumberTracker;
     TempObjectTracker *                     tempObjectTracker;
 #if DBG
+    BVSparse<JitArenaAllocator> *           trackingByteCodeUpwardExposedUsed = nullptr;
     TempObjectVerifyTracker *               tempObjectVerifyTracker;
 #endif
     HashTable<AddPropertyCacheBucket> *     stackSymToFinalType;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -199,8 +199,8 @@ GlobOpt::Optimize()
         this->maxInitialSymID = this->func->m_symTable->GetMaxSymID();
         this->BackwardPass(Js::BackwardPhase);
         this->ForwardPass();
+        this->BackwardPass(Js::DeadStorePhase);
     }
-    this->BackwardPass(Js::DeadStorePhase);
     this->TailDupPass();
 }
 


### PR DESCRIPTION
Verify that bytecodeUpwardExposedUses hasn't changed between Backward and DeadStore pass at the block level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4976)
<!-- Reviewable:end -->
