### PR TITLE
Dataview set/get negative index throw RangeError Fixes: #4978 

### DIFF
--- a/lib/Runtime/Library/DataView.cpp
+++ b/lib/Runtime/Library/DataView.cpp
@@ -159,7 +159,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->template GetValue<int8>(offset, _u("DataView.prototype.GetInt8"), FALSE);
     }
 
@@ -182,7 +182,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValue<uint8>(offset, _u("DataView.prototype.GetUint8"), FALSE);
     }
 
@@ -210,7 +210,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValue<int16>(offset, _u("DataView.prototype.GetInt16"), isLittleEndian);
     }
 
@@ -238,7 +238,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->template GetValue<uint16>(offset, _u("DataView.prototype.GetUint16"), isLittleEndian);
     }
 
@@ -266,7 +266,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValue<uint32>(offset, _u("DataView.prototype.GetUint32"), isLittleEndian);
     }
 
@@ -294,7 +294,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValue<int32>(offset, _u("DataView.prototype.GetInt32"), isLittleEndian);
     }
 
@@ -322,7 +322,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValueWithCheck<float>(offset, _u("DataView.prototype.GetFloat32"), isLittleEndian);
     }
 
@@ -350,7 +350,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         return dataView->GetValueWithCheck<double>(offset, _u("DataView.prototype.GetFloat64"), isLittleEndian);
     }
 
@@ -372,7 +372,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int8 value = JavascriptConversion::ToInt8(args[2], scriptContext);
         dataView->SetValue<int8>(offset, value, _u("DataView.prototype.SetInt8"));
         return scriptContext->GetLibrary()->GetUndefined();
@@ -396,7 +396,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint8 value = JavascriptConversion::ToUInt8(args[2], scriptContext);
         dataView->SetValue<uint8>(offset, value, _u("DataView.prototype.SetUint8"));
         return scriptContext->GetLibrary()->GetUndefined();
@@ -421,7 +421,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int16 value = JavascriptConversion::ToInt16(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
@@ -450,7 +450,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument, _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint16 value = JavascriptConversion::ToUInt16(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
@@ -479,7 +479,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int32 value = JavascriptConversion::ToInt32(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
@@ -508,7 +508,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint32 value = JavascriptConversion::ToUInt32(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
@@ -537,7 +537,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument);
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         float value = JavascriptConversion::ToFloat(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
@@ -566,7 +566,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = JavascriptConversion::ToUInt32(args[1], scriptContext);
+        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         double value = JavascriptConversion::ToNumber(args[2], scriptContext);
         if (args.Info.Count > 3)
         {

--- a/lib/Runtime/Library/DataView.cpp
+++ b/lib/Runtime/Library/DataView.cpp
@@ -159,8 +159,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->template GetValue<int8>(offset, _u("DataView.prototype.GetInt8"), FALSE);
+        return dataView->template GetValue<int8>(args[1], _u("DataView.prototype.GetInt8"), FALSE);
     }
 
     Var DataView::EntryGetUint8(RecyclableObject* function, CallInfo callInfo, ...)
@@ -182,8 +181,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValue<uint8>(offset, _u("DataView.prototype.GetUint8"), FALSE);
+        return dataView->GetValue<uint8>(args[1], _u("DataView.prototype.GetUint8"), FALSE);
     }
 
     Var DataView::EntryGetInt16(RecyclableObject* function, CallInfo callInfo, ...)
@@ -210,8 +208,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValue<int16>(offset, _u("DataView.prototype.GetInt16"), isLittleEndian);
+        return dataView->GetValue<int16>(args[1], _u("DataView.prototype.GetInt16"), isLittleEndian);
     }
 
     Var DataView::EntryGetUint16(RecyclableObject* function, CallInfo callInfo, ...)
@@ -238,8 +235,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->template GetValue<uint16>(offset, _u("DataView.prototype.GetUint16"), isLittleEndian);
+        return dataView->template GetValue<uint16>(args[1], _u("DataView.prototype.GetUint16"), isLittleEndian);
     }
 
     Var DataView::EntryGetUint32(RecyclableObject* function, CallInfo callInfo, ...)
@@ -266,8 +262,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValue<uint32>(offset, _u("DataView.prototype.GetUint32"), isLittleEndian);
+        return dataView->GetValue<uint32>(args[1], _u("DataView.prototype.GetUint32"), isLittleEndian);
     }
 
     Var DataView::EntryGetInt32(RecyclableObject* function, CallInfo callInfo, ...)
@@ -294,8 +289,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValue<int32>(offset, _u("DataView.prototype.GetInt32"), isLittleEndian);
+        return dataView->GetValue<int32>(args[1], _u("DataView.prototype.GetInt32"), isLittleEndian);
     }
 
     Var DataView::EntryGetFloat32(RecyclableObject* function, CallInfo callInfo, ...)
@@ -322,8 +316,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValueWithCheck<float>(offset, _u("DataView.prototype.GetFloat32"), isLittleEndian);
+        return dataView->GetValueWithCheck<float>(args[1], _u("DataView.prototype.GetFloat32"), isLittleEndian);
     }
 
     Var DataView::EntryGetFloat64(RecyclableObject* function, CallInfo callInfo, ...)
@@ -350,8 +343,7 @@ namespace Js
         }
 
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
-        return dataView->GetValueWithCheck<double>(offset, _u("DataView.prototype.GetFloat64"), isLittleEndian);
+       return dataView->GetValueWithCheck<double>(args[1], _u("DataView.prototype.GetFloat64"), isLittleEndian);
     }
 
     Var DataView::EntrySetInt8(RecyclableObject* function, CallInfo callInfo, ...)
@@ -372,9 +364,8 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int8 value = JavascriptConversion::ToInt8(args[2], scriptContext);
-        dataView->SetValue<int8>(offset, value, _u("DataView.prototype.SetInt8"));
+        dataView->SetValue<int8>(args[1], value, _u("DataView.prototype.SetInt8"));
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -396,9 +387,8 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint8 value = JavascriptConversion::ToUInt8(args[2], scriptContext);
-        dataView->SetValue<uint8>(offset, value, _u("DataView.prototype.SetUint8"));
+        dataView->SetValue<uint8>(args[1], value, _u("DataView.prototype.SetUint8"));
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -421,13 +411,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int16 value = JavascriptConversion::ToInt16(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<int16>(offset, value, _u("DataView.prototype.SetInt16"), isLittleEndian);
+        dataView->SetValue<int16>(args[1], value, _u("DataView.prototype.SetInt16"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -450,13 +439,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument, _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint16 value = JavascriptConversion::ToUInt16(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<uint16>(offset, value, _u("DataView.prototype.SetUint16"), isLittleEndian);
+        dataView->SetValue<uint16>(args[1], value, _u("DataView.prototype.SetUint16"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -479,13 +467,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         int32 value = JavascriptConversion::ToInt32(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<int32>(offset, value, _u("DataView.prototype.SetInt32"), isLittleEndian);
+        dataView->SetValue<int32>(args[1], value, _u("DataView.prototype.SetInt32"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -508,13 +495,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         uint32 value = JavascriptConversion::ToUInt32(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<uint32>(offset, value, _u("DataView.prototype.SetUint32"), isLittleEndian);
+        dataView->SetValue<uint32>(args[1], value, _u("DataView.prototype.SetUint32"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -537,13 +523,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument);
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         float value = JavascriptConversion::ToFloat(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<float>(offset, value, _u("DataView.prototype.SetFloat32"), isLittleEndian);
+        dataView->SetValue<float>(args[1], value, _u("DataView.prototype.SetFloat32"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -566,13 +551,12 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_NeedArgument,  _u("offset or value"));
         }
         DataView* dataView = DataView::FromVar(args[0]);
-        uint32 offset = DataView::ToIndex(args[1], scriptContext);
         double value = JavascriptConversion::ToNumber(args[2], scriptContext);
         if (args.Info.Count > 3)
         {
             isLittleEndian = JavascriptConversion::ToBoolean(args[3], scriptContext);
         }
-        dataView->SetValue<double>(offset, value, _u("DataView.prototype.SetFloat64"), isLittleEndian);
+        dataView->SetValue<double>(args[1], value, _u("DataView.prototype.SetFloat64"), isLittleEndian);
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
@@ -676,27 +660,27 @@ namespace Js
 #ifdef _M_ARM
     // Provide template specialization (only) for memory access at unaligned float/double address which causes data alignment exception otherwise.
     template<>
-    Var DataView::GetValueWithCheck<float>(uint32 byteOffset, const char16 *funcName, BOOL isLittleEndian)
+    Var DataView::GetValueWithCheck<float>(Var offset, const char16 *funcName, BOOL isLittleEndian)
     {
-        return this->GetValueWithCheck<float, float UNALIGNED*>(byteOffset, isLittleEndian, funcName);
+        return this->GetValueWithCheck<float, float UNALIGNED*>(offset, isLittleEndian, funcName);
     }
 
     template<>
-    Var DataView::GetValueWithCheck<double>(uint32 byteOffset, const char16 *funcName, BOOL isLittleEndian)
+    Var DataView::GetValueWithCheck<double>(Var offset, const char16 *funcName, BOOL isLittleEndian)
     {
-        return this->GetValueWithCheck<double, double UNALIGNED*>(byteOffset, isLittleEndian, funcName);
+        return this->GetValueWithCheck<double, double UNALIGNED*>(offset, isLittleEndian, funcName);
     }
 
     template<>
-    void DataView::SetValue<float>(uint32 byteOffset, float value, const char16 *funcName, BOOL isLittleEndian)
+    void DataView::SetValue<float>(Var offset, float value, const char16 *funcName, BOOL isLittleEndian)
     {
-        this->SetValue<float, float UNALIGNED*>(byteOffset, value, isLittleEndian, funcName);
+        this->SetValue<float, float UNALIGNED*>(offset, value, isLittleEndian, funcName);
     }
 
     template<>
-    void DataView::SetValue<double>(uint32 byteOffset, double value, const char16 *funcName, BOOL isLittleEndian)
+    void DataView::SetValue<double>(Var offset, double value, const char16 *funcName, BOOL isLittleEndian)
     {
-        this->SetValue<double, double UNALIGNED*>(byteOffset, value, isLittleEndian, funcName);
+        this->SetValue<double, double UNALIGNED*>(offset, value, isLittleEndian, funcName);
     }
 #endif
 

--- a/lib/Runtime/Library/DataView.h
+++ b/lib/Runtime/Library/DataView.h
@@ -55,6 +55,34 @@ namespace Js
             return static_cast<DataView*>(aValue);
         }
 
+        static uint32 ToIndex (Var value, ScriptContext *scriptContext)
+        {
+            if (JavascriptOperators::IsUndefined(value))
+            {
+                return 0;
+            }
+
+            if (TaggedInt::Is(value))
+            {
+                int64 index = TaggedInt::ToInt64(value);
+                if (index < 0)
+                {
+                    JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset);
+                }
+
+                return  (uint32)index;
+            }
+
+            // Slower path
+            double d = JavascriptConversion::ToInteger(value, scriptContext);
+            if (d < 0.0)
+            {
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset);
+            }
+
+            return (uint32)d;
+        }
+
         uint32 GetByteOffset() const { return byteOffset; }
         void ClearLengthAndBufferOnDetach();
 

--- a/lib/Runtime/Library/DataView.h
+++ b/lib/Runtime/Library/DataView.h
@@ -55,34 +55,6 @@ namespace Js
             return static_cast<DataView*>(aValue);
         }
 
-        static uint32 ToIndex (Var value, ScriptContext *scriptContext)
-        {
-            if (JavascriptOperators::IsUndefined(value))
-            {
-                return 0;
-            }
-
-            if (TaggedInt::Is(value))
-            {
-                int64 index = TaggedInt::ToInt64(value);
-                if (index < 0)
-                {
-                    JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset);
-                }
-
-                return  (uint32)index;
-            }
-
-            // Slower path
-            double d = JavascriptConversion::ToInteger(value, scriptContext);
-            if (d < 0.0)
-            {
-                JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset);
-            }
-
-            return (uint32)d;
-        }
-
         uint32 GetByteOffset() const { return byteOffset; }
         void ClearLengthAndBufferOnDetach();
 
@@ -132,106 +104,109 @@ namespace Js
         template<> void SwapRoutine(double* input, double* dest) {*((uint64*)dest) = RtlUlonglongByteSwap(*((uint64*)input)); }
 
         template<typename TypeName>
-        Var GetValue(uint32 byteOffset, const char16* funcName, BOOL isLittleEndian = FALSE)
+        Var GetValue(Var offset, const char16* funcName, BOOL isLittleEndian = FALSE)
         {
             ScriptContext* scriptContext = GetScriptContext();
             if (this->GetArrayBuffer()->IsDetached())
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, funcName);
             }
-            if ((byteOffset + sizeof(TypeName) <= GetLength()) && (byteOffset <= GetLength()))
+
+            uint32 length = GetLength();
+            if (length < sizeof(TypeName))
             {
-                TypeName item;
-                TypeName* typedBuffer = (TypeName*)(buffer + byteOffset);
-                if (!isLittleEndian)
-                {
-                    SwapRoutine<TypeName>(typedBuffer, &item);
-                }
-                else
-                {
-                    item = *typedBuffer;
-                }
-                return JavascriptNumber::ToVar(item, GetScriptContext());
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset, funcName);
+            }
+            uint32 byteOffset = ArrayBuffer::ToIndex(offset, JSERR_DataView_InvalidOffset, scriptContext, length - sizeof(TypeName), false);
+
+            TypeName item;
+            TypeName* typedBuffer = (TypeName*)(buffer + byteOffset);
+            if (!isLittleEndian)
+            {
+                SwapRoutine<TypeName>(typedBuffer, &item);
             }
             else
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_InvalidOffset);
+                item = *typedBuffer;
             }
+            return JavascriptNumber::ToVar(item, GetScriptContext());
         }
 
         template<typename TypeName>
-        inline Var GetValueWithCheck(uint32 byteOffset, const char16* funcName, BOOL isLittleEndian = FALSE)
+        inline Var GetValueWithCheck(Var offset, const char16* funcName, BOOL isLittleEndian = FALSE)
         {
-            return GetValueWithCheck<TypeName, TypeName*>(byteOffset, isLittleEndian, funcName);
+            return GetValueWithCheck<TypeName, TypeName*>(offset, isLittleEndian, funcName);
         }
 
         template<typename TypeName, typename PointerAccessTypeName>
-        Var GetValueWithCheck(uint32 byteOffset, BOOL isLittleEndian, const char16* funcName)
+        Var GetValueWithCheck(Var offset, BOOL isLittleEndian, const char16* funcName)
         {
             ScriptContext* scriptContext = GetScriptContext();
             if (this->GetArrayBuffer()->IsDetached())
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, funcName);
             }
-            if ((byteOffset + sizeof(TypeName) <= GetLength()) && (byteOffset <= GetLength()))
+
+            uint32 length = GetLength();
+            if (length < sizeof(TypeName))
             {
-                TypeName item;
-                TypeName *typedBuffer = (TypeName*)(buffer + byteOffset);
-                if (!isLittleEndian)
-                {
-                    SwapRoutine<TypeName>(typedBuffer, &item);
-                }
-                else
-                {
-                    item = *static_cast<PointerAccessTypeName>(typedBuffer);
-                }
-                return JavascriptNumber::ToVarWithCheck(item, GetScriptContext());
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset, funcName);
+            }
+            uint32 byteOffset = ArrayBuffer::ToIndex(offset, JSERR_DataView_InvalidOffset, scriptContext, length - sizeof(TypeName), false);
+
+            TypeName item;
+            TypeName *typedBuffer = (TypeName*)(buffer + byteOffset);
+            if (!isLittleEndian)
+            {
+                SwapRoutine<TypeName>(typedBuffer, &item);
             }
             else
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_InvalidOffset);
+                item = *static_cast<PointerAccessTypeName>(typedBuffer);
             }
+            return JavascriptNumber::ToVarWithCheck(item, GetScriptContext());
         }
 
         template<typename TypeName>
-        inline void SetValue(uint32 byteOffset, TypeName value, const char16 *funcName, BOOL isLittleEndian = FALSE)
+        inline void SetValue(Var offset, TypeName value, const char16 *funcName, BOOL isLittleEndian = FALSE)
         {
-            SetValue<TypeName, TypeName*>(byteOffset, value, isLittleEndian, funcName);
+            SetValue<TypeName, TypeName*>(offset, value, isLittleEndian, funcName);
         }
 
         template<typename TypeName, typename PointerAccessTypeName>
-        void SetValue(uint32 byteOffset, TypeName value, BOOL isLittleEndian, const char16 *funcName)
+        void SetValue(Var offset, TypeName value, BOOL isLittleEndian, const char16 *funcName)
         {
             ScriptContext* scriptContext = GetScriptContext();
             if (this->GetArrayBuffer()->IsDetached())
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, funcName);
             }
-            if ((byteOffset + sizeof(TypeName) <= GetLength()) && (byteOffset <= GetLength()))
+
+            uint32 length = GetLength();
+            if (length < sizeof(TypeName))
             {
-                TypeName* typedBuffer = (TypeName*)(buffer + byteOffset);
-                if (!isLittleEndian)
-                {
-                    SwapRoutine<TypeName>(&value, typedBuffer);
-                }
-                else
-                {
-                    *static_cast<PointerAccessTypeName>(typedBuffer) = value;
-                }
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_DataView_InvalidOffset, funcName);
+            }
+            uint32 byteOffset = ArrayBuffer::ToIndex(offset, JSERR_DataView_InvalidOffset, scriptContext, length - sizeof(TypeName), false);
+
+            TypeName* typedBuffer = (TypeName*)(buffer + byteOffset);
+            if (!isLittleEndian)
+            {
+                SwapRoutine<TypeName>(&value, typedBuffer);
             }
             else
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_DataView_InvalidOffset);
+                *static_cast<PointerAccessTypeName>(typedBuffer) = value;
             }
         }
 
 #ifdef _M_ARM
         // For ARM, memory access for float/double address causes data alignment exception if the address is not aligned.
         // Provide template specialization (only) for these scenarios.
-        template<> Var GetValueWithCheck<float>(uint32 byteOffset, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
-        template<> Var GetValueWithCheck<double>(uint32 byteOffset, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
-        template<> void SetValue<float>(uint32 byteOffset, float value, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
-        template<> void SetValue<double>(uint32 byteOffset, double value, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
+        template<> Var GetValueWithCheck<float>(Var offset, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
+        template<> Var GetValueWithCheck<double>(Var offset, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
+        template<> void SetValue<float>(Var offset, float value, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
+        template<> void SetValue<double>(Var offset, double value, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
 #endif
 
         Field(uint32) byteOffset;

--- a/test/typedarray/dataview2.js
+++ b/test/typedarray/dataview2.js
@@ -6,8 +6,11 @@
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 const view = new DataView(new ArrayBuffer(50));
-const setters = ["setFloat32", "setFloat64", "setInt16", "setInt32", "setInt8", "setUint16", "setUint32", "setUint8"];
-const getters = ["getFloat32", "getFloat64", "getInt16", "getInt32", "getInt8", "getUint16", "getUint32", "getUint8"];
+const zeroView = new DataView(new ArrayBuffer(0));
+const smallView = new DataView(new ArrayBuffer(1));
+
+const setters = ["setUint8", "setInt8", "setUint16", "setInt16", "setFloat32", "setInt32", "setUint32", "setFloat64"];
+const getters = ["getUint8", "getInt8", "getUint16", "getInt16", "getFloat32", "getInt32", "getUint32", "getFloat64"];
 
 const tests = [
     {
@@ -29,6 +32,52 @@ const tests = [
             {
                 assert.throws(()=>{ view[getters[i]](-1); }, RangeError);
                 assert.throws(()=>{ view[getters[i]](-1000000000); }, RangeError);
+            }
+        }
+    },
+    {
+        name : "Set value in 0 buffer",
+        body : function ()
+        {
+            for (let i = 0; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ zeroView[setters[i]](0, 2); }, RangeError);
+            }
+        }
+    },
+    {
+        name : "Get value in 0 buffer",
+        body : function ()
+        {
+            for (let i = 0; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ zeroView[getters[i]](0); }, RangeError);
+            }
+        }
+    },
+    {
+        name : "Set value in 1 byte buffer",
+        body : function ()
+        {
+            assert.doesNotThrow(()=>{ smallView[setters[0]](0, 3) }, "Storing int 8 in 1 byte array should not throw");
+            assert.doesNotThrow(()=>{ smallView[setters[1]](0, 3) }, "Storing int 8 in 1 byte array should not throw");
+            for (let i = 2; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ smallView[setters[i]](0, 2); }, RangeError);
+                assert.throws(()=>{ smallView[setters[i]](0, 2); }, RangeError);
+            }
+        }
+    },
+    {
+        name : "Get value in 1 byte buffer",
+        body : function ()
+        {
+            assert.doesNotThrow(()=>{ smallView[getters[0]](0) }, "Storing int 8 in 1 byte array should not throw");
+            assert.doesNotThrow(()=>{ smallView[getters[1]](0) }, "Storing int 8 in 1 byte array should not throw");
+            for (let i = 2; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ smallView[getters[i]](0); }, RangeError);
+                assert.throws(()=>{ smallView[getters[i]](0); }, RangeError);
             }
         }
     }

--- a/test/typedarray/dataview2.js
+++ b/test/typedarray/dataview2.js
@@ -1,0 +1,37 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+const view = new DataView(new ArrayBuffer(50));
+const setters = ["setFloat32", "setFloat64", "setInt16", "setInt32", "setInt8", "setUint16", "setUint32", "setUint8"];
+const getters = ["getFloat32", "getFloat64", "getInt16", "getInt32", "getInt8", "getUint16", "getUint32", "getUint8"];
+
+const tests = [
+    {
+        name : "Set with negative index",
+        body : function ()
+        {
+            for (let i = 0; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ view[setters[i]](-1, 2); }, RangeError);
+                assert.throws(()=>{ view[setters[i]](-1000000000, 2); }, RangeError);
+            }
+        }
+    },
+    {
+        name : "Get with negative index",
+        body : function ()
+        {
+            for (let i = 0; i < setters.length; ++i)
+            {
+                assert.throws(()=>{ view[getters[i]](-1); }, RangeError);
+                assert.throws(()=>{ view[getters[i]](-1000000000); }, RangeError);
+            }
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -107,6 +107,13 @@
   </test>
   <test>
     <default>
+      <files>dataview2.js</files>
+      <tags>typedarray</tags>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>objectproperty.js</files>
       <baseline>objectproperty_es6.baseline</baseline>
       <tags>typedarray</tags>


### PR DESCRIPTION
Simple fix for #4978 

Note the ToIndex method I used was based on the implementation in ArrayBuffer.cpp but slightly simpler as DataView.cpp has a check for lengths that are too big later on.

Could clean up the code slightly by using a consistent version of ToIndex in both places though that would be a more invasive change than this.