### PR TITLE
Segfault constructing bound proxy with extra args Fixes #4989

### DIFF
--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -182,7 +182,7 @@ namespace Js
         Var operator [](int idxArg) { return const_cast<Var>(static_cast<const Arguments&>(*this)[idxArg]); }
         const Var operator [](int idxArg) const
         {
-            AssertMsg((idxArg < (int)Info.Count) && (idxArg >= 0), "Ensure a valid argument index");
+            AssertMsg((idxArg < (int)Info.Count + HasExtraArg() ? 1 : 0) && (idxArg >= 0), "Ensure a valid argument index");
             return Values[idxArg];
         }
 

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -154,13 +154,14 @@ namespace Js
         {
             // OACR thinks that this can change between here and the check in the for loop below
             const unsigned int argCount = args.Info.Count;
+            const unsigned int extendedArgCount = args.Info.GetArgCountWithExtraArgs();
 
             if ((boundFunction->count + argCount) > CallInfo::kMaxCountArgs)
             {
                 JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgListTooLarge);
             }
 
-            Field(Var) *newValues = RecyclerNewArray(scriptContext->GetRecycler(), Field(Var), boundFunction->count + argCount);
+            Field(Var) *newValues = RecyclerNewArray(scriptContext->GetRecycler(), Field(Var), boundFunction->count + extendedArgCount);
 
             uint index = 0;
 
@@ -183,7 +184,7 @@ namespace Js
             }
 
             // Copy the extra args
-            for (uint i=1; i<argCount; i++)
+            for (uint i=1; i < extendedArgCount; i++)
             {
                 newValues[index++] = args[i];
             }

--- a/test/es6/boundConstruction.js
+++ b/test/es6/boundConstruction.js
@@ -1,0 +1,37 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+//setup code
+let constructionCount = 0;
+function a(arg1, arg2) {
+    this[arg1] = arg2;
+}
+const b = new Proxy(a, {
+    construct: function (x, y, z) {
+    ++constructionCount;
+    return Reflect.construct(x, y, z);
+}
+});
+const boundObject = {};
+const c = b.bind(boundObject, "prop-name");
+
+const tests = [
+    {
+        name : "Construct bound proxy with Reflect",
+        body : function() {
+            class newTarget {}
+            constructionCount = 0;
+            const obj = Reflect.construct(c, ["prop-value-2"], newTarget);
+            assert.areEqual(newTarget.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            //assert.areEqual(1, constructionCount, "bound proxy should be constructed once"); //currently fails
+            assert.areEqual(a.prototype, obj.__proto__, "constructed object should be instance of original function");
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" }); 

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -51,6 +51,12 @@
   </test>
   <test>
     <default>
+      <files>boundConstruction.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>es6toLength.js</files>
       <compile-flags>-es6toLength -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
This fixes issue #4989 - targeting Release/1.8 as this issues relates to hard crash in the current release.

There are other fixes required to fully correct construction of bound proxies (which are somewhat harder to resolve) - however the other errors I'm aware of throw exceptions not segfaults.