### PR TITLE
Reduce EntryPointInfo size by 16 bytes on 64-bit by ifdef out unused fields

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1029,6 +1029,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         workItem->GetEntryPoint()->SetHasJittedStackClosure();
     }
 
+#if !FLOATVAR
     if (jitWriteData.numberPageSegments)
     {
         if (jitWriteData.numberPageSegments->pageAddress == 0)
@@ -1042,6 +1043,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
             epInfo->SetNumberPageSegment(jitWriteData.numberPageSegments);
         }
     }
+#endif
 
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -10,8 +10,10 @@
 struct PageMemoryData;
 #endif
 
+#if !FLOATVAR
 class CodeGenNumberThreadAllocator;
 struct XProcNumberPageSegmentManager;
+#endif
 
 namespace Memory
 {
@@ -488,8 +490,10 @@ template<> inline PageAllocatorBaseCommon::AllocatorType PageAllocatorBaseCommon
 template<typename TVirtualAlloc, typename TSegment, typename TPageSegment>
 class PageAllocatorBase: public PageAllocatorBaseCommon
 {
+#if !FLOATVAR
     friend class ::CodeGenNumberThreadAllocator;
     friend struct ::XProcNumberPageSegmentManager;
+#endif
     // Allowing recycler to report external memory allocation.
     friend class Recycler;
 public:

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -681,8 +681,10 @@ class Recycler
     friend class ActiveScriptProfilerHeapEnum;
 #endif
     friend class ScriptEngineBase;  // This is for disabling GC for certain Host operations.
+#if !FLOATVAR
     friend class ::CodeGenNumberThreadAllocator;
     friend struct ::XProcNumberPageSegmentManager;
+#endif
 public:
     static const uint ConcurrentThreadStackSize = 300000;
     static const bool FakeZeroLengthArray = true;

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -659,6 +659,7 @@ typedef struct FunctionJITTimeDataIDL
     CHAKRA_PTR weakFuncRef;
 } FunctionJITTimeDataIDL;
 
+#if !FLOATVAR
 typedef struct XProcNumberPageSegment
 {
     struct XProcNumberPageSegment* nextSegment;
@@ -670,6 +671,7 @@ typedef struct XProcNumberPageSegment
     CHAKRA_PTR allocEndAddress;
     CHAKRA_PTR pageSegment;
 } XProcNumberPageSegment;
+#endif
 
 typedef struct PolymorphicInlineCacheIDL
 {
@@ -704,7 +706,9 @@ typedef struct CodeGenWorkItemIDL
     unsigned int inlineeInfoCount;
     unsigned int symIdToValueTypeMapCount;
     X64_PAD4(1)
+#if !FLOATVAR
     XProcNumberPageSegment * xProcNumberPageSegment;
+#endif
 
     PolymorphicInlineCacheInfoIDL * selfInfo;
 
@@ -852,7 +856,9 @@ typedef struct JITOutputIDL
     NativeDataFixupTable* nativeDataFixupTable;
     NativeDataBuffer* buffer;
     EquivalentTypeGuardOffsets* equivalentTypeGuardOffsets;
+#if !FLOATVAR
     XProcNumberPageSegment* numberPageSegments;
+#endif
     __int64 startTime;
 } JITOutputIDL;
 

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -829,6 +829,8 @@ ServerRemoteCodeGen(
             profiler->Initialize(pageAllocator, nullptr);
         }
 #endif
+
+#if !FLOATVAR
         if (jitWorkItem->GetWorkItemData()->xProcNumberPageSegment)
         {
             jitData->numberPageSegments = (XProcNumberPageSegment*)midl_user_allocate(sizeof(XProcNumberPageSegment));
@@ -840,6 +842,7 @@ ServerRemoteCodeGen(
 
             memcpy_s(jitData->numberPageSegments, sizeof(XProcNumberPageSegment), jitWorkItem->GetWorkItemData()->xProcNumberPageSegment, sizeof(XProcNumberPageSegment));
         }
+#endif
 
         Func::Codegen(
             &jitArena,

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -8968,8 +8968,9 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
             DeleteNativeCodeData(this->inProcJITNaticeCodedata);
             this->inProcJITNaticeCodedata = nullptr;
+#if !FLOATVAR
             this->numberChunks = nullptr;
-
+#endif
             if (this->nativeDataBuffer)
             {
                 NativeDataBuffer* buffer = (NativeDataBuffer*)(this->nativeDataBuffer - offsetof(NativeDataBuffer, data));

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -341,12 +341,14 @@ namespace Js
 
         Field(NativeCodeData *) inProcJITNaticeCodedata;
         FieldNoBarrier(char*) nativeDataBuffer;
+#if !FLOATVAR
         union
         {
             Field(Field(JavascriptNumber*)*) numberArray;
             Field(CodeGenNumberChunk*) numberChunks;
         };
         Field(XProcNumberPageSegment*) numberPageSegments;
+#endif
 
         FieldNoBarrier(SmallSpanSequence *) nativeThrowSpanSequence;
         typedef JsUtil::BaseHashSet<RecyclerWeakReference<FunctionBody>*, Recycler, PowerOf2SizePolicy> WeakFuncRefSet;
@@ -456,6 +458,7 @@ namespace Js
         char** GetNativeDataBufferRef() { return &nativeDataBuffer; }
         char* GetNativeDataBuffer() { return nativeDataBuffer; }
         void SetInProcJITNativeCodeData(NativeCodeData* nativeCodeData) { inProcJITNaticeCodedata = nativeCodeData; }
+#if !FLOATVAR
         void SetNumberChunks(CodeGenNumberChunk* chunks)
         {
             Assert(numberPageSegments == nullptr);
@@ -472,6 +475,7 @@ namespace Js
             numberPageSegments = segments;
         }
 #endif
+#endif
 
     protected:
         EntryPointInfo(Js::JavascriptMethod method, JavascriptLibrary* library, void* validationCookie, ThreadContext* context = nullptr, bool isLoopBody = false) :
@@ -480,7 +484,10 @@ namespace Js
             nativeThrowSpanSequence(nullptr), workItem(nullptr), weakFuncRefSet(nullptr),
             jitTransferData(nullptr), sharedPropertyGuards(nullptr), propertyGuardCount(0), propertyGuardWeakRefs(nullptr),
             equivalentTypeCacheCount(0), equivalentTypeCaches(nullptr), constructorCaches(nullptr), state(NotScheduled), inProcJITNaticeCodedata(nullptr),
-            numberChunks(nullptr), numberPageSegments(nullptr), polymorphicInlineCacheInfo(nullptr), runtimeTypeRefs(nullptr),
+#if !FLOATVAR
+            numberChunks(nullptr), numberPageSegments(nullptr), 
+#endif
+            polymorphicInlineCacheInfo(nullptr), runtimeTypeRefs(nullptr),
             isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr), inlineeFrameMap(nullptr),
 #if PDATA_ENABLED
             xdataInfo(nullptr),


### PR DESCRIPTION
We don't need to allocate numbers on 64-bit.
