### PR TITLE
fix bug where Object.assign opt was skipping object arrays

### DIFF
--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -833,6 +833,22 @@ namespace Js
             }
             return false;
         }
+        if (this->HasObjectArray())
+        {
+            if (PHASE_TRACE1(ObjectCopyPhase))
+            {
+                Output::Print(_u("ObjectCopy: Can't copy: to obj has object array\n"));
+            }
+            return false;
+        }
+        if (from->GetOffsetOfInlineSlots() != this->GetOffsetOfInlineSlots())
+        {
+            if (PHASE_TRACE1(ObjectCopyPhase))
+            {
+                Output::Print(_u("ObjectCopy: Can't copy: Don't have same inline slot offset\n"));
+            }
+            return false;
+        }
         if (PathTypeHandlerBase::FromTypeHandler(from->GetTypeHandler())->HasAccessors())
         {
             if (PHASE_TRACE1(ObjectCopyPhase))
@@ -845,7 +861,7 @@ namespace Js
         {
             if (PHASE_TRACE1(ObjectCopyPhase))
             {
-                Output::Print(_u("ObjectCopy: Can't copy: Protoytypes don't match\n"));
+                Output::Print(_u("ObjectCopy: Can't copy: Prototypes don't match\n"));
             }
             return false;
         }
@@ -879,6 +895,10 @@ namespace Js
 
     bool DynamicObject::TryCopy(DynamicObject* from)
     {
+        if (PHASE_OFF1(ObjectCopyPhase))
+        {
+            return false;
+        }
         // Validate that objects are compatible
         if (!this->IsCompatibleForCopy(from))
         {
@@ -913,7 +933,12 @@ namespace Js
 
             CopyArray(thisInlineSlots, inlineSlotCapacity, fromInlineSlots, inlineSlotCapacity);
         }
-
+        if (from->HasObjectArray())
+        {
+            Assert(!this->HasObjectArray());
+            Assert(!this->IsObjectHeaderInlinedTypeHandler());
+            this->SetObjectArray(JavascriptArray::DeepCopyInstance(from->GetObjectArrayOrFlagsAsArray()));
+        }
         if (PHASE_TRACE1(ObjectCopyPhase))
         {
             Output::Print(_u("ObjectCopy succeeded\n"));

--- a/test/Object/assign.baseline
+++ b/test/Object/assign.baseline
@@ -6,5 +6,6 @@ ObjectCopy: Can't copy: Prototypes don't match
 ObjectCopy: Can't copy: from obj has non-enumerable properties
 ObjectCopy succeeded
 ObjectCopy succeeded
+ObjectCopy: Can't copy: to obj has object array
 ObjectCopy: Can't copy: Don't have PathTypeHandler
 pass

--- a/test/Object/assign.baseline
+++ b/test/Object/assign.baseline
@@ -2,7 +2,9 @@ ObjectCopy succeeded
 ObjectCopy: Can't copy: Don't have PathTypeHandler
 ObjectCopy: Can't copy: type handler has accessors
 ObjectCopy: Can't copy: type handler has accessors
-ObjectCopy: Can't copy: Protoytypes don't match
+ObjectCopy: Can't copy: Prototypes don't match
 ObjectCopy: Can't copy: from obj has non-enumerable properties
 ObjectCopy succeeded
+ObjectCopy succeeded
+ObjectCopy: Can't copy: Don't have PathTypeHandler
 pass

--- a/test/Object/assign.js
+++ b/test/Object/assign.js
@@ -105,6 +105,37 @@ var tests = [
             assert.areEqual(newObj.b, "asdf");
             assert.areEqual(newObj.a, orig.a);
         }
+    },
+    {
+        name: "has object array",
+        body: function ()
+        {
+            let orig = {};
+            orig.a = 1;
+            orig[0] = 2;
+            
+            let newObj = Object.assign({}, orig);
+            assert.areEqual(newObj.a, orig.a);
+            assert.areEqual(newObj[0], orig[0]);
+        }
+    },
+    {
+        name: "has object array with non-enumerable prop",
+        body: function ()
+        {
+            let orig = {};
+            orig.a = 1;
+            orig[0] = 2;
+            
+            Object.defineProperty(orig, '1', {
+                value: "3", enumerable: false
+              });
+            
+            let newObj = Object.assign({}, orig);
+            assert.areEqual(newObj.a, orig.a);
+            assert.areEqual(newObj[0], orig[0]);
+            assert.areEqual(newObj[1], undefined);
+        }
     }
 ];
 

--- a/test/Object/assign.js
+++ b/test/Object/assign.js
@@ -120,6 +120,20 @@ var tests = [
         }
     },
     {
+        name: "target has object array",
+        body: function ()
+        {
+            let orig = {};
+            orig.a = 1;
+            orig[0] = 2;
+            let newObj = {};
+            newObj[0] = 3;
+            Object.assign(newObj, orig);
+            assert.areEqual(newObj.a, orig.a);
+            assert.areEqual(newObj[0], orig[0]);
+        }
+    },
+    {
         name: "has object array with non-enumerable prop",
         body: function ()
         {


### PR DESCRIPTION
We should copy object array if source object has one