### PR TITLE
[WIP]Top function declarations in script/eval should conflict with global let/const

### DIFF
--- a/test/LetConst/funcDeclConflict.js
+++ b/test/LetConst/funcDeclConflict.js
@@ -1,0 +1,110 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+function f1_f(){};
+var f2_v = 123;
+function f3_f(){};
+var f4_v = 123;
+
+let f5_l = 123;
+const f6_c = 123;
+
+var tests = [
+    {
+        name: "Top level function in script does not conflict with another top level function",
+        body: function () {
+            WScript.LoadScript("function f1_f(){};");
+        }
+    },
+    {
+        name: "Top level function in script does not conflict with same-named var",
+        body: function () {
+            WScript.LoadScript("function f2_v(){};");
+        }
+    },
+    {
+        name: "Top level function in eval does not conflict with another top level function",
+        body: function () {
+           eval("function f3_f(){};");
+        }
+    },
+    {
+        name: "Top level function in eval does not conflict with same-named var",
+        body: function () {
+            eval("function f4_v(){};");
+        }
+    },
+    {
+        name: "Top level function in script conflicts with top level let",
+        body: function () {
+            assert.throws(()=>WScript.LoadScript("function f5_l(){};"),  ReferenceError, "Let/Const redeclaration");
+        }
+    },
+    {
+        name: "Top level function in script conflicts with top level const",
+        body: function () {
+            assert.throws(()=>WScript.LoadScript("function f6_c(){};"),  ReferenceError, "Let/Const redeclaration");
+        }
+    },
+    {
+        name: "Top level function in eval conflicts with top level let",
+        body: function () {
+            assert.throws(()=>eval("function f5_l(){};"),  ReferenceError, "Let/Const redeclaration");
+        }
+    },
+    {
+        name: "Top level function in eval conflicts with top level const",
+        body: function () {
+            assert.throws(()=>eval("function f6_c(){};"),  ReferenceError, "Let/Const redeclaration");
+        }
+    },
+    {
+        name: "Top level function in eval conflicts with top level const, in a class",        
+        body: function () {
+            class C1
+            {                
+                static M()
+                {
+                    assert.throws(()=>eval("function f6_c(){};"),  ReferenceError, "Let/Const redeclaration");
+                }
+            }
+
+            C1.M();
+        }
+    },
+    {
+        name: "Top level function in eval does not conflict with class level get",        
+        body: function () {
+            class C1
+            {                
+                get f7_l() {return "q";};
+
+                static M()
+                {
+                    eval("function f7_l(){};");
+                }
+            }
+
+            C1.M();
+        }
+    },
+]
+
+
+WScript.RegisterModuleSource("mod0.js", `
+    import 'mod1.js';
+    let qwer = 12;
+`);
+
+WScript.RegisterModuleSource("mod1.js",`
+    // no redeclaration here since modules are not introducing global names.
+    export function qwer(){};
+`);
+
+WScript.LoadScriptFile("mod0.js", "module");
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/LetConst/rlexe.xml
+++ b/test/LetConst/rlexe.xml
@@ -391,4 +391,10 @@
       <files>shadowedsetter.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>funcDeclConflict.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/es6/blockscope-functionbinding.baseline
+++ b/test/es6/blockscope-functionbinding.baseline
@@ -239,32 +239,34 @@ function glo_t19_j() { }
 const glo_t19_j
 function glo_t19_k() { }
 var glo_t19_k
-function glo_t19_l(one) { }
-function glo_t19_l(one) { }
-function glo_t19_l(one) { }
+ReferenceError: Let/Const redeclaration
+let glo_t19_l
+let glo_t19_l
 undefined
-function glo_t19_l(two) { }
-function glo_t19_l(two) { }
+ReferenceError: Let/Const redeclaration
+let declaredLater
+ReferenceError: Let/Const redeclaration
+inner let glo_t19_l
 outer let glo_t19_l
 undefined
-TypeError: Assignment to const
+ReferenceError: Let/Const redeclaration
 const glo_t19_m
 const glo_t19_m
 undefined
-TypeError: Assignment to const
+ReferenceError: Let/Const redeclaration
 inner const m
 const glo_t19_m
 undefined
-function glo_t19_m(three) { }
-function glo_t19_m(three) { }
+ReferenceError: Let/Const redeclaration
+inner let m
 const glo_t19_m
 undefined
 function glo_t19_n() { }
 function glo_t19_n() { }
 function glo_t19_n() { }
-ReferenceError: Use before declaration
+ReferenceError: Let/Const redeclaration
 let glo_t19_o
-TypeError: Assignment to const
+ReferenceError: Let/Const redeclaration
 const glo_t19_p
 function glo_t19_q() { }
 var glo_t19_q

--- a/test/es6/blockscope-functionbinding.js
+++ b/test/es6/blockscope-functionbinding.js
@@ -819,16 +819,22 @@ print(glo_t19_k);
 // dynamic via eval
 let glo_t19_l = 'let glo_t19_l';
 {
-    eval("function glo_t19_l(one) { }; print(glo_t19_l);");
+    try { eval("function glo_t19_l(one) { }; print(glo_t19_l);"); } catch (e) { print(e); }
     print(glo_t19_l);
 }
 print(glo_t19_l);
 print(this.glo_t19_l);
 
+{
+    try { eval("function declaredLater(one) { }; print(declaredLater);"); } catch (e) { print(e); }
+}
+let declaredLater = 'let declaredLater';
+print(declaredLater);
+
 glo_t19_l = 'outer let glo_t19_l';
 {
     let glo_t19_l = 'inner let glo_t19_l';
-    eval("function glo_t19_l(two) { }; print(glo_t19_l);");
+    try { eval("function glo_t19_l(two) { }; print(glo_t19_l);"); } catch (e) { print(e); }
     print(glo_t19_l);
 }
 print(glo_t19_l);


### PR DESCRIPTION
For the purpose of declaration conflicts
```js
function f(){}
```
is the same as 
```js
var f = function(){};
```
and likewise should conflict with global properties of the same name, including global let/const.
In a case if function declaration is added via a script, a dynamic check should be emitted.

Missing such check causes asserts when setting up callsite cache slots or incorrect behavior otherwise.

Fixes:#4953
Fixes:#3275