### PR TITLE
check for CrossSite object at toPrimitive call, not when caching

### DIFF
--- a/lib/Runtime/Language/PrototypeChainCache.cpp
+++ b/lib/Runtime/Language/PrototypeChainCache.cpp
@@ -296,13 +296,7 @@ NoSpecialPropertyCache::IsDefaultHandledSpecialProperty(_In_ JavascriptString* p
 bool
 NoSpecialPropertyCache::IsCached(_In_ RecyclableObject* prototype)
 {
-    if (!prototype->GetType()->ThisAndPrototypesHaveNoSpecialProperties())
-    {
-        return false;
-    }
-    DynamicObject* dynamicObject = JavascriptOperators::TryFromVar<DynamicObject>(prototype);
-
-    return dynamicObject && !dynamicObject->IsCrossSiteObject();
+    return prototype->GetType()->ThisAndPrototypesHaveNoSpecialProperties();
 }
 
 void
@@ -314,13 +308,7 @@ NoSpecialPropertyCache::Cache(_In_ Type* type)
 bool
 NoSpecialPropertyCache::CheckObject(_In_ RecyclableObject* object)
 {
-    if (object->HasAnySpecialProperties() || object->HasDeferredTypeHandler())
-    {
-        return false;
-    }
-    DynamicObject* dynamicObject = JavascriptOperators::TryFromVar<DynamicObject>(object);
-
-    return dynamicObject && !dynamicObject->IsCrossSiteObject();
+    return !object->HasAnySpecialProperties() && !object->HasDeferredTypeHandler();
 }
 
 #if DBG

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -402,7 +402,9 @@ namespace Js
         Var aValue = nullptr;
         if (JavascriptOperators::CheckIfObjectAndProtoChainHasNoSpecialProperties(this))
         {
-            if (this->GetPrototype() == this->GetLibrary()->GetObjectPrototype())
+            if (this->GetPrototype() == requestContext->GetLibrary()->GetObjectPrototype() &&
+                !this->IsCrossSiteObject() &&
+                !requestContext->GetLibrary()->GetObjectPrototype()->IsCrossSiteObject())
             {
                 aValue = (propertyId == PropertyIds::valueOf)
                     ? requestContext->GetLibrary()->GetObjectValueOfFunction()


### PR DESCRIPTION
I was trying to keep cross-site objects out of the NoSpecialPropertyCache, but that isn't really possible, since objects can convert to CrossSiteObjects.

Instead, just check if the object is a CrossSite object before using the cache when doing ToPrimitive.

OS: 17008372