### PR TITLE
Fix construction of bound proxy objects:

### DIFF
--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -182,7 +182,7 @@ namespace Js
         Var operator [](int idxArg) { return const_cast<Var>(static_cast<const Arguments&>(*this)[idxArg]); }
         const Var operator [](int idxArg) const
         {
-            AssertMsg((idxArg < (int)Info.Count) && (idxArg >= 0), "Ensure a valid argument index");
+            AssertMsg((idxArg < (int)Info.Count + HasExtraArg() ? 1 : 0) && (idxArg >= 0), "Ensure a valid argument index");
             return Values[idxArg];
         }
 

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1335,7 +1335,7 @@ CommonNumber:
     {
         bool isCtorSuperCall = JavascriptOperators::IsConstructorSuperCall(args);
         Assert(isCtorSuperCall || !args.IsNewCall()
-                || args[0] == nullptr || JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch);
+                || args.GetNewTarget() == nullptr || JavascriptOperators::GetTypeId(args.GetNewTarget()) == TypeIds_HostDispatch);
         return isCtorSuperCall;
     }
 

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -136,16 +136,14 @@ namespace Js
         Var newVarInstance = nullptr;
         if (callInfo.Flags & CallFlags_New)
         {
-          if (JavascriptProxy::Is(targetFunction))
-          {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(targetFunction);
-            Arguments proxyArgs(CallInfo(CallFlags_New, 1), &targetFunction);
-            args.Values[0] = newVarInstance = proxy->ConstructorTrap(proxyArgs, scriptContext, 0);
-          }
-          else
-          {
-            args.Values[0] = newVarInstance = JavascriptOperators::NewScObjectNoCtor(targetFunction, scriptContext);
-          }
+            if (JavascriptProxy::Is(targetFunction))
+            {
+                args.Values[0] = newVarInstance = JavascriptProxy::FromVar(targetFunction);//JavascriptOperators::CreateFromConstructor(RecyclableObject::FromVar(targetFunction), scriptContext);
+            }
+            else
+            {
+                args.Values[0] = newVarInstance = JavascriptOperators::NewScObjectNoCtor(targetFunction, scriptContext);
+            }
         }
 
         Js::Arguments actualArgs = args;
@@ -183,7 +181,7 @@ namespace Js
             }
 
             // Copy the extra args
-            for (uint i=1; i<argCount; i++)
+            for (uint i=1; i < args.Info.GetArgCountWithExtraArgs(); i++)
             {
                 newValues[index++] = args[i];
             }

--- a/test/es6/boundConstruction.js
+++ b/test/es6/boundConstruction.js
@@ -1,0 +1,48 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+//setup code
+let constructionCount = 0;
+function a(arg1, arg2) {
+    this[arg1] = arg2;
+}
+const b = new Proxy(a, {
+    construct: function (x, y, z) {
+    ++constructionCount;
+    return Reflect.construct(x, y, z);
+}
+});
+const boundObject = {};
+const c = b.bind(boundObject, "prop-name");
+
+const tests = [
+    {
+        name : "Construct bound proxy with new",
+        body : function() {
+            constructionCount = 0;
+            const obj = new c("prop-value");
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.areEqual("prop-value", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, constructionCount, "bound proxy should be constructed once");
+            assert.areEqual(a.prototype, obj.__proto__, "constructed object should be instance of original function");
+        }
+    },
+    {
+        name : "Construct bound proxy with Reflect",
+        body : function() {
+            class newTarget {}
+            constructionCount = 0;
+            const obj = Reflect.construct(c, ["prop-value-2"], newTarget);
+            assert.areEqual(newTarget.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, constructionCount, "bound proxy should be constructed once");
+            assert.areEqual(a.prototype, obj.__proto__, "constructed object should be instance of original function");
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" }); 

--- a/test/es6/proxytest9.baseline
+++ b/test/es6/proxytest9.baseline
@@ -77,9 +77,6 @@ constructor trap
 constructor trap
 get trap prototype
 constructor trap
-constructor trap
-get trap prototype
-constructor trap
 true
 get trap m
 def

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -49,6 +49,12 @@
   </test>
   <test>
     <default>
+      <files>boundConstruction.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>es6toLength.js</files>
       <compile-flags>-es6toLength -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
**Fixes**: #4989 - Reflect.construct on a bound proxy = segfault (newTarget property would not be copied correctly)
**Fixes**: #4918 - constructing bound proxy supplied wrong newTarget value (meant using Reflect.construct inside construct trap would error)
**Fixes:** proxy construct method being invoked twice when constructing a bound proxy (no current open issue)

@sethbrenith I included your test cases from #4918 I hope that's ok? (though I split it into two cases as they error-ed in different ways)

I’ve targeted master for this but wondering if actually the 4989 fix at least should target 1.8 as it is fixing a segfault that is in 1.8.

**edit:** I think that this may be the wrong fix for 1 or 2 of these issues so will take another look and see if I can do it a better way.