### PR TITLE
Update RecyclerExecuteICUWithRetry to provide more verbose asserts

### DIFF
--- a/lib/Runtime/PlatformAgnostic/ChakraICU.h
+++ b/lib/Runtime/PlatformAgnostic/ChakraICU.h
@@ -77,24 +77,6 @@ namespace PlatformAgnostic
         typedef ScopedICUObject<UDateTimePatternGenerator *, udatpg_close> ScopedUDateTimePatternGenerator;
         typedef ScopedICUObject<UFieldPositionIterator *, ufieldpositer_close> ScopedUFieldPositionIterator;
 
-        // This function implements retry logic for calling ICU C APIs,
-        // where it is common that a first call might not succeed because a destination buffer is not big enough
-        template<typename TBuffer, typename ICUFunc, typename AllocatorFunc>
-        inline bool ExecuteICUWithRetry(AllocatorFunc allocate, ICUFunc func, int firstTryLen, TBuffer **ret, int *returnLen)
-        {
-            UErrorCode status = U_ZERO_ERROR;
-            *ret = allocate(firstTryLen);
-            *returnLen = func(reinterpret_cast<UChar *>(*ret), firstTryLen, &status);
-            if (ICU_BUFFER_FAILURE(status))
-            {
-                int secondTryLen = *returnLen + 1;
-                *ret = allocate(secondTryLen);
-                status = U_ZERO_ERROR;
-                *returnLen = func(reinterpret_cast<UChar *>(*ret), secondTryLen, &status);
-            }
-            return U_SUCCESS(status) && status != U_STRING_NOT_TERMINATED_WARNING && *returnLen > 0;
-        }
-
         inline int GetICUMajorVersion()
         {
             UVersionInfo version = { 0 };


### PR DESCRIPTION
We are seeing a handful of failfasts come up in crawler around this function that are difficult to act on, so hopefully these asserts should make it more clear what is going on. See OS#16964000