### PR TITLE
Reduced memory usage by management of keeping alive property record referenced by function body.

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -58,7 +58,6 @@ namespace Js
     class JavascriptNumber;
 #pragma endregion
 
-    typedef JsUtil::BaseDictionary<Js::PropertyId, const Js::PropertyRecord*, RecyclerNonLeafAllocator, PowerOf2SizePolicy, DefaultComparer, JsUtil::SimpleDictionaryEntry> PropertyRecordList;
     typedef JsUtil::BaseHashSet<void*, Recycler, PowerOf2SizePolicy> TypeRefSet;
 
      // Definition of scopes such as With, Catch and Block which will be used further in the debugger for additional look-ups.
@@ -1669,7 +1668,7 @@ namespace Js
         };
 
     protected:
-        ParseableFunctionInfo(JavascriptMethod method, int nestedFunctionCount, LocalFunctionId functionId, Utf8SourceInfo* sourceInfo, ScriptContext* scriptContext, uint functionNumber, const char16* displayName, uint m_displayNameLength, uint displayShortNameOffset, FunctionInfo::Attributes attributes, Js::PropertyRecordList* propertyRecordList, FunctionBodyFlags flags);
+        ParseableFunctionInfo(JavascriptMethod method, int nestedFunctionCount, LocalFunctionId functionId, Utf8SourceInfo* sourceInfo, ScriptContext* scriptContext, uint functionNumber, const char16* displayName, uint m_displayNameLength, uint displayShortNameOffset, FunctionInfo::Attributes attributes, FunctionBodyFlags flags);
 
         ParseableFunctionInfo(ParseableFunctionInfo * proxy);
 
@@ -1702,7 +1701,7 @@ namespace Js
         uint GetNestedCount() const { return nestedArray == nullptr ? 0 : nestedArray->nestedCount; }
 
     public:
-        static ParseableFunctionInfo* New(ScriptContext* scriptContext, int nestedFunctionCount, LocalFunctionId functionId, Utf8SourceInfo* utf8SourceInfo, const char16* displayName, uint m_displayNameLength, uint displayShortNameOffset, Js::PropertyRecordList* propertyRecordList, FunctionInfo::Attributes attributes, FunctionBodyFlags flags);
+        static ParseableFunctionInfo* New(ScriptContext* scriptContext, int nestedFunctionCount, LocalFunctionId functionId, Utf8SourceInfo* utf8SourceInfo, const char16* displayName, uint m_displayNameLength, uint displayShortNameOffset, FunctionInfo::Attributes attributes, FunctionBodyFlags flags);
         static ParseableFunctionInfo* NewDeferredFunctionFromFunctionBody(FunctionBody *functionBody);
 
         DEFINE_VTABLE_CTOR_NO_REGISTER(ParseableFunctionInfo, FunctionProxy);
@@ -1815,7 +1814,6 @@ namespace Js
         ScopeInfo* GetScopeInfo() const { return static_cast<ScopeInfo*>(this->GetAuxPtr(AuxPointerType::ScopeInfo)); }
         void SetScopeInfo(ScopeInfo* scopeInfo) {  this->SetAuxPtr(AuxPointerType::ScopeInfo, scopeInfo); }
         PropertyId GetOrAddPropertyIdTracked(JsUtil::CharacterBuffer<WCHAR> const& propName);
-        bool IsTrackedPropertyId(PropertyId pid);
 
         void SetScopeSlotArraySizes(uint scopeSlotCount, uint scopeSlotCountForParamScope)
         {
@@ -1828,17 +1826,6 @@ namespace Js
         {
             SetScopeSlotArraySizes(scopeSlotCount, scopeSlotCountForParamScope);
             this->SetAuxPtr(AuxPointerType::PropertyIdsForScopeSlotArray, propertyIdsForScopeSlotArray);
-        }
-
-        Js::PropertyRecordList* GetBoundPropertyRecords() { return this->m_boundPropertyRecords; }
-        void SetBoundPropertyRecords(Js::PropertyRecordList* boundPropertyRecords)
-        {
-            Assert(this->m_boundPropertyRecords == nullptr);
-            this->m_boundPropertyRecords = boundPropertyRecords;
-        }
-        void ClearBoundPropertyRecords()
-        {
-            this->m_boundPropertyRecords = nullptr;
         }
 
         void SetInitialDefaultEntryPoint();
@@ -2039,7 +2026,6 @@ namespace Js
         FieldWithBarrier(ULONG) m_columnNumber;
         FieldWithBarrier(const char16*) m_displayName;  // Optional name
         FieldWithBarrier(uint) m_displayNameLength;
-        FieldWithBarrier(PropertyRecordList*) m_boundPropertyRecords;
         FieldWithBarrier(NestedArray*) nestedArray;
 
     public:
@@ -2439,7 +2425,7 @@ namespace Js
 #endif
 
         FunctionBody(ScriptContext* scriptContext, const char16* displayName, uint displayNameLength, uint displayShortNameOffset, uint nestedCount, Utf8SourceInfo* sourceInfo,
-            uint uFunctionNumber, uint uScriptId, Js::LocalFunctionId functionId, Js::PropertyRecordList* propRecordList, FunctionInfo::Attributes attributes, FunctionBodyFlags flags
+            uint uFunctionNumber, uint uScriptId, Js::LocalFunctionId functionId, FunctionInfo::Attributes attributes, FunctionBodyFlags flags
 #ifdef PERF_COUNTERS
             , bool isDeserializedFunction = false
 #endif
@@ -2460,7 +2446,7 @@ namespace Js
 
     public:
         FunctionBody(ByteCodeCache* cache, Utf8SourceInfo* sourceInfo, ScriptContext* scriptContext):
-            ParseableFunctionInfo((JavascriptMethod) nullptr, 0, (LocalFunctionId) 0, sourceInfo, scriptContext, 0, nullptr, 0, 0, FunctionInfo::Attributes::None, nullptr, Flags_None)
+            ParseableFunctionInfo((JavascriptMethod) nullptr, 0, (LocalFunctionId) 0, sourceInfo, scriptContext, 0, nullptr, 0, 0, FunctionInfo::Attributes::None, Flags_None)
         {
             // Dummy constructor- does nothing
             // Must be stack allocated
@@ -2468,21 +2454,21 @@ namespace Js
         }
 
         static FunctionBody * NewFromRecycler(Js::ScriptContext * scriptContext, const char16 * displayName, uint displayNameLength, uint displayShortNameOffset, uint nestedCount,
-            Utf8SourceInfo* sourceInfo, uint uScriptId, Js::LocalFunctionId functionId, Js::PropertyRecordList* boundPropertyRecords, FunctionInfo::Attributes attributes
+            Utf8SourceInfo* sourceInfo, uint uScriptId, Js::LocalFunctionId functionId, FunctionInfo::Attributes attributes
             , FunctionBodyFlags flags
 #ifdef PERF_COUNTERS
             , bool isDeserializedFunction
 #endif
             );
         static FunctionBody * NewFromRecycler(Js::ScriptContext * scriptContext, const char16 * displayName, uint displayNameLength, uint displayShortNameOffset, uint nestedCount,
-            Utf8SourceInfo* sourceInfo, uint uFunctionNumber, uint uScriptId, Js::LocalFunctionId functionId, Js::PropertyRecordList* boundPropertyRecords, FunctionInfo::Attributes attributes
+            Utf8SourceInfo* sourceInfo, uint uFunctionNumber, uint uScriptId, Js::LocalFunctionId functionId, FunctionInfo::Attributes attributes
             , FunctionBodyFlags flags
 #ifdef PERF_COUNTERS
             , bool isDeserializedFunction
 #endif
             );
 
-        static FunctionBody * NewFromParseableFunctionInfo(ParseableFunctionInfo * info, PropertyRecordList *boundPropertyRecords);
+        static FunctionBody * NewFromParseableFunctionInfo(ParseableFunctionInfo * info);
 
         FunctionEntryPointInfo * GetEntryPointInfo(int index) const;
         FunctionEntryPointInfo * TryGetEntryPointInfo(int index) const;

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -43,7 +43,8 @@ namespace Js
         debugModeSourceLength(0),
         m_isInDebugMode(false),
 #endif
-        callerUtf8SourceInfo(nullptr)
+        callerUtf8SourceInfo(nullptr),
+        boundedPropertyRecordHashSet(scriptContext->GetRecycler())
 #ifndef NTBUILD
         ,sourceRef(scriptSource)
 #endif

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -11,6 +11,7 @@ namespace Js
         typedef JsUtil::LeafValueDictionary<Js::LocalFunctionId, Js::FunctionBody*>::Type FunctionBodyDictionary;
         typedef JsUtil::LeafValueDictionary<Js::LocalFunctionId, Js::ParseableFunctionInfo*>::Type DeferredFunctionsDictionary;
         typedef JsUtil::List<Js::FunctionInfo *, Recycler> FunctionInfoList;
+        typedef JsUtil::BaseHashSet<Js::PropertyRecord const *, Recycler>  BoundedPropertyRecordHashSet;
 
         friend class RemoteUtf8SourceInfo;
         friend class ScriptContext;
@@ -367,6 +368,7 @@ namespace Js
         void SetCallerUtf8SourceInfo(Utf8SourceInfo* callerUtf8SourceInfo);
         Utf8SourceInfo* GetCallerUtf8SourceInfo() const;
 
+        BoundedPropertyRecordHashSet * GetBoundedPropertyRecordHashSet() { return &this->boundedPropertyRecordHashSet; }
 #ifdef NTBUILD
         bool GetDebugDocumentName(BSTR * sourceName);
 #endif
@@ -380,6 +382,7 @@ namespace Js
         Field(FunctionBodyDictionary*) functionBodyDictionary;
         Field(DeferredFunctionsDictionary*) m_deferredFunctionsDictionary;
         Field(FunctionInfoList*) topLevelFunctionInfoList;
+        Field(BoundedPropertyRecordHashSet) boundedPropertyRecordHashSet;
 
 #ifdef ENABLE_SCRIPT_DEBUGGING
         Field(DebugDocument*) m_debugDocument;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -14,7 +14,6 @@ private:
     Js::ScriptContext* scriptContext;
     ArenaAllocator *alloc;
     uint32 flags;
-    Js::PropertyRecordList* propertyRecords;
     SList<FuncInfo*> *funcInfoStack;
     ParseNodeBlock *currentBlock;
     ParseNode *currentTopStatement;
@@ -125,17 +124,6 @@ public:
 
     ArenaAllocator *GetAllocator() {
         return alloc;
-    }
-
-    Js::PropertyRecordList* EnsurePropertyRecordList()
-    {
-        if (this->propertyRecords == nullptr)
-        {
-            Recycler* recycler = this->scriptContext->GetRecycler();
-            this->propertyRecords = RecyclerNew(recycler, Js::PropertyRecordList, recycler);
-        }
-
-        return this->propertyRecords;
     }
 
     bool IsEvalWithNoParentScopeInfo()

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3722,7 +3722,7 @@ public:
                 sourceInfo,
                 functionNumber,
                 sourceInfo->GetSrcInfo()->sourceContextInfo->sourceContextId,
-                firstFunctionId + functionId, nullptr, (FunctionInfo::Attributes)attributes,
+                firstFunctionId + functionId, (FunctionInfo::Attributes)attributes,
                 Js::FunctionBody::FunctionBodyFlags::Flags_None  // bytecode serializer will initialize
 #ifdef PERF_COUNTERS
                 , (deferDeserializeFunctionInfo != nullptr)
@@ -3738,7 +3738,7 @@ public:
         }
         else
         {
-            *function = ParseableFunctionInfo::New(this->scriptContext, nestedCount, firstFunctionId + functionId, utf8SourceInfo, displayName, displayNameLength, displayShortNameOffset, nullptr, (FunctionInfo::Attributes)attributes,
+            *function = ParseableFunctionInfo::New(this->scriptContext, nestedCount, firstFunctionId + functionId, utf8SourceInfo, displayName, displayNameLength, displayShortNameOffset, (FunctionInfo::Attributes)attributes,
                         Js::FunctionBody::FunctionBodyFlags::Flags_None);
         }
 

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -409,7 +409,6 @@ void WasmModuleGenerator::GenerateFunctionHeader(uint32 index)
         m_sourceInfo,
         m_sourceInfo->GetSrcInfo()->sourceContextInfo->sourceContextId,
         wasmInfo->GetNumber(),
-        nullptr,
         Js::FunctionInfo::Attributes::ErrorOnNew,
         Js::FunctionBody::Flags_None
 #ifdef PERF_COUNTERS


### PR DESCRIPTION
Change from hash dicitionary to hash set (save memory by not storing the propertyId key, which the property record has already)
Also move the hash set to Utf8SourceInfo so function from the same script block can share.

Memory reduced (after page loaded):
  MS Teams     ~5MB
  OWA          ~2MB
  PowerBI      ~2MB
  Azure Portal ~1.5MB
