### PR TITLE
Only pre-initialize ICU when using Windows Kit ICU

### DIFF
--- a/lib/Runtime/PlatformAgnostic/ChakraICU.h
+++ b/lib/Runtime/PlatformAgnostic/ChakraICU.h
@@ -22,6 +22,7 @@
 #include "unicode/udat.h"
 #include "unicode/udatpg.h"
 #include "unicode/uloc.h"
+#include "unicode/ulocdata.h"
 #include "unicode/unumsys.h"
 #include "unicode/ustring.h"
 #include "unicode/unorm2.h"


### PR DESCRIPTION
Third attempt at this after #4984 and #5001, but I have actually confirmed that this makes Node-ChakraCore's chakracore-master branch build, launch, and run Intl code successfully once more. This definitely isn't the best solution, however if we refer to https://github.com/nodejs/node-chakracore/blob/d94b22785fb6ab7dde77cb13b7e95e958e581375/src/node_i18n.cc#L568-L581, we can see that Node somewhat explicitly also does not call u_init if they call udata_setCommonData.