### PR TITLE
don't allow cross site objects in NoSpecialPropertyCache

### DIFF
--- a/lib/Runtime/Language/PrototypeChainCache.cpp
+++ b/lib/Runtime/Language/PrototypeChainCache.cpp
@@ -155,7 +155,7 @@ PrototypeChainCache<T>::Check(_In_ RecyclableObject* object)
         }
     }
 
-    if (!T::CheckObject(object))
+    if (!this->cache.CheckObject(object))
     {
         return false;
     }
@@ -198,7 +198,7 @@ PrototypeChainCache<T>::CheckProtoChainInternal(RecyclableObject* prototype)
         {
             onlyOneScriptContext = false;
         }
-        if (!T::CheckObject(prototype))
+        if (!this->cache.CheckObject(prototype))
         {
             return false;
         }
@@ -303,7 +303,13 @@ NoSpecialPropertyCache::Cache(_In_ Type* type)
 bool
 NoSpecialPropertyCache::CheckObject(_In_ RecyclableObject* object)
 {
-    return !object->HasAnySpecialProperties() && !object->HasDeferredTypeHandler();
+    if (object->HasAnySpecialProperties() || object->HasDeferredTypeHandler())
+    {
+        return false;
+    }
+    DynamicObject* dynamicObject = JavascriptOperators::TryFromVar<DynamicObject>(object);
+
+    return dynamicObject && !dynamicObject->IsCrossSiteObject();
 }
 
 #if DBG

--- a/lib/Runtime/Language/PrototypeChainCache.h
+++ b/lib/Runtime/Language/PrototypeChainCache.h
@@ -80,12 +80,12 @@ public:
         _In_ DynamicTypeHandler* typeHandler,
         PropertyAttributes attributes,
         _In_ KeyType propertyKey);
+    bool CheckObject(_In_ RecyclableObject* object);
 
     static void ClearType(_In_ Type* type);
 
     static bool IsCached(_In_ Type* type);
     static void Cache(_In_ Type* type);
-    static bool CheckObject(_In_ RecyclableObject* object);
 
     static bool IsSpecialProperty(PropertyId propertyId);
     static bool IsSpecialProperty(_In_ PropertyRecord const* propertyRecord);
@@ -131,12 +131,12 @@ public:
         _In_ DynamicTypeHandler* typeHandler,
         PropertyAttributes attributes,
         _In_ KeyType propertyKey);
+    bool CheckObject(_In_ RecyclableObject* object);
 
     static void ClearType(_In_ Type* type);
 
     static bool IsCached(_In_ Type* type);
     static void Cache(_In_ Type* type);
-    static bool CheckObject(_In_ RecyclableObject* object);
 #if DBG
     void RegistrationAssert(_In_ Type* type);
 #endif


### PR DESCRIPTION
There can be some different semantics around calling valueOf on cross site objects, so disallow them from the cache.
