### PR TITLE
Fix super's set property to check thisInstance for not being an object

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2675,7 +2675,7 @@ CommonNumber:
             return TRUE;
         }
 
-        if (!TaggedNumber::Is(instance))
+        if (!TaggedNumber::Is(instance) && !TaggedNumber::Is(thisInstance))
         {
             return JavascriptOperators::SetProperty(RecyclableObject::UnsafeFromVar(thisInstance), RecyclableObject::UnsafeFromVar(instance), propertyId, newValue, info, scriptContext, flags);
         }

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -1249,13 +1249,14 @@ namespace Js
         }
         else
         {
-            JavascriptOperators::PatchPutValueNoLocalFastPath<false>(
+            JavascriptOperators::PatchPutValueWithThisPtrNoLocalFastPath<false>(
                 functionBody,
                 inlineCache,
                 inlineCacheIndex,
                 instance,
                 propertyId,
                 value,
+                thisInstance,
                 flags);
         }
 

--- a/test/es6/ES6Super.js
+++ b/test/es6/ES6Super.js
@@ -71,6 +71,30 @@ var tests = [
         assert.areEqual("expression", obj1.prop);
     }
   },
+    {
+        name: "super bound through call",
+        body: function () {
+            var obj = {
+                m() {
+                    super.x = 17;
+                },
+                n() {
+                    'use strict';
+                    super.x = 19;
+                }
+            };
+
+            var bar = { x: 11 };
+            obj.m.call(bar);
+            assert.areEqual(17, bar.x);
+
+            obj.n.call(bar);
+            assert.areEqual(19, bar.x);
+
+            obj.m.call(42); // noop in non-strict mode
+            assert.throws(() => obj.n.call(42), TypeError, "super bound to number", "Assignment to read-only properties is not allowed in strict mode");
+        }
+    },
   {
     name: "super in strict mode - class",
     body: function () {


### PR DESCRIPTION
Fixes OS#16290511

Recent a0c78d5cc7de11 introduced the crash. Also fixing profiled case to use thisInstance, when available.

Credit for finding the bug goes to OSS-Fuzz