### PR TITLE
Let substrings get property string pointers too

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -798,12 +798,18 @@ ThreadContext::FindPropertyRecord(Js::JavascriptString *pstName, Js::PropertyRec
         return;
     }
 
-    LPCWSTR psz = pstName->GetSz();
-    FindPropertyRecord(psz, pstName->GetLength(), propertyRecord);
+    // GetString is not guaranteed to be null-terminated, but we explicitly pass length to the next step
+    LPCWCH propertyName = pstName->GetString();
+    FindPropertyRecord(propertyName, pstName->GetLength(), propertyRecord);
+
+    if (*propertyRecord)
+    {
+        pstName->CachePropertyRecord(*propertyRecord);
+    }
 }
 
 void
-ThreadContext::FindPropertyRecord(__in LPCWSTR propertyName, __in int propertyNameLength, Js::PropertyRecord const ** propertyRecord)
+ThreadContext::FindPropertyRecord(__in LPCWCH propertyName, __in int propertyNameLength, Js::PropertyRecord const ** propertyRecord)
 {
     EnterPinnedScope((volatile void **)propertyRecord);
     *propertyRecord = FindPropertyRecord(propertyName, propertyNameLength);

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1104,7 +1104,7 @@ private:
     template <bool locked> Js::PropertyRecord const * GetPropertyNameImpl(Js::PropertyId propertyId);
 public:
     void FindPropertyRecord(Js::JavascriptString *pstName, Js::PropertyRecord const ** propertyRecord);
-    void FindPropertyRecord(__in LPCWSTR propertyName, __in int propertyNameLength, Js::PropertyRecord const ** propertyRecord);
+    void FindPropertyRecord(__in LPCWCH propertyName, __in int propertyNameLength, Js::PropertyRecord const ** propertyRecord);
     const Js::PropertyRecord * FindPropertyRecord(const char16 * propertyName, int propertyNameLength);
 
     JsUtil::List<const RecyclerWeakReference<Js::PropertyRecord const>*>* FindPropertyIdNoCase(Js::ScriptContext * scriptContext, LPCWSTR propertyName, int propertyNameLength);

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -134,17 +134,10 @@ namespace Js
             return this->propertyString;
         }
 
-        ScriptContext * scriptContext = this->GetScriptContext();
+        Js::PropertyRecord const * propertyRecord = nullptr;
+        GetPropertyRecordImpl(&propertyRecord);
 
-        if (this->propertyRecord == nullptr)
-        {
-            Js::PropertyRecord const * propertyRecord = nullptr;
-            scriptContext->GetOrAddPropertyRecord(this->GetSz(), static_cast<int>(this->GetLength()),
-                &propertyRecord);
-            this->propertyRecord = propertyRecord;
-        }
-
-        this->propertyString = scriptContext->GetPropertyString(propertyRecord->GetPropertyId());
+        this->propertyString = this->GetScriptContext()->GetPropertyString(propertyRecord->GetPropertyId());
         return this->propertyString;
     }
 
@@ -173,27 +166,53 @@ namespace Js
 
     void LiteralStringWithPropertyStringPtr::GetPropertyRecord(_Out_ PropertyRecord const** propRecord, bool dontLookupFromDictionary)
     {
-        *propRecord = nullptr;
-        ScriptContext * scriptContext = this->GetScriptContext();
+        return GetPropertyRecordImpl(propRecord, dontLookupFromDictionary);
+    }
 
-        if (this->propertyRecord == nullptr)
+    void LiteralStringWithPropertyStringPtr::GetPropertyRecordImpl(_Out_ PropertyRecord const** propRecord, bool dontLookupFromDictionary)
+    {
+        if (this->propertyRecord)
         {
-            if (!dontLookupFromDictionary)
-            {
-                // cache PropertyRecord
-                Js::PropertyRecord const * localPropertyRecord;
-                scriptContext->GetOrAddPropertyRecord(this->GetSz(),
-                    static_cast<int>(this->GetLength()),
-                    &localPropertyRecord);
-                this->propertyRecord = localPropertyRecord;
-            }
-            else
-            {
-                return;
-            }
+            *propRecord = this->propertyRecord;
+            return;
         }
 
-        *propRecord = this->propertyRecord;
+        __super::GetPropertyRecord(propRecord, dontLookupFromDictionary);
+
+        if (*propRecord)
+        {
+            CachePropertyRecordImpl(*propRecord);
+        }
+    }
+
+    void LiteralStringWithPropertyStringPtr::CachePropertyRecord(_In_ PropertyRecord const* propertyRecord)
+    {
+        return CachePropertyRecordImpl(propertyRecord);
+    }
+
+    void LiteralStringWithPropertyStringPtr::CachePropertyRecordImpl(_In_ PropertyRecord const* propertyRecord)
+    {
+        this->propertyRecord = propertyRecord;
+        Assert(this->GetLength() == propertyRecord->GetLength());
+
+        // PropertyRecord has its own copy of the string content, so we can drop the reference to our old copy.
+        // This is okay because the PropertyRecord pointer will keep the data alive.
+        this->SetBuffer(propertyRecord->GetBuffer());
+    }
+
+    RecyclableObject* LiteralStringWithPropertyStringPtr::CloneToScriptContext(ScriptContext* requestContext)
+    {
+        if (this->propertyRecord == nullptr)
+        {
+            // Without a property record, we can safely multi-reference the underlying buffer. Assertions in
+            // the constructor of LiteralString will verify this.
+            return __super::CloneToScriptContext(requestContext);
+        }
+
+        // We have a property record, so go ahead and make this be a property string in the request context.
+        // The strings in both contexts will refer to the same property record, since property records are
+        // shared among all script contexts on a thead.
+        return requestContext->GetPropertyString(this->propertyRecord);
     }
 
     /////////////////////// ConcatStringBase //////////////////////////

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -6,6 +6,11 @@
 
 namespace Js
 {
+    // Upon construction, LiteralStringWithPropertyStringPtr is guaranteed to point to a recycler-allocated
+    // buffer, so it passes the LiteralString assertions. However, upon receiving a property record pointer,
+    // this object will update to point to the copy of its data in that property record, meaning that using
+    // this class is just like using PropertyString: you can't take a reference to the underlying buffer via
+    // GetSz or GetString, drop the reference to the owning string, and expect the buffer to stay alive.
     class LiteralStringWithPropertyStringPtr : public LiteralString
     {
     private:
@@ -14,6 +19,11 @@ namespace Js
 
     public:
         virtual void GetPropertyRecord(_Out_ PropertyRecord const** propRecord, bool dontLookupFromDictionary = false) override;
+        void GetPropertyRecordImpl(_Out_ PropertyRecord const** propRecord, bool dontLookupFromDictionary = false);
+        virtual void CachePropertyRecord(_In_ PropertyRecord const* propertyRecord) override;
+        void CachePropertyRecordImpl(_In_ PropertyRecord const* propertyRecord);
+
+        virtual RecyclableObject* CloneToScriptContext(ScriptContext* requestContext) override;
 
         bool HasPropertyRecord() const { return propertyRecord != nullptr; }
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -235,6 +235,11 @@ namespace Js
         GetScriptContext()->GetOrAddPropertyRecord(GetString(), GetLength(), propertyRecord);
     }
 
+    void JavascriptString::CachePropertyRecord(_In_ PropertyRecord const* propertyRecord)
+    {
+        // Base string doesn't have enough room to keep this value, so do nothing
+    }
+
     JavascriptString* JavascriptString::FromVar(Var aValue)
     {
         AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -51,6 +51,7 @@ namespace Js
         char16 GetItem(charcount_t index);
 
         virtual void GetPropertyRecord(_Out_ PropertyRecord const** propertyRecord, bool dontLookupFromDictionary = false);
+        virtual void CachePropertyRecord(_In_ PropertyRecord const* propertyRecord);
 
         _Ret_range_(m_charLength, m_charLength) charcount_t GetLength() const;
 

--- a/lib/Runtime/Library/SubString.cpp
+++ b/lib/Runtime/Library/SubString.cpp
@@ -96,4 +96,12 @@ namespace Js
         return false;
     }
 
+    void SubString::CachePropertyRecord(_In_ PropertyRecord const* propertyRecord)
+    {
+        // Now that the property record owns a copy of the string data, transform
+        // this instance into a more efficient type.
+        this->originalFullStringReference = nullptr;
+        LiteralStringWithPropertyStringPtr* converted = LiteralStringWithPropertyStringPtr::ConvertString(this);
+        converted->CachePropertyRecordImpl(propertyRecord);
+    }
 }

--- a/lib/Runtime/Library/SubString.h
+++ b/lib/Runtime/Library/SubString.h
@@ -9,6 +9,7 @@ namespace Js
     class SubString sealed : public JavascriptString
     {
         Field(void const *) originalFullStringReference;          // Only here to prevent recycler to free this buffer.
+        Field(void const *) unused; // Recycler would allocate this space anyway due to bucket sizing, so make it explicit
 
         SubString(void const * originalFullStringReference, const char16* subString, charcount_t length, ScriptContext *scriptContext);
 
@@ -22,5 +23,6 @@ namespace Js
         virtual void const * GetOriginalStringReference() override;
         virtual size_t GetAllocatedByteCount() const override;
         virtual bool IsSubstring() const override;
+        virtual void CachePropertyRecord(_In_ PropertyRecord const* propertyRecord) override;
     };
 }


### PR DESCRIPTION
We currently have a system to promote CompoundString or ConcatString instances to become LiteralStringWithPropertyStringPointer. This applies the same transformation to SubString. Also:

- Call GetString instead of GetSz in ThreadContext::FindPropertyRecord to avoid an extra copy
- Actively cache the result in ThreadContext::FindPropertyRecord to avoid a separate lookup later
- Update the buffer in LiteralStringWithPropertyStringPtr to point to the copy of the string allocated alongside the PropertyRecord, which could free up some memory in some cases

With this change, I see about 8% speedup on the Ember test in Speedometer, because Ember uses many strings that begin their lifetime as substrings.

We are still emitting a helper call to OP_GetElementI for the particular function I was focusing on improving (in its entirety, `function(e){return this.data[e]}`) because our profile data happens to be all cache misses, so we have no indication that we would eventually get a bunch of local-cache hits. At least we can now use the fast path in the helper, which seems to make a big difference.