### PR TITLE
RL: Stop on first error seen

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -322,7 +322,7 @@ BOOL FVerbose;
 BOOL FQuiet;
 BOOL FNoWarn;
 BOOL FTest;
-BOOL FStonOnError = FALSE;
+BOOL FStopOnError = FALSE;
 BOOL GStopDueToError = FALSE;
 BOOL FLow;
 BOOL FNoDelete;
@@ -2853,7 +2853,7 @@ ParseArg(
          }
          if (!_stricmp(&arg[1], "stoponerror"))
          {
-             FStonOnError = TRUE;
+             FStopOnError = TRUE;
              break;
          }
          if (!_stricmp(&arg[1], "exeflags")) {
@@ -3591,7 +3591,7 @@ GetTestInfoFromNode
             {
                // Validate the timeout string now to fail early so we don't run any tests when there is an error.
                if (!IsTimeoutStringValid(testInfo->data[i])) {
-                  CFG_ERROR_EX(fileName, node->LineNumber, 
+                  CFG_ERROR_EX(fileName, node->LineNumber,
                      "Invalid timeout specified. Cannot parse or too large.\n", NULL);
                   childNode->Dump();
                   return FALSE;
@@ -5083,7 +5083,7 @@ main(int argc, char *argv[])
       if (status == PCS_ERROR)
       {
           exit(1);
-      } 
+      }
       else
       {
 

--- a/bin/rl/rl.h
+++ b/bin/rl/rl.h
@@ -871,7 +871,7 @@ extern BOOL FParallel;
 extern BOOL FSyncEnumDirs;
 extern BOOL FNogpfnt;
 extern BOOL FTest;
-extern BOOL FStonOnError;
+extern BOOL FStopOnError;
 extern BOOL FAppendTestNameToExtraCCFlags;
 extern BOOL FNoProgramOutput;
 extern BOOL FOnlyAssertOutput;

--- a/bin/rl/rl.h
+++ b/bin/rl/rl.h
@@ -871,6 +871,7 @@ extern BOOL FParallel;
 extern BOOL FSyncEnumDirs;
 extern BOOL FNogpfnt;
 extern BOOL FTest;
+extern BOOL FStonOnError;
 extern BOOL FAppendTestNameToExtraCCFlags;
 extern BOOL FNoProgramOutput;
 extern BOOL FOnlyAssertOutput;
@@ -882,6 +883,7 @@ extern const char *OptFlags[MAXOPTIONS + 1], *PogoOptFlags[MAXOPTIONS + 1];
 extern BOOL FDebug;
 #endif
 
+extern BOOL GStopDueToError;
 extern BOOL bThreadStop;
 
 extern BOOL FSyncImmediate;

--- a/bin/rl/rlrun.cpp
+++ b/bin/rl/rlrun.cpp
@@ -524,7 +524,7 @@ int
         }
 
         //
-        // If the test is a JS test and we've passed in a custom config file, 
+        // If the test is a JS test and we've passed in a custom config file,
         // ignore all of the other flags and just pass the config file in
         //
         if (kind == TK_JSCRIPT && pTestVariant->testInfo.data[TIK_CUSTOM_CONFIG_FILE] != nullptr)
@@ -598,7 +598,7 @@ logFailure:
         if (fDumpOutputFile) {
             DumpFileToLog(full);
         }
-        if (FStonOnError)
+        if (FStopOnError)
         {
             GStopDueToError = TRUE;
         }

--- a/bin/rl/rlrun.cpp
+++ b/bin/rl/rlrun.cpp
@@ -42,8 +42,6 @@ __declspec(thread) char EnvFlags[MAX_ENV_LEN];
 // either be protected by synchronization or use thread-local storage.
 //
 
-// currently, none
-
 
 LOCAL void __cdecl
     RunCleanUp()
@@ -599,6 +597,10 @@ logFailure:
         LogOut("    %s", cmdbuf);
         if (fDumpOutputFile) {
             DumpFileToLog(full);
+        }
+        if (FStonOnError)
+        {
+            GStopDueToError = TRUE;
         }
     }
 
@@ -1333,7 +1335,7 @@ int
 
     // Check to see if all of the files exist.
 
-    for (StringList * pFile = pTest->files; pFile != NULL; pFile = pFile->next)
+    for (StringList * pFile = pTest->files; pFile != NULL && !GStopDueToError; pFile = pFile->next)
     {
         // Get a pointer to the filename sans path, if present.
 

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -58,6 +58,8 @@ goto :main
   echo Options:
   echo.
   echo   -dirs dirname  Run only the specified directory
+  echo   -rebase        Create .rebase file on baseline comparision failure
+  echo   -stoponerror   Stop testing after first failure (will finish current execution)
   :: TODO Add more usage help
 
   goto :eof
@@ -177,6 +179,7 @@ goto :main
   :: TODO Consider removing -drt and exclude_drt in some reasonable manner
   if /i "%1" == "-drt"              set _drt=1& set _NOTTAGS=%_NOTTAGS% -nottags:exclude_drt&   goto :ArgOk
   if /i "%1" == "-rebase"           set _rebase=-rebase&                                        goto :ArgOk
+  if /i "%1" == "-stoponerror"      set _stoponerror=-stoponerror&                              goto :ArgOk
   if /i "%1" == "-rundebug"         set _RUNDEBUG=1&                                            goto :ArgOk
   :: TODO Figure out best way to specify build arch for tests that are excluded to specific archs
   if /i "%1" == "-platform"         set _buildArch=%2&                                          goto :ArgOkShift2
@@ -273,6 +276,7 @@ goto :main
   set _DIRTAGS=
   set _drt=
   set _rebase=
+  set _stoponerror=
   set _ExtraVariants=
   set _dynamicprofilecache=-dynamicprofilecache:profile.dpl
   set _dynamicprofileinput=-dynamicprofileinput:profile.dpl
@@ -381,6 +385,15 @@ goto :main
 :: Run one variant
 :: ============================================================================
 :RunOneVariant
+  if exist %_logsRoot%\%_BuildArch%_%_BuildType%\%_TESTCONFIG% (
+    rd /q /s %_logsRoot%\%_BuildArch%_%_BuildType%\%_TESTCONFIG%
+  )
+
+  if %_HadFailures% NEQ 0 (
+    if "%_stoponerror%" NEQ "" (
+      goto :eof
+    )
+  )
 
   if "%_BuildType%" == "test" (
     rem bytecode layout switches not available in test build
@@ -521,6 +534,7 @@ goto :main
   set _rlArgs=%_rlArgs% -exe
   set _rlArgs=%_rlArgs% %EXTRA_RL_FLAGS%
   set _rlArgs=%_rlArgs% %_rebase%
+  set _rlArgs=%_rlArgs% %_stoponerror%
 
   set REGRESS=%CD%
 


### PR DESCRIPTION
Add an option to rl to stop testing upon seeing an error.
This is great when working on a feature and you just want to find a failing unit test quick to iterate faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5039)
<!-- Reviewable:end -->
