### PR TITLE
Support polymorphic type checks for equivalent objtypespec

### DIFF
--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -475,7 +475,6 @@
     <ClInclude Include="NativeCodeGenerator.h" />
     <ClInclude Include="Opnd.h" />
     <ClInclude Include="Peeps.h" />
-    <ClInclude Include="PropertyGuard.h" />
     <ClInclude Include="QueuedFullJitWorkItem.h" />
     <ClInclude Include="Region.h" />
     <ClInclude Include="SccLiveness.h" />

--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -372,7 +372,6 @@
     <ClInclude Include="ValueInfo.h" />
     <ClInclude Include="JITThunkEmitter.h" />
     <ClInclude Include="IntConstMath.h" />
-    <ClInclude Include="PropertyGuard.h" />
     <ClInclude Include="JavascriptNativeOperators.h" />
     <ClInclude Include="EquivalentTypeSet.h" />
     <ClInclude Include="arm64\MdOpCodes.h">

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1585,6 +1585,26 @@ Func::CreateEquivalentTypeGuard(JITTypeHolder type, uint32 objTypeSpecFldId)
 
     Js::JitEquivalentTypeGuard* guard = NativeCodeDataNewNoFixup(GetNativeCodeDataAllocator(), Js::JitEquivalentTypeGuard, type->GetAddr(), this->indexedPropertyGuardCount++, objTypeSpecFldId);
 
+    this->InitializeEquivalentTypeGuard(guard);
+
+    return guard;
+}
+
+Js::JitPolyEquivalentTypeGuard*
+Func::CreatePolyEquivalentTypeGuard(uint32 objTypeSpecFldId)
+{
+    EnsureEquivalentTypeGuards();
+
+    Js::JitPolyEquivalentTypeGuard* guard = NativeCodeDataNewNoFixup(GetNativeCodeDataAllocator(), Js::JitPolyEquivalentTypeGuard, this->indexedPropertyGuardCount++, objTypeSpecFldId);
+
+    this->InitializeEquivalentTypeGuard(guard);
+
+    return guard;
+}
+
+void
+Func::InitializeEquivalentTypeGuard(Js::JitEquivalentTypeGuard * guard)
+{
     // If we want to hard code the address of the cache, we will need to go back to allocating it from the native code data allocator.
     // We would then need to maintain consistency (double write) to both the recycler allocated cache and the one on the heap.
     Js::EquivalentTypeCache* cache = nullptr;
@@ -1601,8 +1621,6 @@ Func::CreateEquivalentTypeGuard(JITTypeHolder type, uint32 objTypeSpecFldId)
     // Give the cache a back-pointer to the guard so that the guard can be cleared at runtime if necessary.
     cache->SetGuard(guard);
     this->equivalentTypeGuards->Prepend(guard);
-
-    return guard;
 }
 
 void

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -449,8 +449,10 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
     void EnsureSingleTypeGuards();
     Js::JitTypePropertyGuard* GetOrCreateSingleTypeGuard(intptr_t typeAddr);
 
-    void  EnsureEquivalentTypeGuards();
+    void EnsureEquivalentTypeGuards();
+    void InitializeEquivalentTypeGuard(Js::JitEquivalentTypeGuard * guard);
     Js::JitEquivalentTypeGuard * CreateEquivalentTypeGuard(JITTypeHolder type, uint32 objTypeSpecFldId);
+    Js::JitPolyEquivalentTypeGuard * CreatePolyEquivalentTypeGuard(uint32 objTypeSpecFldId);
 
     void ThrowIfScriptClosed();
     void EnsurePropertyGuardsByPropertyId();

--- a/lib/Backend/JITTimeConstructorCache.cpp
+++ b/lib/Backend/JITTimeConstructorCache.cpp
@@ -22,7 +22,7 @@ JITTimeConstructorCache::JITTimeConstructorCache(const Js::JavascriptFunction* c
     m_data.guardedPropOps = 0;
     if (runtimeCache->IsNormal())
     {
-        JITType::BuildFromJsType(runtimeCache->content.type, (JITType*)&m_data.type);
+        JITType::BuildFromJsType(reinterpret_cast<Js::DynamicType*>(runtimeCache->GetValue()), (JITType*)&m_data.type);
     }
 }
 

--- a/lib/Backend/JavascriptNativeOperators.h
+++ b/lib/Backend/JavascriptNativeOperators.h
@@ -133,6 +133,9 @@ namespace Js
 #endif        
         static bool CheckIfTypeIsEquivalent(Type* type, JitEquivalentTypeGuard* guard);
         static bool CheckIfTypeIsEquivalentForFixedField(Type* type, JitEquivalentTypeGuard* guard);
+        static bool CheckIfPolyTypeIsEquivalent(Type* type, JitPolyEquivalentTypeGuard* guard, uint8 index);
+        static bool CheckIfPolyTypeIsEquivalentForFixedField(Type* type, JitPolyEquivalentTypeGuard* guard, uint8 index);
+        static bool EquivalenceCheckHelper(Type* type, JitEquivalentTypeGuard* guard, intptr_t value);
 
         static Var OP_GetElementI_JIT_ExpectingNativeFloatArray(Var instance, Var index, ScriptContext *scriptContext);
         static Var OP_GetElementI_JIT_ExpectingVarArray(Var instance, Var index, ScriptContext *scriptContext);

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -252,6 +252,8 @@ HELPERCALL(Op_ScopedGetMethodPolymorphic, ((Js::Var (*)(Js::FunctionBody *const,
 
 HELPERCALL(CheckIfTypeIsEquivalent, Js::JavascriptNativeOperators::CheckIfTypeIsEquivalent, 0)
 HELPERCALL(CheckIfTypeIsEquivalentForFixedField, Js::JavascriptNativeOperators::CheckIfTypeIsEquivalentForFixedField, 0)
+HELPERCALL(CheckIfPolyTypeIsEquivalent, Js::JavascriptNativeOperators::CheckIfPolyTypeIsEquivalent, 0)
+HELPERCALL(CheckIfPolyTypeIsEquivalentForFixedField, Js::JavascriptNativeOperators::CheckIfPolyTypeIsEquivalentForFixedField, 0)
 
 HELPERCALL(Op_Delete, Js::JavascriptOperators::Delete, AttrCanThrow)
 HELPERCALL(OP_InitSetter, Js::JavascriptOperators::OP_InitSetter, AttrCanThrow)

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -136,9 +136,12 @@ private:
     IR::RegOpnd *   GenerateCachedTypeCheck(IR::Instr *instrInsert, IR::PropertySymOpnd *propertySymOpnd,
                         IR::LabelInstr* labelObjCheckFailed, IR::LabelInstr *labelTypeCheckFailed, IR::LabelInstr *labelSecondChance = nullptr);
     void            GenerateCachedTypeWithoutPropertyCheck(IR::Instr *instrInsert, IR::PropertySymOpnd *propertySymOpnd, IR::Opnd *typeOpnd, IR::LabelInstr *labelTypeCheckFailed);
+    IR::RegOpnd *   GeneratePolymorphicTypeIndex(IR::RegOpnd * typeOpnd, Js::PropertyGuard * typeCheckGuard, IR::Instr * instrInsert);
+    void            GenerateLeaOfOOPData(IR::RegOpnd * regOpnd, void * address, int32 offset, IR::Instr * instrInsert);
+    IR::Opnd *      GenerateIndirOfOOPData(void * address, int32 offset, IR::Instr * instrInsert);
     void            GenerateFixedFieldGuardCheck(IR::Instr *insertPointInstr, IR::PropertySymOpnd *propertySymOpnd, IR::LabelInstr *labelBailOut);
     Js::JitTypePropertyGuard* CreateTypePropertyGuardForGuardedProperties(JITTypeHolder type, IR::PropertySymOpnd* propertySymOpnd);
-    Js::JitEquivalentTypeGuard* CreateEquivalentTypeGuardAndLinkToGuardedProperties(JITTypeHolder type, IR::PropertySymOpnd* propertySymOpnd);
+    Js::JitEquivalentTypeGuard* CreateEquivalentTypeGuardAndLinkToGuardedProperties(IR::PropertySymOpnd* propertySymOpnd);
     bool            LinkCtorCacheToGuardedProperties(JITTimeConstructorCache* cache);
     template<typename LinkFunc>
     bool            LinkGuardToGuardedProperties(const BVSparse<JitArenaAllocator>* guardedPropOps, LinkFunc link);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -1086,6 +1086,12 @@ PropertySymOpnd::CloneUseInternalSub(Func *func)
     return this->CopyInternalSub(func);
 }
 
+bool 
+PropertySymOpnd::ShouldUsePolyEquivTypeGuard(Func *const func) const
+{
+    return this->IsPoly() && this->m_polyCacheUtil >= PolymorphicInlineCacheUtilizationThreshold && !PHASE_OFF(Js::PolyEquivTypeGuardPhase, func);
+}
+
 RegOpnd::RegOpnd(StackSym *sym, RegNum reg, IRType type)
 {
     Initialize(sym, reg, type);

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -678,6 +678,8 @@ public:
         }
     }
 
+    bool ShouldUsePolyEquivTypeGuard(Func *const func) const;
+
     bool HasObjTypeSpecFldInfo() const
     {
         return this->objTypeSpecFldInfo != nullptr;

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -50,7 +50,6 @@ typedef double  FloatConstType;
 #include "IRType.h"
 #include "InlineeFrameInfo.h"
 #include "CodeGenAllocators.h"
-#include "PropertyGuard.h"
 
 NativeCodeGenerator * NewNativeCodeGenerator(Js::ScriptContext * nativeCodeGen);
 void DeleteNativeCodeGenerator(NativeCodeGenerator * nativeCodeGen);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -155,6 +155,7 @@ PHASE(All)
                     PHASE(DisabledObjTypeSpec)
                     PHASE(DepolymorphizeInlinees)
                     PHASE(ReuseAuxSlotPtr)
+                    PHASE(PolyEquivTypeGuard)
                     #if DBG
                         PHASE(SimulatePolyCacheWithOneTypeForFunction)
                     #endif

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -228,6 +228,7 @@
     <ClInclude Include="ModuleNamespace.h" />
     <ClInclude Include="ModuleNamespaceEnumerator.h" />
     <ClInclude Include="ProfilingHelpers.h" />
+    <ClInclude Include="PropertyGuard.h" />
     <ClInclude Include="PrototypeChainCache.h" />
     <ClInclude Include="SourceDynamicProfileManager.h" />
     <ClInclude Include="ModuleRecordBase.h" />

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
@@ -154,6 +154,7 @@
     <ClInclude Include="ConstructorCache.h" />
     <ClInclude Include="AsmJsArrayBufferViews.h" />
     <ClInclude Include="PrototypeChainCache.h" />
+    <ClInclude Include="PropertyGuard.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\amd64_Thunks.asm">

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -11,12 +11,6 @@
 #define TypeHasAuxSlotTag(_t) \
     (!!(reinterpret_cast<size_t>(_t) & InlineCacheAuxSlotTypeTag))
 
-#if defined(TARGET_32)
-#define PolymorphicInlineCacheShift 5 // On 32 bit architectures, the least 5 significant bits of a DynamicTypePointer is 0
-#else
-#define PolymorphicInlineCacheShift 6 // On 64 bit architectures, the least 6 significant bits of a DynamicTypePointer is 0
-#endif
-
 // forward decl
 class JITType;
 struct InlineCacheData;

--- a/lib/Runtime/Language/PropertyGuard.h
+++ b/lib/Runtime/Language/PropertyGuard.h
@@ -4,23 +4,40 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
+
+#if ENABLE_NATIVE_CODEGEN
+class JitPolyEquivalentTypeGuard;
+#endif
 
 class PropertyGuard
 {
     friend class PropertyGuardValidator;
+#if ENABLE_NATIVE_CODEGEN
+    friend class JitPolyEquivalentTypeGuard;
+#endif
 
 private:
     Field(intptr_t) value; // value is address of Js::Type
+#if ENABLE_NATIVE_CODEGEN
+    Field(bool) isPoly;
+#endif
 #if DBG
     Field(bool) wasReincarnated = false;
 #endif
 public:
     static PropertyGuard* New(Recycler* recycler) { return RecyclerNewLeaf(recycler, Js::PropertyGuard); }
-    PropertyGuard() : value(GuardValue::Uninitialized) {}
+    PropertyGuard() : value(GuardValue::Uninitialized)
+#if ENABLE_NATIVE_CODEGEN
+                      , isPoly(false)
+#endif
+    {
+    }
     PropertyGuard(intptr_t value) : value(value)
+#if ENABLE_NATIVE_CODEGEN
+                      , isPoly(false)
+#endif
     {
         // GuardValue::Invalidated and GuardValue::Invalidated_DuringSweeping can only be set using
         // Invalidate() and InvalidatedDuringSweep() methods respectively.
@@ -44,14 +61,8 @@ public:
         this->value = value;
     }
     intptr_t const* GetAddressOfValue() { return &this->value; }
-    void Invalidate() { this->value = GuardValue::Invalidated; }
-    void InvalidateDuringSweep()
-    {
-#if DBG
-        wasReincarnated = true;
-#endif
-        this->value = GuardValue::Invalidated_DuringSweep;
-    }
+    void Invalidate();
+    void InvalidateDuringSweep();
 #if DBG
     bool WasReincarnated() { return this->wasReincarnated; }
 #endif
@@ -61,6 +72,16 @@ public:
         Uninitialized = 1,
         Invalidated_DuringSweep = 2
     };
+
+#if ENABLE_NATIVE_CODEGEN
+    bool IsPoly() const { return this->isPoly; }
+
+    JitPolyEquivalentTypeGuard * AsPolyTypeCheckGuard()
+    {
+        AssertOrFailFast(this->IsPoly());
+        return (JitPolyEquivalentTypeGuard*)(this);
+    }
+#endif
 };
 
 class PropertyGuardValidator
@@ -70,6 +91,9 @@ class PropertyGuardValidator
     // CompileAssert(offsetof(ConstructorCache, guard.value) == offsetof(PropertyGuard, value));
 };
 
+
+#if ENABLE_NATIVE_CODEGEN
+
 class JitIndexedPropertyGuard : public Js::PropertyGuard
 {
 private:
@@ -78,6 +102,9 @@ private:
 public:
     JitIndexedPropertyGuard(intptr_t value, int index) :
         Js::PropertyGuard(value), index(index) {}
+
+    JitIndexedPropertyGuard(int index) :
+        Js::PropertyGuard(), index(index) {}
 
     int GetIndex() const { return this->index; }
 };
@@ -194,6 +221,11 @@ public:
 #endif
     }
 
+    JitEquivalentTypeGuard(int index, uint32 objTypeSpecFldId) :
+        JitIndexedPropertyGuard(index), cache(nullptr), objTypeSpecFldId(objTypeSpecFldId)
+    {
+    }
+
     intptr_t GetTypeAddr() const { return this->GetValue(); }
 
     void SetTypeAddr(const intptr_t typeAddr)
@@ -227,6 +259,100 @@ public:
     }
 };
 
+class JitPolyEquivalentTypeGuard : public JitEquivalentTypeGuard
+{
+public:
+    JitPolyEquivalentTypeGuard(int index, uint32 objTypeSpecFldId) : JitEquivalentTypeGuard(index, objTypeSpecFldId)
+    {
+        isPoly = true;
+
+        for (uint i = 0; i < GetSize(); i++)
+        {
+            polyValues[i] = GuardValue::Uninitialized;
+        }
+    }
+
+private:
+    intptr_t polyValues[EQUIVALENT_TYPE_CACHE_SIZE];
+
+public:
+    static int32 GetOffsetOfPolyValues() { return offsetof(JitPolyEquivalentTypeGuard, polyValues); }
+
+    // TODO: Revisit optimal size. Make it vary according to the number of caches? Is this worth a variable-size allocation?
+    uintptr_t GetSize() const { return EQUIVALENT_TYPE_CACHE_SIZE; }
+    intptr_t const * GetAddressOfPolyValues() { return &this->polyValues[0]; }
+
+    intptr_t GetPolyValue(uint8 index) const
+    {
+        AssertOrFailFast(index < GetSize());
+        return polyValues[index];
+    }
+
+    void SetPolyValue(intptr_t value, uint8 index)
+    {
+        AssertOrFailFast(index < GetSize());
+        polyValues[index] = value;
+    }
+
+    uint8 GetIndexForValue(intptr_t value) const
+    {
+        return (uint8)((value >> PolymorphicInlineCacheShift) & (GetSize() - 1));
+    }
+
+    void Invalidate()
+    {
+        for (uint8 i = 0; i < GetSize(); i++)
+        {
+            Invalidate(i);
+        }
+    }
+
+    void Invalidate(uint8 i)
+    {
+        AssertOrFailFast(i < GetSize());
+        polyValues[i] = GuardValue::Invalidated;
+    }
+
+    void InvalidateDuringSweep()
+    {
+        for (uint8 i = 0; i < GetSize(); i++)
+        {
+            InvalidateDuringSweep(i);
+        }
+    }
+
+    void InvalidateDuringSweep(uint8 i)
+    {
+        AssertOrFailFast(i < GetSize());
+        polyValues[i] = GuardValue::Invalidated_DuringSweep;
+    }
+};
+
+#endif // ENABLE_NATIVE_CODEGEN
+
+inline void PropertyGuard::Invalidate()
+{ 
+    this->value = GuardValue::Invalidated; 
+#if ENABLE_NATIVE_CODEGEN
+    if (this->IsPoly())
+    {
+        this->AsPolyTypeCheckGuard()->JitPolyEquivalentTypeGuard::Invalidate();
+    }
+#endif
+}
+
+inline void PropertyGuard::InvalidateDuringSweep()
+{
+#if DBG
+    wasReincarnated = true;
+#endif
+    this->value = GuardValue::Invalidated_DuringSweep;
+#if ENABLE_NATIVE_CODEGEN
+    if (this->IsPoly())
+    {
+        this->AsPolyTypeCheckGuard()->JitPolyEquivalentTypeGuard::InvalidateDuringSweep();
+    }
+#endif
+}
 
 };
-#endif // ENABLE_NATIVE_CODEGEN

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -371,8 +371,9 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Types/TypeId.h"
 
 #include "Base/Constants.h"
-#include "Language/ConstructorCache.h"
 #include "BackendApi.h"
+#include "Language/PropertyGuard.h"
+#include "Language/ConstructorCache.h"
 #include "ByteCode/OpLayoutsCommon.h"
 #include "ByteCode/OpLayouts.h"
 #include "ByteCode/OpLayoutsAsmJs.h"

--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -9,6 +9,12 @@
 
 const extern int TotalNumberOfBuiltInProperties;
 
+#if defined(TARGET_32)
+#define PolymorphicInlineCacheShift 5 // On 32 bit architectures, the least 5 significant bits of a DynamicTypePointer is 0
+#else
+#define PolymorphicInlineCacheShift 6 // On 64 bit architectures, the least 6 significant bits of a DynamicTypePointer is 0
+#endif
+
 namespace Js
 {
     // Forwards


### PR DESCRIPTION
For type checks where we have a set of multiple equivalent types, create a property guard that is structured like a polymorphic inline cache, with an underlying array of types indexed by a hash of the type pointer.