### PR TITLE
[MSFT 17327799] Don't preserve accessor and non-default attributes when PathTypeHandler::SetAttributesHelper is called from SetPropertyWithAttributes.

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -355,11 +355,11 @@ namespace Js
         return found;
     }
 
-    BOOL PathTypeHandlerBase::SetAttributesHelper(DynamicObject* instance, PropertyId propertyId, PropertyIndex propertyIndex, ObjectSlotAttributes * instanceAttributes, ObjectSlotAttributes propertyAttributes, bool isInit)
+    BOOL PathTypeHandlerBase::SetAttributesHelper(DynamicObject* instance, PropertyId propertyId, PropertyIndex propertyIndex, ObjectSlotAttributes * instanceAttributes, ObjectSlotAttributes propertyAttributes, bool setAllAttributes)
     {
         if (instanceAttributes)
         {
-            if (!isInit)
+            if (!setAllAttributes)
             {
                 // Preserve non-default bits like accessors
                 propertyAttributes = (ObjectSlotAttributes)(propertyAttributes | (instanceAttributes[propertyIndex] & ~ObjectSlotAttr_PropertyAttributesMask));
@@ -755,7 +755,7 @@ namespace Js
 
             if (setAttributes)
             {
-                this->SetAttributesHelper(instance, propertyId, index, GetAttributeArray(), attr, isInit);
+                this->SetAttributesHelper(instance, propertyId, index, GetAttributeArray(), attr, true);
             }
             else if (isInit)
             {

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -192,7 +192,7 @@ namespace Js
         BOOL FindNextPropertyHelper(ScriptContext* scriptContext, ObjectSlotAttributes * objectAttributes, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info);
         BOOL SetAttributesAtIndex(DynamicObject* instance, PropertyId propertyId, PropertyIndex index, PropertyAttributes attributes);
-        BOOL SetAttributesHelper(DynamicObject* instance, PropertyId propertyId, PropertyIndex propertyIndex, ObjectSlotAttributes * instanceAttributes, ObjectSlotAttributes propertyAttributes, bool isInit = false);
+        BOOL SetAttributesHelper(DynamicObject* instance, PropertyId propertyId, PropertyIndex propertyIndex, ObjectSlotAttributes * instanceAttributes, ObjectSlotAttributes propertyAttributes, bool setAllAttributes = false);
         BOOL SetAccessorsHelper(DynamicObject* instance, PropertyId propertyId, ObjectSlotAttributes * attributes, PathTypeSetterSlotIndex * setters, Var getter, Var setter, PropertyOperationFlags flags);
 
 #if ENABLE_NATIVE_CODEGEN

--- a/test/es5/defineProperty.baseline
+++ b/test/es5/defineProperty.baseline
@@ -66,6 +66,8 @@ PASSED
 PASSED
 *** Running test #34 (test34): Convert accessor to a data property for non-extensible object (WIN8 bug 463559)
 PASSED
-*** Running test #35 (test_last_01): 8.12.9.3: define property for non-extensible object, check that it throws TypeError
+*** Running test #35 (test35): Set and unset getter property on a non-configurable property
 PASSED
-Summary of tests: total executed: 35; passed: 35; failed: 0
+*** Running test #36 (test_last_01): 8.12.9.3: define property for non-extensible object, check that it throws TypeError
+PASSED
+Summary of tests: total executed: 36; passed: 36; failed: 0

--- a/test/es5/defineProperty.js
+++ b/test/es5/defineProperty.js
@@ -530,6 +530,20 @@ var tests = {
     }
   },
 
+  test35: {
+    name: "Set and unset getter property on a non-configurable property",
+    body: function() {
+        function function_1(a,b,c)
+        {
+            return 1;
+        }
+
+        function_1.__defineGetter__("length",function(){});
+        Object.defineProperty(function_1,"length", { value:(0x0a000030/2) });
+        assert.areEqual(function_1.length, 0x0a000030/2, "value in defineProperty not assigned");
+    }
+  },
+
   // Note: this test irreversibly changes the dummy object (that's important when dummy object is document/window), 
   //       it should in the very end.
   test_last_01: {


### PR DESCRIPTION
We preserve accessor-ness on a property when it is set via a normal store but shouldn't do that when it's set via defineProperty or some other means that can actually change accessor-ness.