### PR TITLE
don't clear cache in registry if scriptContext is finalized

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -139,8 +139,8 @@ namespace Js
         hasUsedInlineCache(false),
         hasProtoOrStoreFieldInlineCache(false),
         hasIsInstInlineCache(false),
-        noSpecialPropertyRegistry(threadContext->GetNoSpecialPropertyRegistry()),
-        onlyWritablePropertyRegistry(threadContext->GetOnlyWritablePropertyRegistry()),
+        noSpecialPropertyRegistry(this, threadContext->GetNoSpecialPropertyRegistry()),
+        onlyWritablePropertyRegistry(this, threadContext->GetOnlyWritablePropertyRegistry()),
         firstInterpreterFrameReturnAddress(nullptr),
         builtInLibraryFunctions(nullptr),
         isWeakReferenceDictionaryListCleared(false)

--- a/lib/Runtime/Language/PrototypeChainCache.cpp
+++ b/lib/Runtime/Language/PrototypeChainCache.cpp
@@ -56,8 +56,9 @@ ThreadCacheRegistry<T>::Clear()
 }
 
 template <typename T>
-ScriptCacheRegistry<T>::ScriptCacheRegistry(_In_ ThreadCacheRegistry<T>* threadRegistry) :
+ScriptCacheRegistry<T>::ScriptCacheRegistry(_In_ ScriptContext* scriptContext, _In_ ThreadCacheRegistry<T>* threadRegistry) :
     threadRegistry(threadRegistry),
+    scriptContext(scriptContext),
     cache(nullptr),
     registration(nullptr)
 {
@@ -89,7 +90,11 @@ ScriptCacheRegistry<T>::Clear(bool isThreadClear)
     if (this->registration != nullptr)
     {
         Assert(this->cache);
-        this->cache->Clear();
+        if (!this->scriptContext->IsFinalized())
+        {
+            // If ScriptContext is finalized, then cache is invalid
+            this->cache->Clear();
+        }
         // Thread clear will reset the registry, so we don't need to call unregister
         if (!isThreadClear)
         {

--- a/lib/Runtime/Language/PrototypeChainCache.h
+++ b/lib/Runtime/Language/PrototypeChainCache.h
@@ -29,7 +29,7 @@ template <typename T>
 class ScriptCacheRegistry
 {
 public:
-    ScriptCacheRegistry(_In_ ThreadCacheRegistry<T>* threadRegistry);
+    ScriptCacheRegistry(_In_ ScriptContext* scriptContext, _In_ ThreadCacheRegistry<T>* threadRegistry);
     void Register();
     void Clear(bool isThreadClear);
     void AssignCache(_In_ T* cache);
@@ -37,6 +37,7 @@ private:
     T* cache;
     ScriptCacheRegistry<T>** registration;
     ThreadCacheRegistry<T>* threadRegistry;
+    ScriptContext* scriptContext;
 };
 
 template <typename T>


### PR DESCRIPTION
Missed this when I was doing refactoring, but this restores the original behavior.

Fixes flaky UT failures.