### PR TITLE
RegExp syntax error for invalid Unicode codepoint fix #2753

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -257,6 +257,7 @@ namespace UnifiedRegex
 
             if (codePoint > 0x10FFFF)
             {
+                DeferredFailIfUnicode(JSERR_RegExpInvalidEscape);
                 return 0;
             }
             i++;

--- a/test/es6/unicode_escape_sequences.baseline
+++ b/test/es6/unicode_escape_sequences.baseline
@@ -1,6 +1,7 @@
 SyntaxError: Syntax error in regular expression
 SyntaxError: Invalid codepoint value in the escape sequence.
 SyntaxError: Invalid range in character set
+SyntaxError: Invalid regular expression: invalid escape in unicode pattern
 false
 false
 false

--- a/test/es6/unicode_escape_sequences.js
+++ b/test/es6/unicode_escape_sequences.js
@@ -81,6 +81,22 @@ try {
     e.echo();
 }
 
+try {
+    new RegExp(/\u{10FFFF}/,"u");
+}
+catch (e)
+{
+    print ("Unexpected error " + e);
+}
+
+try {
+    new RegExp(/\u{110000}/, "u");
+}
+catch (e)
+{
+    print (e);
+}
+
 // Shouldn't throw From here onwards.
 eval('var test = "\\u{0000}"');
 
@@ -169,11 +185,11 @@ invalidStrings.forEach(function (str){
 /a\u{}b/u.test("au\{\}b").echo();
 /a\u{1}b/u.test("a\u0001b").echo();
 /a\u{1.1}b/u.test("au\{1.1\}b").echo();
-/a\u{110000}b/u.test("a" + (Array(110001).join('u')) +"b").echo();
-/a\u{11FFFF}b/u.test("au\{11FFFF\}b").echo();
+/a\u{110000}b/.test("a" + (Array(110001).join('u')) +"b").echo();
+/a\u{11FFFF}b/.test("au\{11FFFF\}b").echo();
 /a\u{10FFFF}b/.test("a\uDBFF\uDFFFb").echo();
 
-/a\u{1000000}b/u.test("au\{1000000\}b").echo();
+/a\u{1000000}b/.test("au\{1000000\}b").echo();
 /a\u{1.1}b/u.test("a\u0001b").echo();
 /a\u{1}b/u.test("a\\ub").echo();
 /a\u{1}b/u.test("aub").echo();


### PR DESCRIPTION
Somewhat self-explanatory fix for https://github.com/Microsoft/ChakraCore/issues/2753

Note three of the currently tested RegExps in the unicode_escape_sequences.js test become invalid with this change - I verified that they were already invalid with other engines using eshost then updated them.

I also added an extra case to that file to explicitly test for this.