### PR TITLE
Use consistent error messages in invalid `extends` clause

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -7092,7 +7092,7 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
                 {
                     if (!RecyclableObject::Is(extends))
                     {
-                        JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidPrototype, _u("extends"));
+                        JavascriptError::ThrowTypeError(scriptContext, JSERR_ErrorOnNew);
                     }
                     RecyclableObject * extendsObj = RecyclableObject::FromVar(extends);
                     if (!JavascriptOperators::IsConstructor(extendsObj))


### PR DESCRIPTION
A class that tries to extend from a number might get two separate error messages depending on whether the number happens to be represented internally as a JavascriptNumber heap object or a tagged int. Either behavior is fine by [the spec](https://tc39.github.io/ecma262/#sec-runtime-semantics-classdefinitionevaluation), but we should be consistent to avoid failures in tools that use string comparison.

Fixes OS:17285098
