### PR TITLE
Add -only flag to UnitTestFramework to run subset of tests

### DIFF
--- a/test/UnitTestFramework/UnitTestFramework.js
+++ b/test/UnitTestFramework/UnitTestFramework.js
@@ -167,9 +167,15 @@ var testRunner = function testRunner() {
                 _verbose = options.verbose;
             }
 
+            const onlyFlag = WScript.Arguments.filter((arg) => arg.substring(0, 6) === "-only:")
+            let only = undefined;
+            if (onlyFlag.length === 1) {
+                only = onlyFlag[0].substring(6).split(",");
+            }
+
             for (var i in testsToRun) {
                 var isRunnable = typeof testsToRun[i] === objectType;
-                if (isRunnable) {
+                if (isRunnable && (only === undefined || only.includes(i) || only.includes(testsToRun[i].name))) {
                     this.runTest(i, testsToRun[i].name, testsToRun[i].body);
                 }
             }


### PR DESCRIPTION
This lets you run a test with `-args -only:testID,testName,testID2 -endargs` to specify a subset of tests. I have found this useful while adding a new test to an existing large test file.