### PR TITLE
Adding additional logging to native tests in CI

### DIFF
--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -104,7 +104,7 @@ set _error=0
   echo -- jenkins.testone.cmd ^>^> Running native tests... this can take some time
   if not exist %_LogDir%\ mkdir %_LogDir%
   set _LogFile=%_LogDir%\nativetests.log
-  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogFile% 2>&1
+  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% -d yes > %_LogFile% 2>&1
   echo -- jenkins.testone.cmd ^>^> Running native tests... DONE!
 
   if "%_error%" NEQ "0" (

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -146,7 +146,7 @@ set _HadFailures=0
   echo -- runcitests.cmd ^>^> Running native tests... this can take some time
   if not exist %_LogDir%\ mkdir %_LogDir%
   set _LogFile=%_TestDir%\logs\%1_%2\nativetests.log
-  call :do %_TestDir%\runnativetests.cmd -%1%2 > %_LogFile% 2>&1
+  call :do %_TestDir%\runnativetests.cmd -%1%2 -d yes > %_LogFile% 2>&1
   echo -- runcitests.cmd ^>^> Running native tests... DONE!
 
   if "%_error%" NEQ "0" (


### PR DESCRIPTION
We've been seeing some sporadic failures that are hard to reproduce.
This causes the CI to run nativetests in a way that prints the duration
of tests, so we can see where things break.