### PR TITLE
Plumbing telemetry discrminator values through Chakra

### DIFF
--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -90,6 +90,13 @@
         BYTECODE_TESTING=1
       </PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(BuildWabt)'=='true'">%(PreprocessorDefinitions);CAN_BUILD_WABT=1</PreprocessorDefinitions>
+
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildNumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_NUMBER=$(ChakraVersionBuildNumber)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildQFENumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_QFE=$(ChakraVersionBuildQFENumber)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildCommit)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_COMMIT=$(ChakraVersionBuildCommit)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildDate)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_DATE=$(ChakraVersionBuildDate)</PreprocessorDefinitions>
+
+
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions Condition="'$(ChakraVersionBuildNumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_NUMBER=$(ChakraVersionBuildNumber)</PreprocessorDefinitions>

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1615,6 +1615,10 @@ FLAGNR(Boolean, VerifyBarrierBit, "Verify software write barrier bit is set whil
 FLAGNR(Boolean, EnableBGFreeZero, "Use to turn off background freeing and zeroing to simulate linux", DEFAULT_CONFIG_EnableBGFreeZero)
 FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep until reuse", DEFAULT_CONFIG_KeepRecyclerTrackData)
 
+FLAGR(String, TelemetryRunOrigin, "Value sent with telemetry events indicating origin class of data.  E.g., if data was triggered from Edge Crawler.", _u(""))
+FLAGR(String, TelemetryDiscriminator1, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
+FLAGR(String, TelemetryDiscriminator2, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
+
 #undef FLAG_REGOVR_EXP
 #undef FLAG_EXPERIMENTAL
 #undef FLAG

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1615,7 +1615,7 @@ FLAGNR(Boolean, VerifyBarrierBit, "Verify software write barrier bit is set whil
 FLAGNR(Boolean, EnableBGFreeZero, "Use to turn off background freeing and zeroing to simulate linux", DEFAULT_CONFIG_EnableBGFreeZero)
 FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep until reuse", DEFAULT_CONFIG_KeepRecyclerTrackData)
 
-FLAGR(String, TelemetryRunOrigin, "Value sent with telemetry events indicating origin class of data.  E.g., if data was triggered from Edge Crawler.", _u(""))
+FLAGR(String, TelemetryRunType, "Value sent with telemetry events indicating origin class of data.  E.g., if data was triggered from Edge Crawler.", _u(""))
 FLAGR(String, TelemetryDiscriminator1, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
 FLAGR(String, TelemetryDiscriminator2, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
 

--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -252,7 +252,7 @@ void ConfigParser::ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser)
     dwSize = sizeof(dwValue);
     if (NOERROR == RegGetValueW(hk, nullptr, _u("EnumerationCompat"), RRF_RT_DWORD, nullptr, (LPBYTE)&dwValue, &dwSize))
     {
-        if(dwValue == 1)
+        if (dwValue == 1)
         {
             Js::Configuration::Global.flags.EnumerationCompat = true;
         }
@@ -267,7 +267,7 @@ void ConfigParser::ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser)
     dwSize = sizeof(dwValue);
     if (NOERROR == RegGetValueW(hk, nullptr, _u("FailFastIfDisconnectedDelegate"), RRF_RT_DWORD, nullptr, (LPBYTE)&dwValue, &dwSize))
     {
-        if(dwValue == 1)
+        if (dwValue == 1)
         {
             Js::Configuration::Global.flags.FailFastIfDisconnectedDelegate = true;
         }
@@ -347,8 +347,62 @@ void ConfigParser::ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser)
         }
     }
 
+    SetConfigStringFromRegistry(hk, _u("TelemetryDiscriminator1"), Js::Configuration::Global.flags.TelemetryDiscriminator1);
+    SetConfigStringFromRegistry(hk, _u("TelemetryDiscriminator2"), Js::Configuration::Global.flags.TelemetryDiscriminator2);
+    SetConfigStringFromRegistry(hk, _u("TelemetryRunType"), Js::Configuration::Global.flags.TelemetryRunType);
+
 #endif // _WIN32
 }
+
+#ifdef _WIN32
+
+void ConfigParser::SetConfigStringFromRegistry(_In_ HKEY hk, _In_ const char16* valName, _Inout_ Js::String& str)
+{
+    const char16* regValue = nullptr;
+    DWORD len = 0;
+    ReadRegistryString(hk, valName, &regValue, &len);
+    if (regValue != nullptr)
+    {
+        str = regValue;
+        // Js::String  makes a copy of buffer so delete here
+        NoCheckHeapDeleteArray(len, regValue);
+    }
+}
+
+/**
+ * Read a string from the registry.  Will return nullptr if string registry entry 
+ * doesn't exist, or if we can't allocate memory.  
+ * Will allocate a char16* buffer on the heap. Caller is responsibile for freeing.
+ */
+void ConfigParser::ReadRegistryString(_In_ HKEY hk, _In_ const char16* valName, _Out_ const char16** sz, _Out_ DWORD* length)
+{
+    byte* buf = nullptr;
+    DWORD bufLength = 0;
+
+    // first read to get size of string
+    if (NOERROR == RegGetValueW(hk, nullptr, valName, RRF_RT_REG_SZ, nullptr, nullptr, &bufLength))
+    {
+        if (bufLength > 0)
+        {
+            buf = NoCheckHeapNewArrayZ(byte, bufLength);
+            if (buf != nullptr)
+            {
+                DWORD strLength;
+                if (NOERROR != RegGetValueW(hk, nullptr, valName, RRF_RT_REG_SZ, nullptr, buf, &strLength))
+                {
+                    // failed to read registry key
+                    NoCheckHeapDeleteArray(bufLength, buf);
+                    buf = nullptr;
+                    bufLength = 0;
+                }
+            }
+            
+        }
+    }
+    *length = bufLength / sizeof(char16);
+    *sz = reinterpret_cast<char16*>(buf);
+}
+#endif // _WIN32
 
 void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser, const char16* strCustomConfigFile)
 {

--- a/lib/Common/Core/ConfigParser.h
+++ b/lib/Common/Core/ConfigParser.h
@@ -39,6 +39,11 @@ private:
 
     void ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser);
 
+#ifdef _WIN32
+    static void ConfigParser::SetConfigStringFromRegistry(_In_ HKEY hk, _In_ const char16* valName, _Inout_ Js::String& str);
+    static void ConfigParser::ReadRegistryString(_In_ HKEY hk, _In_ const char16* valName, _Out_ const char16** sz, _Out_ DWORD* length);
+#endif
+
 public:
     static ConfigParser s_moduleConfigParser;
 


### PR DESCRIPTION
This change enables reading some strings through JSConfig or Registry that will provide three values to be used to isolate chakra telemetry data to specific scenarios.  These are:

 - TelemetryRunType - value set by crawler.  Will allow us to identfy telemetry data from `Official` and `Private` crawler runs.
- TelemetryDiscriminator1 - custom user-defined value set in private crawler runs.
- TelemetryDiscriminator2 - custom user-defined value set in private crawler runs. 

