### PR TITLE
Rename functions with *fatal* to *unrecoverable* so !analyze doesn't skip them when walking the stack

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3750,7 +3750,7 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
         if (callType == RemoteCallType::MemFree)
         {
             // if freeing memory fails due to OOM, it means we failed to fill with debug breaks -- so failfast
-            RpcFailure_fatal_error(hr);
+            RpcFailure_unrecoverable_error(hr);
         }
         else
         {
@@ -3764,13 +3764,13 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
 
     if (CONFIG_FLAG(CrashOnOOPJITFailure))
     {
-        RpcFailure_fatal_error(hr);
+        RpcFailure_unrecoverable_error(hr);
     }
     // we only expect to see these hresults in case server has been closed. failfast otherwise
     if (hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED) &&
         hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED_DNE))
     {
-        RpcFailure_fatal_error(hr);
+        RpcFailure_unrecoverable_error(hr);
     }
 
     // if JIT process is gone, record that and stop trying to call it
@@ -3791,7 +3791,7 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
         return false;
     default:
         Assert(UNREACHED);
-        RpcFailure_fatal_error(hr);
+        RpcFailure_unrecoverable_error(hr);
     }
     return false;
 }

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -444,7 +444,7 @@
 #endif
 
 #if ENABLE_TTD
-#define TTDAssert(C, M) { if(!(C)) TTDAbort_fatal_error(M); }
+#define TTDAssert(C, M) { if(!(C)) TTDAbort_unrecoverable_error(M); }
 #else
 #define TTDAssert(C, M)
 #endif

--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -46,27 +46,27 @@ _NOINLINE void JavascriptDispatch_OOM_fatal_error(
     ReportFatalException(context, E_OUTOFMEMORY, JavascriptDispatch_OUTOFMEMORY, scenario);
 };
 
-_NOINLINE void CustomHeap_BadPageState_fatal_error(
+_NOINLINE void CustomHeap_BadPageState_unrecoverable_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
     ReportFatalException(context, E_UNEXPECTED, CustomHeap_MEMORYCORRUPTION, scenario);
 };
 
-_NOINLINE void MarkStack_OOM_fatal_error()
+_NOINLINE void MarkStack_OOM_unrecoverable_error()
 {
     int scenario = 1;
     ReportFatalException(NULL, E_OUTOFMEMORY, MarkStack_OUTOFMEMORY, scenario);
 };
 
-_NOINLINE void Amd64StackWalkerOutOfContexts_fatal_error(
+_NOINLINE void Amd64StackWalkerOutOfContexts_unrecoverable_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
     ReportFatalException(context, E_UNEXPECTED, Fatal_Amd64StackWalkerOutOfContexts, scenario);
 }
 
-_NOINLINE void FailedToBox_OOM_fatal_error(
+_NOINLINE void FailedToBox_OOM_unrecoverable_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
@@ -74,7 +74,7 @@ _NOINLINE void FailedToBox_OOM_fatal_error(
 }
 
 #if defined(RECYCLER_WRITE_BARRIER) && defined(TARGET_64)
-_NOINLINE void X64WriteBarrier_OOM_fatal_error()
+_NOINLINE void X64WriteBarrier_OOM_unrecoverable_error()
 {
     int scenario = 3;
     ReportFatalException(NULL, E_OUTOFMEMORY, WriteBarrier_OUTOFMEMORY, scenario);
@@ -109,19 +109,19 @@ _NOINLINE void LargeHeapBlock_Metadata_Corrupted(
 #endif
 
 // If you see this error, it is because of a DOM bug. Assign to daniec or jdweiner.
-_NOINLINE void FromDOM_NoScriptScope_fatal_error()
+_NOINLINE void FromDOM_NoScriptScope_unrecoverable_error()
 {
     int scenario = 5;
     ReportFatalException(NULL, E_UNEXPECTED, EnterScript_FromDOM_NoScriptScope, scenario);
 }
 
-_NOINLINE void Debugger_AttachDetach_fatal_error(HRESULT hr)
+_NOINLINE void Debugger_AttachDetach_unrecoverable_error(HRESULT hr)
 {
     int scenario = 5;
     ReportFatalException(NULL, hr, Fatal_Debugger_AttachDetach_Failure, scenario);
 }
 
-_NOINLINE void EntryExitRecord_Corrupted_fatal_error()
+_NOINLINE void EntryExitRecord_Corrupted_unrecoverable_error()
 {
     int scenario = 6;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_EntryExitRecordCorruption, scenario);
@@ -133,13 +133,13 @@ _NOINLINE void UnexpectedExceptionHandling_fatal_error()
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_UnexpectedExceptionHandling, scenario);
 }
 
-_NOINLINE void RpcFailure_fatal_error(HRESULT hr)
+_NOINLINE void RpcFailure_unrecoverable_error(HRESULT hr)
 {
     int scenario = 8;
     ReportFatalException(NULL, hr, Fatal_RpcFailure, scenario);
 }
 
-_NOINLINE void OutOfMemory_fatal_error()
+_NOINLINE void OutOfMemory_unrecoverable_error()
 {
     int scenario = 9;
     ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);

--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -43,26 +43,26 @@ extern "C" void ReportFatalException(
 void JavascriptDispatch_OOM_fatal_error(
     __in ULONG_PTR context);
 
-void CustomHeap_BadPageState_fatal_error(
+void CustomHeap_BadPageState_unrecoverable_error(
     __in ULONG_PTR context);
 
-void Amd64StackWalkerOutOfContexts_fatal_error(
+void Amd64StackWalkerOutOfContexts_unrecoverable_error(
     __in ULONG_PTR context);
 
-void FailedToBox_OOM_fatal_error(
+void FailedToBox_OOM_unrecoverable_error(
     __in ULONG_PTR context);
 
 #if defined(RECYCLER_WRITE_BARRIER) && defined(TARGET_64)
-void X64WriteBarrier_OOM_fatal_error();
+void X64WriteBarrier_OOM_unrecoverable_error();
 #endif
 
 void DebugHeap_OOM_fatal_error();
 
-void MarkStack_OOM_fatal_error();
+void MarkStack_OOM_unrecoverable_error();
 
 void Binary_Inconsistency_fatal_error();
 void Version_Inconsistency_fatal_error();
-void EntryExitRecord_Corrupted_fatal_error();
+void EntryExitRecord_Corrupted_unrecoverable_error();
 void UnexpectedExceptionHandling_fatal_error();
 
 #ifdef LARGEHEAPBLOCK_ENCODING
@@ -70,10 +70,10 @@ void LargeHeapBlock_Metadata_Corrupted(
     __in ULONG_PTR context, __in unsigned char calculatedCheckSum);
 #endif
 
-void FromDOM_NoScriptScope_fatal_error();
-void Debugger_AttachDetach_fatal_error(HRESULT hr);
-void RpcFailure_fatal_error(HRESULT hr);
-void OutOfMemory_fatal_error();
+void FromDOM_NoScriptScope_unrecoverable_error();
+void Debugger_AttachDetach_unrecoverable_error(HRESULT hr);
+void RpcFailure_unrecoverable_error(HRESULT hr);
+void OutOfMemory_unrecoverable_error();
 
 #ifndef DISABLE_SEH
 // RtlReportException is available on Vista and up, but we cannot use it for OOB release.

--- a/lib/Common/Exceptions/Throw.h
+++ b/lib/Common/Exceptions/Throw.h
@@ -293,4 +293,4 @@ namespace Js {
     catch (ex) \
     {
 
-#define DEBUGGER_ATTACHDETACH_FATAL_ERROR_IF_FAILED(hr) if (hr != S_OK) Debugger_AttachDetach_fatal_error(hr);
+#define DEBUGGER_ATTACHDETACH_FATAL_ERROR_IF_FAILED(hr) if (hr != S_OK) Debugger_AttachDetach_unrecoverable_error(hr);

--- a/lib/Common/Memory/CustomHeap.cpp
+++ b/lib/Common/Memory/CustomHeap.cpp
@@ -573,7 +573,7 @@ bool Heap<TAlloc, TPreReservedAlloc>::AllocInPage(Page* page, size_t bytes, usho
     BVIndex index = GetFreeIndexForPage(page, bytes);
     if (index == BVInvalidIndex)
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return false;
     }
     char* address = page->address + Page::Alignment * index;
@@ -622,14 +622,14 @@ bool Heap<TAlloc, TPreReservedAlloc>::AllocInPage(Page* page, size_t bytes, usho
     //Section of the Page should already be freed.
     if (!page->freeBitVector.TestRange(index, length))
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return false;
     }
 
     //Section of the Page should already be freed.
     if (!page->freeBitVector.TestRange(index, length))
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return false;
     }
 
@@ -816,7 +816,7 @@ bool Heap<TAlloc, TPreReservedAlloc>::FreeAllocation(Allocation* object)
     // Make sure that the section under interest or the whole page has not already been freed
     if (page->IsEmpty() || page->freeBitVector.TestAnyInRange(index, length))
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return false;
     }
 

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -2582,7 +2582,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
         || ((uint)(((char *)address) - segment->GetAddress()) > (segment->GetPageCount() - pageCount) * AutoSystemInfo::PageSize))
     {
         // OOPJIT TODO: don't bring down the whole JIT process
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return FALSE;
     }
 
@@ -2604,7 +2604,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
         || memBasicInfo.RegionSize < pageCount * AutoSystemInfo::PageSize
         || desiredOldProtectFlag != memBasicInfo.Protect)
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return FALSE;
     }
 
@@ -2614,7 +2614,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
         (dwVirtualProtectFlags & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)) &&
         ((dwVirtualProtectFlags & PAGE_TARGETS_NO_UPDATE) == 0))
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
         return FALSE;
     }
 #endif
@@ -2636,7 +2636,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
     BOOL retVal = VirtualProtect(address, pageCount * AutoSystemInfo::PageSize, dwVirtualProtectFlags, &oldProtect);
     if (retVal == FALSE)
     {
-        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
     }
     else
     {

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -2915,7 +2915,7 @@ Recycler::EndMarkOnLowMemory()
             // The fail-fast is present for two reasons:
             // 1) Defense-in-depth for cases we hadn't thought about
             // 2) Deal with cases like -MaxMarkStackPageCount:1 which can still hang without the fail-fast
-            MarkStack_OOM_fatal_error();
+            MarkStack_OOM_unrecoverable_error();
         }
 
         autoHeap.Rescan(RescanFlags_None);

--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -63,7 +63,7 @@ LPVOID VirtualAllocWrapper::AllocPages(LPVOID lpAddress, size_t pageCount, DWORD
             BOOL result = VirtualProtect(address, dwSize, protectFlags, &oldProtectFlags);
             if (result == FALSE)
             {
-                CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+                CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
             }
         }
     }
@@ -329,7 +329,7 @@ LPVOID PreReservedVirtualAllocWrapper::AllocPages(LPVOID lpAddress, size_t pageC
                 || memBasicInfo.RegionSize < requestedNumOfSegments * AutoSystemInfo::Data.GetAllocationGranularityPageSize()
                 || memBasicInfo.State == MEM_COMMIT)
             {
-                CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+                CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
             }
         }
         else
@@ -380,7 +380,7 @@ LPVOID PreReservedVirtualAllocWrapper::AllocPages(LPVOID lpAddress, size_t pageC
                     BOOL result = VirtualProtect(allocatedAddress, dwSize, protectFlags, &oldProtect);
                     if (result == FALSE)
                     {
-                        CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+                        CustomHeap_BadPageState_unrecoverable_error((ULONG_PTR)this);
                     }
                     AssertMsg(oldProtect == (PAGE_EXECUTE_READWRITE), "CFG Bitmap gets allocated and bits will be set to invalid only upon passing these flags.");
                 }

--- a/lib/Jsrt/JsrtDiag.cpp
+++ b/lib/Jsrt/JsrtDiag.cpp
@@ -95,7 +95,7 @@ CHAKRA_API JsDiagStartDebugging(
             HRESULT hr;
             if (FAILED(hr = scriptContext->OnDebuggerAttached()))
             {
-                Debugger_AttachDetach_fatal_error(hr); // Inconsistent state, we can't continue from here
+                Debugger_AttachDetach_unrecoverable_error(hr); // Inconsistent state, we can't continue from here
                 return JsErrorFatal;
             }
 
@@ -147,7 +147,7 @@ CHAKRA_API JsDiagStopDebugging(
             HRESULT hr;
             if (FAILED(hr = scriptContext->OnDebuggerDetached()))
             {
-                Debugger_AttachDetach_fatal_error(hr); // Inconsistent state, we can't continue from here
+                Debugger_AttachDetach_unrecoverable_error(hr); // Inconsistent state, we can't continue from here
                 return JsErrorFatal;
             }
 

--- a/lib/Runtime/Base/Exception.cpp
+++ b/lib/Runtime/Base/Exception.cpp
@@ -17,7 +17,7 @@ namespace Js
             if (kind == ExceptionKind_OutOfMemory &&
                 CONFIG_FLAG(EnableFatalErrorOnOOM) && !threadContext->TestThreadContextFlag(ThreadContextFlagDisableFatalOnOOM))
             {
-                OutOfMemory_fatal_error();
+                OutOfMemory_unrecoverable_error();
             }
 
             if (threadContext->IsScriptActive())

--- a/lib/Runtime/Base/LeaveScriptObject.cpp
+++ b/lib/Runtime/Base/LeaveScriptObject.cpp
@@ -18,7 +18,7 @@ namespace Js
         if (scriptContext->GetThreadContext() &&
             scriptContext->GetThreadContext()->IsNoScriptScope())
         {
-            FromDOM_NoScriptScope_fatal_error();
+            FromDOM_NoScriptScope_unrecoverable_error();
         }
 
         // Keep a copy locally so the optimizer can just copy prop it to the dtor

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2085,7 +2085,7 @@ ThreadContext::DisposeObjects(Recycler * recycler)
     // Callers of DisposeObjects should ensure !IsNoScriptScope() before calling DisposeObjects.
     if (this->IsNoScriptScope())
     {
-        FromDOM_NoScriptScope_fatal_error();
+        FromDOM_NoScriptScope_unrecoverable_error();
     }
 
     if (!this->IsScriptActive())
@@ -2131,7 +2131,7 @@ ThreadContext::PushEntryExitRecord(Js::ScriptEntryExitRecord * record)
                 && !IS_ASAN_FAKE_STACK_ADDR(record)
                 && !IS_ASAN_FAKE_STACK_ADDR(lastRecord)))
         {
-            EntryExitRecord_Corrupted_fatal_error();
+            EntryExitRecord_Corrupted_unrecoverable_error();
         }
     }
 
@@ -2153,7 +2153,7 @@ void ThreadContext::PopEntryExitRecord(Js::ScriptEntryExitRecord * record)
             && !IS_ASAN_FAKE_STACK_ADDR(this->entryExitRecord)
             && !IS_ASAN_FAKE_STACK_ADDR(next))))
     {
-        EntryExitRecord_Corrupted_fatal_error();
+        EntryExitRecord_Corrupted_unrecoverable_error();
     }
 
     this->entryExitRecord = next;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2146,7 +2146,7 @@ void ByteCodeGenerator::CheckDeferParseHasMaybeEscapedNestedFunc()
             }
             catch (Js::OutOfMemoryException)
             {
-                FailedToBox_OOM_fatal_error((ULONG_PTR)functionBody);
+                FailedToBox_OOM_unrecoverable_error((ULONG_PTR)functionBody);
             }
 
             return;

--- a/lib/Runtime/Debug/TTSupport.cpp
+++ b/lib/Runtime/Debug/TTSupport.cpp
@@ -6,7 +6,7 @@
 
 #if ENABLE_TTD
 
-void TTDAbort_fatal_error(const char* msg)
+void TTDAbort_unrecoverable_error(const char* msg)
 {
     Output::Print(_u("TTD assert failed: %S\n"), msg);
 

--- a/lib/Runtime/Debug/TTSupport.h
+++ b/lib/Runtime/Debug/TTSupport.h
@@ -62,7 +62,7 @@ namespace TTD
     class TTDebuggerSourceLocation;
 }
 
-void _NOINLINE __declspec(noreturn) TTDAbort_fatal_error(const char* msg);
+void _NOINLINE __declspec(noreturn) TTDAbort_unrecoverable_error(const char* msg);
 
 ////////
 //Memory allocators used by the TT code

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -1191,7 +1191,7 @@ namespace Js
 
         if (CONFIG_FLAG(EnableFatalErrorOnOOM) && !threadContext->TestThreadContextFlag(ThreadContextFlagDisableFatalOnOOM))
         {
-            OutOfMemory_fatal_error();
+            OutOfMemory_unrecoverable_error();
         }
         else
         {

--- a/lib/Runtime/Language/amd64/StackFrame.cpp
+++ b/lib/Runtime/Language/amd64/StackFrame.cpp
@@ -253,7 +253,7 @@ CONTEXT* Js::Amd64ContextsManager::Allocate()
 
     default:
         AssertMsg(false, "Unexpected usage of JavascriptStackWalker. We run out of CONTEXTs on amd64.");
-        Amd64StackWalkerOutOfContexts_fatal_error((ULONG_PTR)this);
+        Amd64StackWalkerOutOfContexts_unrecoverable_error((ULONG_PTR)this);
     }
 
     AnalysisAssert(pair);

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -45,7 +45,7 @@ namespace Js
         }
         catch (Js::OutOfMemoryException)
         {
-           FailedToBox_OOM_fatal_error((ULONG_PTR)stackScriptFunction);
+           FailedToBox_OOM_unrecoverable_error((ULONG_PTR)stackScriptFunction);
         }
         return boxedFunction;
     }


### PR DESCRIPTION
Fixes #4927
Confirmed that !analyze has no rules for 'unrecoverable'
