### PR TITLE
Remove redundant fscrImplicitParents from parser flags

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1568,7 +1568,7 @@ void Parser::CreateSpecialSymbolDeclarations(ParseNodeFnc * pnodeFnc)
         return;
     }
 
-    bool isTopLevelEventHandler = (this->m_grfscr & fscrImplicitThis || this->m_grfscr & fscrImplicitParents) && !pnodeFnc->IsNested();
+    bool isTopLevelEventHandler = (this->m_grfscr & fscrImplicitThis) && !pnodeFnc->IsNested();
 
     // Create a 'this' symbol for non-lambda functions with references to 'this', and all class constructors and top level event hanlders.
     ParseNodePtr varDeclNode = CreateSpecialVarDeclIfNeeded(pnodeFnc, wellKnownPropertyPids._this, pnodeFnc->IsClassConstructor() || isTopLevelEventHandler);

--- a/lib/Parser/ParseFlags.h
+++ b/lib/Parser/ParseFlags.h
@@ -11,7 +11,7 @@ enum
     // Unused = 1 << 0,
     fscrReturnExpression = 1 << 1,   // call should return the last expression
     fscrImplicitThis = 1 << 2,   // 'this.' is optional (for Call)
-    fscrImplicitParents = 1 << 3,   // the parents of 'this' are implicit
+    // Unused = 1 << 3,
     // Unused = 1 << 4,
     fscrDynamicCode = 1 << 5,   // The code is being generated dynamically (eval, new Function, etc.)
     // Unused = 1 << 6,

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -140,7 +140,7 @@ void BeginVisitCatch(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
     FuncInfo *func = scope->GetFunc();
 
     if (func->GetCallsEval() || func->GetChildCallsEval() ||
-        (byteCodeGenerator->GetFlags() & (fscrEval | fscrImplicitThis | fscrImplicitParents)))
+        (byteCodeGenerator->GetFlags() & (fscrEval | fscrImplicitThis)))
     {
         scope->SetIsObject();
     }
@@ -810,7 +810,7 @@ void ByteCodeGenerator::SetRootFuncInfo(FuncInfo* func)
 {
     Assert(pRootFunc == nullptr || pRootFunc == func->byteCodeFunction || !IsInNonDebugMode());
 
-    if ((this->flags & (fscrImplicitThis | fscrImplicitParents)) && !this->HasParentScopeInfo())
+    if ((this->flags & fscrImplicitThis) && !this->HasParentScopeInfo())
     {
         // Mark a top-level event handler, since it will need to construct the "this" pointer's
         // namespace hierarchy to access globals.
@@ -1892,7 +1892,7 @@ bool ByteCodeGenerator::NeedObjectAsFunctionScope(FuncInfo * funcInfo, ParseNode
     return funcInfo->GetCallsEval()
         || funcInfo->GetChildCallsEval()
         || NeedScopeObjectForArguments(funcInfo, pnodeFnc)
-        || (this->flags & (fscrEval | fscrImplicitThis | fscrImplicitParents));
+        || (this->flags & (fscrEval | fscrImplicitThis));
 }
 
 Scope * ByteCodeGenerator::FindScopeForSym(Scope *symScope, Scope *scope, Js::PropertyId *envIndex, FuncInfo *funcInfo) const
@@ -2766,7 +2766,7 @@ FuncInfo* PostVisitFunction(ParseNodeFnc* pnodeFnc, ByteCodeGenerator* byteCodeG
             top->GetCallsEval() ||
             top->GetHasClosureReference() ||
             byteCodeGenerator->InDynamicScope() ||
-            (byteCodeGenerator->GetFlags() & (fscrImplicitThis | fscrImplicitParents | fscrEval)))
+            (byteCodeGenerator->GetFlags() & (fscrImplicitThis | fscrEval)))
         {
             byteCodeGenerator->SetNeedEnvRegister();
         }
@@ -3577,7 +3577,7 @@ void PostVisitBlock(ParseNodeBlock *pnodeBlock, ByteCodeGenerator *byteCodeGener
 
     Scope *scope = pnodeBlock->scope;
 
-    if (pnodeBlock->GetCallsEval() || pnodeBlock->GetChildCallsEval() || (byteCodeGenerator->GetFlags() & (fscrEval | fscrImplicitThis | fscrImplicitParents)))
+    if (pnodeBlock->GetCallsEval() || pnodeBlock->GetChildCallsEval() || (byteCodeGenerator->GetFlags() & (fscrEval | fscrImplicitThis)))
     {
         bool scopeIsEmpty = scope->IsEmpty();
         scope->SetIsObject();
@@ -5188,7 +5188,7 @@ bool ByteCodeGenerator::NeedScopeObjectForArguments(FuncInfo *funcInfo, ParseNod
         && (funcInfo->GetIsStrictMode()
             || pnodeFnc->HasNonSimpleParameterList())
         // We're not in eval or event handler, which will force the scope(s) to be objects
-        && !(this->flags & (fscrEval | fscrImplicitThis | fscrImplicitParents))
+        && !(this->flags & (fscrEval | fscrImplicitThis))
         // Neither of the scopes are objects
         && !funcInfo->paramScope->GetIsObject()
         && !funcInfo->bodyScope->GetIsObject();


### PR DESCRIPTION
"fscrImplicitThis" and "fscrImplicitParents" are treated interchangeably by the engine, so merge them to one flag.