### PR TITLE
Restore SuperRestrictionState after methods fix #5030

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4297,6 +4297,7 @@ ParseNodeBin * Parser::ParseMemberGetSet(OpCode nop, LPCOLESTR* ppNameHint)
         flags |= fFncOneArg;
     }
 
+    AutoParsingSuperRestrictionStateRestorer restorer(this);
     this->m_parsingSuperRestrictionState = ParsingSuperRestrictionState_SuperPropertyAllowed;
     ParseNodeFnc * pnodeFnc = ParseFncDeclNoCheckScope<buildAST>(flags, *ppNameHint,
         /*needsPIDOnRCurlyScan*/ false, /*resetParsingSuperRestrictionState*/ false);
@@ -4609,6 +4610,8 @@ ParseNodePtr Parser::ParseMemberList(LPCOLESTR pNameHint, uint32* pNameHintLengt
 
             // Rewind to the PID and parse a function expression.
             this->GetScanner()->SeekTo(atPid);
+
+            AutoParsingSuperRestrictionStateRestorer restorer(this);
             this->m_parsingSuperRestrictionState = ParsingSuperRestrictionState_SuperPropertyAllowed;
             ParseNodeFnc * pnodeFnc = ParseFncDeclNoCheckScope<buildAST>(fncDeclFlags | (isAsyncMethod ? fFncAsync : fFncNoFlgs), pFullNameHint,
                 /*needsPIDOnRCurlyScan*/ false, /*resetParsingSuperRestrictionState*/ false);

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -487,6 +487,39 @@ var tests = [
     }
   },
   {
+      name: "Super used after object literal in constructor",
+      body: function () {
+        class emptyLiteral extends Object{
+          constructor(){
+            const bar = {};
+            super();
+          }
+        }
+        class methodLiteral extends Object{
+          constructor(){
+            const bar = { c () {}};
+            super();
+          }
+        }
+        class functionLiteral extends Object{
+          constructor(){
+            const bar = { c : function () {}};
+            super();
+          }
+        }
+        class getSetLiteral extends Object{
+          constructor(){
+            const bar = { hid : 5, get c () {return hid;}, set c (x) { hid = x; }};
+            super();
+          }
+        }
+        assert.doesNotThrow(()=>{new emptyLiteral()}, "Super should be valid in constructor after literal.");
+        assert.doesNotThrow(()=>{new methodLiteral()}, "Super should be valid in constructor after literal.");
+        assert.doesNotThrow(()=>{new functionLiteral()}, "Super should be valid in constructor after literal.");
+        assert.doesNotThrow(()=>{new getSetLiteral()}, "Super should be valid in constructor after literal.");
+      }
+  },
+  {
     name: "Super used outside the class declaration function",
     body: function () {
       class A1


### PR DESCRIPTION
Wanted to learn more about how parsing works so thought I'd have a look at #5030

And unless I've got this wrong the fix is very simple.

When parsing a class member or a function the SuperRestrictionState is restored using AutoParsingSuperRestrictionStateRestorer after parsing the member or function is complete.

This was not being done for getters/setters or methods within object literals. This had not previously been noticed as it's only relevant for getters/setters/methods that are declared in an object literal inside a class constructor before super is called - a somewhat niche case I assume.