### PR TITLE
Don't allow function objects that are prototypes to use the shared type for that FunctionProxy if properties/attributes are changed

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1929,6 +1929,14 @@ namespace Js
         });
     }
 
+    bool JavascriptObject::IsPrototypeOfStopAtProxy(RecyclableObject* proto, RecyclableObject* object, ScriptContext* scriptContext)
+    {
+        return JavascriptOperators::MapObjectAndPrototypesUntil<true>(object, [=](RecyclableObject* obj)
+        {
+            return obj == proto;
+        });
+    }
+
     static const size_t ConstructNameGetSetLength = 5;    // 5 = 1 ( for .) + 3 (get or set) + 1 for null)
 
     /*static*/

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -108,6 +108,8 @@ namespace Js
         static BOOL DefineOwnPropertyHelper(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, ScriptContext* scriptContext, bool throwOnError = true);
         static Var ToStringHelper(Var thisArg, ScriptContext* scriptContext);
         static JavascriptString* ToStringTagHelper(Var thisArg, ScriptContext* scriptContext, TypeId type);
+        static bool IsPrototypeOf(RecyclableObject* proto, RecyclableObject* obj, ScriptContext* scriptContext);
+        static bool IsPrototypeOfStopAtProxy(RecyclableObject* proto, RecyclableObject* obj, ScriptContext* scriptContext);
 
     private:
         template <bool tryCopy>
@@ -121,7 +123,6 @@ namespace Js
         static Var DefinePropertiesHelper(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static Var DefinePropertiesHelperForGenericObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static Var DefinePropertiesHelperForProxyObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
-        static bool IsPrototypeOf(RecyclableObject* proto, RecyclableObject* obj, ScriptContext* scriptContext);
 
         static Var GetToStringTagValue(RecyclableObject *thisArg, ScriptContext *scriptContext);
     };

--- a/lib/Runtime/Types/DeferredTypeHandler.cpp
+++ b/lib/Runtime/Types/DeferredTypeHandler.cpp
@@ -20,7 +20,7 @@ namespace Js
         // also responsible for populating PropertyTypes to indicate whether there are any read-only
         // properties unknown to the type handler.
 
-        BOOL isProto = (GetFlags() & IsPrototypeFlag);
+        BOOL isProto = this->GetIsPrototype();
 
         ScriptContext* scriptContext = instance->GetScriptContext();
         instance->EnsureSlots(0, typeHandler->GetSlotCapacity(), scriptContext, typeHandler);
@@ -31,7 +31,7 @@ namespace Js
         {
             undeferredFunctionType = functionProxy->GetUndeferredFunctionType();
         }
-        if (undeferredFunctionType && !instance->IsCrossSiteObject())
+        if (undeferredFunctionType && !isProto && !instance->IsCrossSiteObject())
         {
             Assert(undeferredFunctionType->GetIsShared());
             Assert(!CrossSite::IsThunk(undeferredFunctionType->GetEntryPoint()));
@@ -40,7 +40,7 @@ namespace Js
         else
         {
             typeHandler->SetInstanceTypeHandler(instance);
-            if (functionProxy && typeHandler->GetMayBecomeShared() && !CrossSite::IsThunk(instance->GetType()->GetEntryPoint()) && !PHASE_OFF1(ShareFuncTypesPhase))
+            if (functionProxy && !isProto && typeHandler->GetMayBecomeShared() && !CrossSite::IsThunk(instance->GetType()->GetEntryPoint()) && !PHASE_OFF1(ShareFuncTypesPhase))
             {
                 Assert(!functionProxy->GetUndeferredFunctionType());
                 functionProxy->SetUndeferredFunctionType(ScriptFunction::UnsafeFromVar(instance)->GetScriptFunctionType());

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -350,6 +350,9 @@ namespace Js
         AssertMsg(DynamicObject::IsTypeHandlerCompatibleForObjectHeaderInlining(this->GetTypeHandler(), type->GetTypeHandler()),
             "Object is ObjectHeaderInlined and should have compatible TypeHandlers for proper transition");
 
+        AssertMsg(!JavascriptObject::IsPrototypeOfStopAtProxy(this, type->GetPrototype(), GetScriptContext()),
+            "Replacing the type should not create a cycle in the prototype chain");
+
         this->type = type;
     }
 

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -64,7 +64,7 @@ namespace Js
     template<size_t size>
     bool SimpleTypeHandler<size>::DoConvertToPathType(DynamicType* type)
     {
-        if (CrossSite::IsThunk(type->GetEntryPoint()))
+        if (CrossSite::IsThunk(type->GetEntryPoint()) || type->GetTypeHandler()->GetIsPrototype())
         {
             return false;
         }

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1459,6 +1459,11 @@
 </test>
 <test>
   <default>
+    <files>setUserFuncAsProto.js</files>
+  </default>
+</test>
+<test>
+  <default>
     <files>function-expr-capture2.js</files>
     <compile-flags>-force:deferparse</compile-flags>
   </default>

--- a/test/es6/setUserFuncAsProto.js
+++ b/test/es6/setUserFuncAsProto.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo() {
+    function bar() {
+        // Deferred function   
+    }
+
+    return bar;
+}
+
+// Create two deferred functions
+var func1 = foo();
+var func2 = foo();
+
+// Set the prototype of `func2` to `func1`
+Object.setPrototypeOf(func2, func1);
+
+// Set a property of `func2` first causing it to be undeferred
+func2.x = 1;
+
+// Set a property of `func1` second causing it to share the type of `func2`
+func1.x = 2;
+
+// Try to access an undefined property, this will loop infinitely
+if (undefined === func1.y)
+{
+    WScript.Echo('pass');
+}
+


### PR DESCRIPTION
Doing so can result in a cycle in the prototype chain.