### PR TITLE
Plumbing telemetry discrminator values through Chakra

### DIFF
--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -90,6 +90,13 @@
         BYTECODE_TESTING=1
       </PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(BuildWabt)'=='true'">%(PreprocessorDefinitions);CAN_BUILD_WABT=1</PreprocessorDefinitions>
+
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildNumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_NUMBER=$(ChakraVersionBuildNumber)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildQFENumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_QFE=$(ChakraVersionBuildQFENumber)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildCommit)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_COMMIT=$(ChakraVersionBuildCommit)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ChakraVersionBuildDate)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_DATE=$(ChakraVersionBuildDate)</PreprocessorDefinitions>
+
+
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions Condition="'$(ChakraVersionBuildNumber)'!=''">%(PreprocessorDefinitions);CHAKRA_VERSION_BUILD_NUMBER=$(ChakraVersionBuildNumber)</PreprocessorDefinitions>

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1616,6 +1616,12 @@ FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep unt
 
 FLAGNR(Number, MaxSingleAllocSizeInMB, "Max size(in MB) in single allocation", DEFAULT_CONFIG_MaxSingleAllocSizeInMB)
 
+#ifdef ENABLE_BASIC_TELEMETRY
+FLAGR(String, TelemetryRunType, "Value sent with telemetry events indicating origin class of data.  E.g., if data was triggered from Edge Crawler.", _u(""))
+FLAGR(String, TelemetryDiscriminator1, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
+FLAGR(String, TelemetryDiscriminator2, "Value sent with telemetry events. Used to identify filter telemetry data to specific runs.", _u(""))
+#endif
+
 #undef FLAG_REGOVR_EXP
 #undef FLAG_EXPERIMENTAL
 #undef FLAG

--- a/lib/Common/Core/ConfigParser.h
+++ b/lib/Common/Core/ConfigParser.h
@@ -39,6 +39,11 @@ private:
 
     void ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser);
 
+#ifdef _WIN32
+    static void ConfigParser::SetConfigStringFromRegistry(_In_ HKEY hk, _In_ const char16* subKeyName, _In_ const char16* valName, _Inout_ Js::String& str);
+    static void ConfigParser::ReadRegistryString(_In_ HKEY hk, _In_ const char16* subKeyName, _In_ const char16* valName, _Out_ const char16** sz, _Out_ DWORD* length);
+#endif
+
 public:
     static ConfigParser s_moduleConfigParser;
 


### PR DESCRIPTION
This change enables reading some strings through JSConfig or Registry that will provide three values to be used to isolate chakra telemetry data to specific scenarios.  These are:

 - TelemetryRunType - value set by crawler.  Will allow us to identfy telemetry data from `Official` and `Private` crawler runs.
- TelemetryDiscriminator1 - custom user-defined value set in private crawler runs.
- TelemetryDiscriminator2 - custom user-defined value set in private crawler runs. 
