### PR TITLE
Make runtests.py exclude tests marked exclude_ch fixes #4999

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -129,7 +129,7 @@ if not os.path.isfile(binary):
 
 # global tags/not_tags
 tags = set(args.tag or [])
-not_tags = set(args.not_tag or []).union(['fail', 'exclude_' + arch, 'exclude_' + flavor])
+not_tags = set(args.not_tag or []).union(['fail', 'exclude_' + arch, 'exclude_' + flavor, 'exclude_ch'])
 
 if arch_alias:
     not_tags.add('exclude_' + arch_alias)


### PR DESCRIPTION
Rather trivial fix but does the job. See #4999 for more detail.

Note this has no accompanying test as is relevant only for running tests offline.