### PR TITLE
disable wabt virtual terminal

### DIFF
--- a/lib/wabt/chakra/windows/config.h
+++ b/lib/wabt/chakra/windows/config.h
@@ -38,7 +38,7 @@
 #define HAVE_STRCASECMP 0
 
 /* Whether ENABLE_VIRTUAL_TERMINAL_PROCESSING is defined by windows.h */
-#define HAVE_WIN32_VT100 1
+#define HAVE_WIN32_VT100 0
 
 #define COMPILER_IS_CLANG 0
 #define COMPILER_IS_GNU 0


### PR DESCRIPTION
Disable Virtual Terminal for wabt. 
We do not use colors in our console output and this breaks the build on older versions of Windows.
Fixes #4991

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5002)
<!-- Reviewable:end -->
