### PR TITLE
Update NativeTests.exe to use TestHooks, add UnicodeText tests from #4905

### DIFF
--- a/bin/ChakraCore/TestHooks.cpp
+++ b/bin/ChakraCore/TestHooks.cpp
@@ -6,6 +6,19 @@
 #include "Core/ConfigParser.h"
 #include "TestHooks.h"
 
+namespace PlatformAgnostic
+{
+namespace UnicodeText
+{
+namespace Internal
+{
+// this is in place of including PlatformAgnostic/UnicodeTextInternal.h, which has template
+// instantiations that upset Clang on macOS and Linux
+int LogicalStringCompareImpl(const char16* p1, const char16* p2);
+}
+}
+}
+
 #ifdef ENABLE_TEST_HOOKS
 
 HRESULT __stdcall SetConfigFlags(__in int argc, __in_ecount(argc) LPWSTR argv[], ICustomConfigFlags* customConfigFlags)
@@ -153,6 +166,7 @@ HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
         PrintConfigFlagsUsageString,
         SetAssertToConsoleFlag,
         SetEnableCheckMemoryLeakOutput,
+        PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl,
 
 #define FLAG(type, name, description, defaultValue, ...) FLAG_##type##(name)
 #define FLAGINCLUDE(name) \

--- a/bin/ChakraCore/TestHooks.h
+++ b/bin/ChakraCore/TestHooks.h
@@ -22,12 +22,14 @@ struct TestHooks
     typedef HRESULT(TESTHOOK_CALL *SetAssertToConsoleFlagPtr)(bool flag);
     typedef HRESULT(TESTHOOK_CALL *SetEnableCheckMemoryLeakOutputPtr)(bool flag);
     typedef void(TESTHOOK_CALL * NotifyUnhandledExceptionPtr)(PEXCEPTION_POINTERS exceptionInfo);
+    typedef int(TESTHOOK_CALL *LogicalStringCompareImpl)(const char16* p1, const char16* p2);
 
     SetConfigFlagsPtr pfSetConfigFlags;
     SetConfigFilePtr  pfSetConfigFile;
     PrintConfigFlagsUsageStringPtr pfPrintConfigFlagsUsageString;
     SetAssertToConsoleFlagPtr pfSetAssertToConsoleFlag;
     SetEnableCheckMemoryLeakOutputPtr pfSetEnableCheckMemoryLeakOutput;
+    LogicalStringCompareImpl pfLogicalCompareStringImpl;
 
 #define FLAG(type, name, description, defaultValue, ...) FLAG_##type##(name)
 #define FLAG_String(name) \

--- a/bin/NativeTests/FunctionExecutionTest.h
+++ b/bin/NativeTests/FunctionExecutionTest.h
@@ -18,6 +18,7 @@
 #define PHASE_FORCE(foo, bar) false
 #define NewSimpleJit 1
 #define FullJitPhase 2
+#undef DEFAULT_CONFIG_MinSimpleJitIterations
 #define DEFAULT_CONFIG_MinSimpleJitIterations 0
 
 namespace FunctionExecutionTest

--- a/bin/NativeTests/NativeTests.cpp
+++ b/bin/NativeTests/NativeTests.cpp
@@ -12,8 +12,18 @@
 #include "catch.hpp"
 #pragma warning(pop)
 
-// Use nativetests.exe -? to get all command line options
+TestHooks g_testHooks = { 0 };
+bool g_testHooksLoaded = false;
 
+extern "C"
+HRESULT __stdcall OnChakraCoreLoadedEntry(TestHooks& testHooks)
+{
+    g_testHooks = testHooks;
+    g_testHooksLoaded = true;
+    return S_OK;
+}
+
+// Use nativetests.exe -? to get all command line options
 int _cdecl main(int argc, char * const argv[])
 {
     return Catch::Session().run(argc, argv);

--- a/bin/NativeTests/NativeTests.def
+++ b/bin/NativeTests/NativeTests.def
@@ -1,0 +1,4 @@
+NAME NativeTests
+
+EXPORTS
+    OnChakraCoreLoadedEntry

--- a/bin/NativeTests/NativeTests.vcxproj
+++ b/bin/NativeTests/NativeTests.vcxproj
@@ -22,17 +22,23 @@
     <ClCompile>
       <AdditionalIncludeDirectories>
         $(ChakraCoreRootDirectory)Lib\Jsrt;
-        $(MSBuildThisFileDirectory);
         $(ChakraCoreRootDirectory)Lib\Common;
         $(ChakraCoreRootDirectory)bin\External;
+        $(ChakraCoreRootDirectory)bin\ChakraCore;
+        $(MSBuildThisFileDirectory);
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>
+        ENABLE_TEST_HOOKS=1;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <MinimalRebuild>false</MinimalRebuild>
       <!-- <CallingConvention Condition="'$(Platform)'=='Win32'">CDecl</CallingConvention> -->
     </ClCompile>
     <Link>
+      <ModuleDefinitionFile>NativeTests.def</ModuleDefinitionFile>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -51,6 +57,7 @@
     <ClCompile Include="MemoryPolicyTest.cpp" />
     <ClCompile Include="NativeTests.cpp" />
     <ClCompile Include="ThreadServiceTest.cpp" />
+    <ClCompile Include="UnicodeTextTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\lib\Common\Codex\Chakra.Common.Codex.vcxproj">

--- a/bin/NativeTests/UnicodeTextTests.cpp
+++ b/bin/NativeTests/UnicodeTextTests.cpp
@@ -1,0 +1,87 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "stdafx.h"
+#include "catch.hpp"
+
+namespace UnicodeTextTest
+{
+    void Test(const WCHAR* str1, const WCHAR* str2, int expected)
+    {
+        REQUIRE(g_testHooksLoaded);
+
+        // there are two tests, one to validate the expected value and validate the result of the call
+        int compareStringResult = CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE | SORT_DIGITSASNUMBERS, str1, -1, str2, -1);
+        CHECK(compareStringResult != 0);
+        compareStringResult = compareStringResult - CSTR_EQUAL;
+
+        int res = g_testHooks.pfLogicalCompareStringImpl(str1, str2);
+
+        //test to check that expected value passed is correct
+        REQUIRE(compareStringResult == expected);
+
+        //test to check that the result from call to LogicalStringCompareImpl is the expected value
+        REQUIRE(res == expected);
+    }
+
+    TEST_CASE("LogicalCompareString_BasicLatinLowercase", "[UnicodeText]")
+    {
+        Test(_u("a"), _u("a"), 0);
+        Test(_u("a"), _u("b"), -1);
+        Test(_u("b"), _u("a"), 1);
+    }
+
+    TEST_CASE("LogicalCompareString_BasicNumbers", "[UnicodeText]")
+    {
+        Test(_u("1"), _u("2"), -1);
+        Test(_u("2"), _u("1"), 1);
+        Test(_u("10"), _u("01"), 1);
+        Test(_u("01"), _u("10"), -1);
+        Test(_u("01"), _u("1"), -1);
+        Test(_u("1"), _u("01"), 1);
+    }
+
+    TEST_CASE("LogicalCompareString_Alphanumeric", "[UnicodeText]")
+    {
+        Test(_u("1a"), _u("a1"), -1);
+        Test(_u("aa1"), _u("a1"), 1);
+        Test(_u("a1"), _u("a1"), 0);
+        Test(_u("a1"), _u("b1"), -1);
+        Test(_u("b1"), _u("a1"), 1);
+        Test(_u("a1"), _u("a2"), -1);
+        Test(_u("a10"), _u("a2"), 1);
+        Test(_u("a2"), _u("a10"), -1);
+    }
+
+    TEST_CASE("LogicalCompareString_ComplexAlphanumeric", "[UnicodeText]")
+    {
+        Test(_u("A1"), _u("a1"), 0);
+        Test(_u("A1"), _u("b1"), -1);
+        Test(_u("B1"), _u("a1"), 1);
+        Test(_u("A1"), _u("a2"), -1);
+        Test(_u("A10"), _u("a2"), 1);
+        Test(_u("A2"), _u("a10"), -1);
+        Test(_u("123"), _u("456"), -1);
+        Test(_u("456"), _u("123"), 1);
+        Test(_u("abc123"), _u("def123"), -1);
+        Test(_u("abc123"), _u("abc123"), 0);
+        Test(_u("abc123"), _u("abc0123"), 1);
+        Test(_u("abc123"), _u("abc124"), -1);
+        Test(_u("abc124"), _u("abc123"), 1);
+        Test(_u("abc123def"), _u("abc123def"), 0);
+        Test(_u("abc123def"), _u("abc123eef"), -1);
+        Test(_u("abc123eef"), _u("abc123def"), 1);
+        Test(_u("abc1def"), _u("abc10def"), -1);
+        Test(_u("abc1def1"), _u("abc1def12"), -1);
+        Test(_u("2string"), _u("3string"), -1);
+        Test(_u("20string"), _u("3string"), 1);
+        Test(_u("20string"), _u("st2ring"), -1);
+        Test(_u("st3ring"), _u("st2ring"), 1);
+        Test(_u("2String"), _u("3string"), -1);
+        Test(_u("20String"), _u("3string"), 1);
+        Test(_u("20sTRing"), _u("st2ring"), -1);
+        Test(_u("st3rING"), _u("st2riNG"), 1);
+    }
+}

--- a/bin/NativeTests/stdafx.h
+++ b/bin/NativeTests/stdafx.h
@@ -44,3 +44,7 @@ if (!(exp)) \
 #include "Core/CommonTypedefs.h"
 
 #include <FileLoadHelpers.h>
+#include "TestHooks.h"
+
+extern TestHooks g_testHooks;
+extern bool g_testHooksLoaded;


### PR DESCRIPTION
@aileronajay did the original work for this PR, but adding TestHooks to NativeTests.exe was required and a bit too involved for a first-time contributor. Hopefully this will allow more direct native unit testing in the future.