### PR TITLE
Add support for traced large recycledvisited objects.

### DIFF
--- a/bin/GCStress/GCStress.cpp
+++ b/bin/GCStress/GCStress.cpp
@@ -230,8 +230,10 @@ void BuildObjectCreationTable()
     objectCreationTable.AddWeightedEntry(&ScannedObject<1001, 50000>::New, 10);
     objectCreationTable.AddWeightedEntry(&BarrierObject<1001, 50000>::New, 2);
     objectCreationTable.AddWeightedEntry(&FinalizedObject<1001, 50000>::New, 2);
-//    objectCreationTable.AddWeightedEntry(&TrackedObject<1001, 50000>::New, 2);    // Large tracked objects are not supported
-//    objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<1001, 50000>::New, 2); // Large recycler visited objects are not supported
+    //objectCreationTable.AddWeightedEntry(&TrackedObject<1001, 50000>::New, 2);    // Large tracked objects are not supported
+#ifdef RECYCLER_VISITED_HOST
+    objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<1001, 50000>::New, 2);
+#endif
 }
 
 void BuildOperationTable()

--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -28,7 +28,7 @@ enum ErrorReason
     Fatal_TTDAbort = 20,
     Fatal_Failed_API_Result = 21,
     Fatal_OutOfMemory = 22,
-    Fatal_RecyclerVisitedHost_LargeHeapBlock = 23,
+    // Unused = 23,
     Fatal_JsBuiltIn_Error = 24,
 };
 

--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -166,6 +166,7 @@ HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * obj
     if (attributes & TrackBit)
     {
         FinalizableObject * trackedObject = (FinalizableObject *)objectAddress;
+
 #if ENABLE_PARTIAL_GC
         if (!markContext->GetRecycler()->inPartialCollectMode)
 #endif

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -129,6 +129,12 @@ public:
 
     template <bool doSpecialMark>
     void Mark(void* objectAddress, MarkContext * markContext);
+
+#ifdef RECYCLER_VISITED_HOST
+    template <bool doSpecialMark, typename Fn>
+    bool UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * objectAddress, size_t objectSize, unsigned char attributes, Fn fn);
+#endif
+
     virtual byte* GetRealAddressFromInterior(void* interiorAddress) override;
     bool TestObjectMarkedBit(void* objectAddress) override;
     void SetObjectMarkedBit(void* objectAddress) override;


### PR DESCRIPTION
This change adds support for traced large recycledvisited objects. Tracked LargeHeapBlocks is applicable just for RecycledVisitedObjects so it is safe to make the assumption that a tracked LargeHeapBlock is a RecycledVisitedObject.
Adding tracked largeheapblocks support needs special behavior in:
- HeapBlock::UpdateAttributesOfMarkedObjects - where we have to precisely track the large RecycledVisitedObject
- LargeHeapBlock::RescanMultiPage\RescanOnePage - where if the page / or one of the object's page is dirty we have to track the object.