### PR TITLE
Small tweak to bytecode dumper

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeDumper.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeDumper.cpp
@@ -197,7 +197,7 @@ namespace Js
 #else
                     Output::Print(_u("%-10s"), OpCodeUtil::GetOpCodeName(OpCode::Ld_A));
 #endif
-                    Output::Print(_u(" (\"%s\")"), JavascriptString::FromVar(varConst)->GetSz());
+                    Output::Print(_u(" (\"%s\")%s"), JavascriptString::FromVar(varConst)->GetSz(), Js::PropertyString::Is(varConst) ? _u(" [prop]") : _u(""));
                     break;
                 case Js::TypeIds_GlobalObject:
 #if ENABLE_NATIVE_CODEGEN


### PR DESCRIPTION
Updated DumpConstantTable to annotate property strings if the constant strings are indeed property strings
