### PR TITLE
Making -off:fieldPRE work

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -4522,7 +4522,7 @@ BasicBlock::MergePredBlocksValueMaps(GlobOpt* globOpt)
         Assert(blockData.hoistableFields == nullptr);
         blockData.InitBlockData(globOpt, globOpt->func);
     }
-    else if (blockData.hoistableFields)
+    else if (blockData.hoistableFields && this->globOptData.liveFields)
     {
         Assert(globOpt->TrackHoistableFields());
         blockData.hoistableFields->And(this->globOptData.liveFields);

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -157,6 +157,7 @@ GlobOpt::DoFieldCopyProp(Loop * loop) const
 bool
 GlobOpt::DoFieldHoisting(Loop *loop)
 {
+#if 0
     if (loop == nullptr)
     {
         return false;
@@ -186,6 +187,9 @@ GlobOpt::DoFieldHoisting(Loop *loop)
     }
 
     return loop->CanDoFieldHoist();
+#endif
+
+    return false;
 }
 
 bool


### PR DESCRIPTION
Adding a null-check and disabling field hoisting even when forced as the code for field hoisting simply doesn't work now. 