### PR TITLE
Make cached source string a weak ref

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1454,7 +1454,7 @@ namespace Js
 #endif
         CopyDeferParseField(scopeSlotArraySize);
         CopyDeferParseField(paramScopeSlotArraySize);
-        other->SetCachedSourceString(this->GetCachedSourceString());
+        other->SetCachedSourceStringWeakRef(this->GetCachedSourceStringWeakRef());
         CopyDeferParseField(m_isAsmjsMode);
         CopyDeferParseField(m_isAsmJsFunction);
         CopyDeferParseField(deferredPrototypeType);
@@ -1895,6 +1895,41 @@ namespace Js
         // TODO: Disabling the creation of deferred stubs for now. We need to rethink the design again as the current behavior
         // is not usable with precise capturing.
         this->SetDeferredStubs(nullptr);
+    }
+
+    JavascriptString * ParseableFunctionInfo::GetCachedSourceString()
+    {
+        RecyclerWeakReference<JavascriptString> * weakRef = GetCachedSourceStringWeakRef();
+        if (weakRef)
+        {
+            JavascriptString * string = weakRef->Get();
+            if (string)
+            {
+                return string;
+            }
+            this->SetAuxPtr(AuxPointerType::CachedSourceString, nullptr);
+        }
+        return nullptr;
+    }
+
+    void ParseableFunctionInfo::SetCachedSourceString(JavascriptString * sourceString)
+    {
+        Assert(this->GetCachedSourceString() == nullptr);
+        if (sourceString)
+        {
+            this->SetCachedSourceStringWeakRef(this->GetRecycler()->CreateWeakReferenceHandle(sourceString));
+        }
+    }
+
+    RecyclerWeakReference<JavascriptString> * ParseableFunctionInfo::GetCachedSourceStringWeakRef()
+    {
+        return static_cast<RecyclerWeakReference<JavascriptString> *>(this->GetAuxPtr(AuxPointerType::CachedSourceString));
+    }
+
+    void ParseableFunctionInfo::SetCachedSourceStringWeakRef(RecyclerWeakReference<JavascriptString> * weakRef)
+    {
+        Assert(this->GetCachedSourceString() == nullptr);
+        this->SetAuxPtr(AuxPointerType::CachedSourceString, weakRef);
     }
 
     FunctionInfoArray ParseableFunctionInfo::GetNestedFuncArray()

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1940,12 +1940,9 @@ namespace Js
 
         virtual void Finalize(bool isShutdown) override;
 
-        Var GetCachedSourceString() { return this->GetAuxPtr(AuxPointerType::CachedSourceString); }
-        void SetCachedSourceString(Var sourceString)
-        {
-            Assert(this->GetCachedSourceString() == nullptr);
-            this->SetAuxPtr(AuxPointerType::CachedSourceString, sourceString);
-        }
+        JavascriptString * GetCachedSourceString();
+
+        void SetCachedSourceString(JavascriptString * sourceString);
 
         FunctionInfoArray GetNestedFuncArray();
         FunctionInfo* GetNestedFunc(uint index);
@@ -1958,7 +1955,9 @@ namespace Js
         void SetDeferredStubs(DeferredFunctionStub *stub) { this->SetAuxPtr(AuxPointerType::DeferredStubs, stub); }
         void RegisterFuncToDiag(ScriptContext * scriptContext, char16 const * pszTitle);
         bool IsES6ModuleCode() const;
-
+    private:
+        RecyclerWeakReference<JavascriptString> * GetCachedSourceStringWeakRef();
+        void SetCachedSourceStringWeakRef(RecyclerWeakReference<JavascriptString> * weakRef);
     protected:
         static HRESULT MapDeferredReparseError(HRESULT& hrParse, const CompileScriptException& se);
 

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1790,7 +1790,7 @@ LABEL1:
         this->GetDynamicType()->SetEntryPoint(method);
     }
 
-    Var JavascriptFunction::EnsureSourceString()
+    JavascriptString * JavascriptFunction::EnsureSourceString()
     {
         return this->GetLibrary()->GetFunctionDisplayString();
     }

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -177,7 +177,7 @@ namespace Js
 
         BOOL IsScriptFunction() const;
         virtual Var GetSourceString() const { return nullptr; }
-        virtual Var EnsureSourceString();
+        virtual JavascriptString * EnsureSourceString();
         virtual BOOL IsExternalFunction() { return FALSE; }
         virtual BOOL IsWinRTFunction() { return FALSE; }
         BOOL IsStrictMode() const;

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -248,7 +248,7 @@ namespace Js
         return scriptFunction->GetSourceString();
     }
 
-    Var JavascriptGeneratorFunction::EnsureSourceString()
+    JavascriptString * JavascriptGeneratorFunction::EnsureSourceString()
     {
         return scriptFunction->EnsureSourceString();
     }

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -55,7 +55,7 @@ namespace Js
         virtual bool IsAnonymousFunction() const override;
 
         virtual Var GetSourceString() const;
-        virtual Var EnsureSourceString();
+        virtual JavascriptString * EnsureSourceString();
 
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/RuntimeFunction.cpp
+++ b/lib/Runtime/Library/RuntimeFunction.cpp
@@ -18,14 +18,16 @@ namespace Js
         : JavascriptFunction(type, functionInfo, cache), functionNameId(nullptr)
     {}
 
-    Var
+    JavascriptString *
     RuntimeFunction::EnsureSourceString()
     {
         JavascriptLibrary* library = this->GetLibrary();
         ScriptContext * scriptContext = library->GetScriptContext();
+        JavascriptString * retStr = nullptr;
         if (this->functionNameId == nullptr)
         {
-            this->functionNameId = library->GetFunctionDisplayString();
+            retStr = library->GetFunctionDisplayString();
+            this->functionNameId = retStr;
         }
         else
         {
@@ -41,11 +43,15 @@ namespace Js
 
                 // This has a side-effect where any other code (such as debugger) that uses functionNameId value will now get the value like "function foo() { native code }"
                 // instead of just "foo". Alternative ways will need to be devised; if it's not desirable to use this full display name value in those cases.
-                this->functionNameId = GetNativeFunctionDisplayString(scriptContext, scriptContext->GetPropertyString(TaggedInt::ToInt32(this->functionNameId)));
+                 retStr = GetNativeFunctionDisplayString(scriptContext, scriptContext->GetPropertyString(TaggedInt::ToInt32(this->functionNameId)));
+                 this->functionNameId = retStr;
+            }
+            else
+            {
+                retStr = JavascriptString::FromVar(this->functionNameId);
             }
         }
-        Assert(JavascriptString::Is(this->functionNameId));
-        return this->functionNameId;
+        return retStr;
     }
 
     void

--- a/lib/Runtime/Library/RuntimeFunction.h
+++ b/lib/Runtime/Library/RuntimeFunction.h
@@ -27,7 +27,7 @@ namespace Js
         // See RuntimeFunction::EnsureSourceString() for details.
         Field(Var) functionNameId;
         virtual Var GetSourceString() const { return functionNameId; }
-        virtual Var EnsureSourceString();
+        virtual JavascriptString * EnsureSourceString();
 
 #if ENABLE_TTD
     public:

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -328,11 +328,11 @@ namespace Js
         return this->GetFunctionProxy()->EnsureDeserialized()->GetCachedSourceString();
     }
 
-    Var ScriptFunction::FormatToString(JavascriptString* inputString)
+    JavascriptString * ScriptFunction::FormatToString(JavascriptString* inputString)
     {
         FunctionProxy* proxy = this->GetFunctionProxy();
         ParseableFunctionInfo * pFuncBody = proxy->EnsureDeserialized();
-        Var returnStr = nullptr;
+        JavascriptString * returnStr = nullptr;
 
         EnterPinnedScope((volatile void**)& inputString);
 
@@ -440,12 +440,12 @@ namespace Js
         return returnStr;
     }
 
-    Var ScriptFunction::EnsureSourceString()
+    JavascriptString * ScriptFunction::EnsureSourceString()
     {
         // The function may be defer serialize, need to be deserialized
         FunctionProxy* proxy = this->GetFunctionProxy();
         ParseableFunctionInfo * pFuncBody = proxy->EnsureDeserialized();
-        Var cachedSourceString = pFuncBody->GetCachedSourceString();
+        JavascriptString * cachedSourceString = pFuncBody->GetCachedSourceString();
         if (cachedSourceString != nullptr)
         {
             return cachedSourceString;

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -64,7 +64,7 @@ namespace Js
         Field(Var) homeObj;
         Field(bool) hasInlineCaches;
 
-        Var FormatToString(JavascriptString* inputString);
+        JavascriptString * FormatToString(JavascriptString* inputString);
         static JavascriptString* GetComputedName(Var computedNameVar, ScriptContext * scriptContext);
         static bool GetSymbolName(Var computedNameVar, const char16** symbolName, charcount_t *length);
     protected:
@@ -108,7 +108,7 @@ namespace Js
         virtual ScriptFunctionType * DuplicateType() override;
 
         virtual Var GetSourceString() const;
-        virtual Var EnsureSourceString();
+        virtual JavascriptString * EnsureSourceString();
 
         bool GetHasInlineCaches() { return hasInlineCaches; }
         void SetHasInlineCaches(bool has) { hasInlineCaches = has; }


### PR DESCRIPTION
Reduces MS teams site page load and other scenarios memory usage by ~4MB
