### PR TITLE
Fix build break

### DIFF
--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -42,6 +42,9 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
         // And clean up all the cache not monitor by the GC (e.g. inline caches)
         AUTO_NO_EXCEPTION_REGION;
 
+        // RecyclerSweep may not be initialized till later in this function but
+        // GCETW relies on the recycler pointer being correctly set up
+        this->recycler = recycler;
         GCETW(GC_PRESWEEPCALLBACK_START, (this));
         recycler->collectionWrapper->PreSweepCallback();
         GCETW(GC_PRESWEEPCALLBACK_STOP, (this));

--- a/manifests/Microsoft-Scripting-Chakra-Instrumentation.man
+++ b/manifests/Microsoft-Scripting-Chakra-Instrumentation.man
@@ -2101,7 +2101,7 @@
                     outType="xs:string"
                     />
                 <data
-                    inType="win:UInt8"
+                    inType="win:Boolean"
                     name="Rethunk"
                     outType="xs:boolean"
                     />


### PR DESCRIPTION
The recent ETW manifest change assumes that UInt8 can be represented by the output type xs:boolean. However, this is a change supported only by mc.exe version 10.0.14251. In versions older than that, it breaks (which is also why github CI didn't catch it). Switched to using the Win32 BOOL input type instead.

There is a second issue where recycler sweep's pointer to the recycler might not be valid at the point of the pre-sweep callback. Updated to account for this