### PR TITLE
Breakpoint APIs don't verify current context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ build_*.log
 build_*.wrn
 Build/ipch/
 Build/swum-cache.txt
+Build/VCBuild.Lite/
 Build/VCBuild.NoJIT/
 Build/VCBuild.SWB/
 Build/VCBuild/

--- a/bin/NativeTests/JsDiagApiTest.cpp
+++ b/bin/NativeTests/JsDiagApiTest.cpp
@@ -1,0 +1,90 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "stdafx.h"
+#include "catch.hpp"
+#include <process.h>
+
+#pragma warning(disable:4100) // unreferenced formal parameter
+#pragma warning(disable:6387) // suppressing preFAST which raises warning for passing null to the JsRT APIs
+#pragma warning(disable:6262) // CATCH is using stack variables to report errors, suppressing the preFAST warning.
+
+namespace JsDiagApiTest
+{
+    static void CALLBACK DebugEventCallback(JsDiagDebugEvent debugEvent, JsValueRef eventData, void* callbackState)
+    {
+    }
+
+    bool TestSetup(JsRuntimeHandle *runtime)
+    {
+        JsValueRef context = JS_INVALID_REFERENCE;
+        JsValueRef setContext = JS_INVALID_REFERENCE;
+
+        // Create runtime, context and set current context
+        REQUIRE(JsCreateRuntime(JsRuntimeAttributeNone, nullptr, runtime) == JsNoError);
+        REQUIRE(JsCreateContext(*runtime, &context) == JsNoError);
+        REQUIRE(JsSetCurrentContext(context) == JsNoError);
+        REQUIRE(((JsGetCurrentContext(&setContext) == JsNoError) || setContext == context));
+
+        // Enable debugging
+        REQUIRE(JsDiagStartDebugging(*runtime, JsDiagApiTest::DebugEventCallback, nullptr) == JsNoError);
+
+        return true;
+    }
+
+    bool TestCleanup(JsRuntimeHandle runtime)
+    {
+        if (runtime != nullptr)
+        {
+            // Disable debugging
+            JsDiagStopDebugging(runtime, nullptr);
+
+            JsSetCurrentContext(nullptr);
+            JsDisposeRuntime(runtime);
+        }
+        return true;
+    }
+
+    template <class Handler>
+    void WithSetup(Handler handler)
+    {
+        JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
+        if (!TestSetup(&runtime))
+        {
+            REQUIRE(false);
+            return;
+        }
+
+        handler(runtime);
+
+        TestCleanup(runtime);
+    }
+
+#ifndef BUILD_WITHOUT_SCRIPT_DEBUG
+    void BreakpointsContextTest(JsRuntimeHandle runtime)
+    {
+        JsContextRef context = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetCurrentContext(&context) == JsNoError);
+
+        // Verify no errors with a context set
+        JsValueRef scriptsArray = JS_INVALID_REFERENCE;
+        REQUIRE(JsDiagGetScripts(&scriptsArray) == JsNoError);
+
+        // Verify the APIs return an error when no current context set
+        JsSetCurrentContext(nullptr);
+        CHECK(JsDiagGetScripts(&scriptsArray) == JsErrorNoCurrentContext);
+
+        JsValueRef breakpoint = JS_INVALID_REFERENCE;
+        CHECK(JsDiagSetBreakpoint(0, 0, 0, &breakpoint) == JsErrorNoCurrentContext);
+
+        CHECK(JsDiagRemoveBreakpoint(0) == JsErrorNoCurrentContext);
+    }
+
+    TEST_CASE("JsDiagApiTest_BreakpointsContextTest", "[JsDiagApiTest]")
+    {
+        JsDiagApiTest::WithSetup(JsDiagApiTest::BreakpointsContextTest);
+    }
+#endif // BUILD_WITHOUT_SCRIPT_DEBUG
+}

--- a/bin/NativeTests/NativeTests.vcxproj
+++ b/bin/NativeTests/NativeTests.vcxproj
@@ -27,7 +27,6 @@
         $(ChakraCoreRootDirectory)bin\External;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <MinimalRebuild>false</MinimalRebuild>
@@ -47,6 +46,7 @@
     <ClCompile Include="CodexTests.cpp" />
     <ClCompile Include="FileLoadHelpers.cpp" />
     <ClCompile Include="FunctionExecutionTest.cpp" />
+    <ClCompile Include="JsDiagApiTest.cpp" />
     <ClCompile Include="JsRTApiTest.cpp" />
     <ClCompile Include="MemoryPolicyTest.cpp" />
     <ClCompile Include="NativeTests.cpp" />


### PR DESCRIPTION
The JsDiag APIs for breakpoints use the `GlobalAPIWrapper_NoRecord`
wrapper which does not validate that there's a current context. During
the function they then get the current context and attempt to use it
without checking whether it's `nullptr`.

The fix is to use `ContextAPIWrapper_NoRecord` instead which will
ensure that there's a current context.
