### PR TITLE
Allow redeferral of functions that were fully compiled on original parse

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -141,7 +141,7 @@ public:
     size_t GetSourceLength() { return m_length; }
     size_t GetOriginalSourceLength() { return m_originalLength; }
     static ULONG GetDeferralThreshold(bool isProfileLoaded);
-    BOOL DeferredParse(Js::LocalFunctionId functionId);
+    BOOL WillDeferParse(Js::LocalFunctionId functionId);
     BOOL IsDeferredFnc();
     void ReduceDeferredScriptLength(size_t chars);
 

--- a/lib/Parser/ParseFlags.h
+++ b/lib/Parser/ParseFlags.h
@@ -11,8 +11,8 @@ enum
     // Unused = 1 << 0,
     fscrReturnExpression = 1 << 1,   // call should return the last expression
     fscrImplicitThis = 1 << 2,   // 'this.' is optional (for Call)
-    // Unused = 1 << 3,
-    // Unused = 1 << 4,
+    fscrWillDeferFncParse = 1 << 3,  // Heuristically choosing to defer parsing of functions
+    fscrCanDeferFncParse = 1 << 4,   // Functionally able to defer parsing of functions
     fscrDynamicCode = 1 << 5,   // The code is being generated dynamically (eval, new Function, etc.)
     // Unused = 1 << 6,
     fscrNoImplicitHandlers = 1 << 7,   // same as Opt NoConnect at start of block
@@ -26,7 +26,7 @@ enum
     fscrEval = 1 << 10,  // this expression has eval semantics (i.e., run in caller's context
     fscrEvalCode = 1 << 11,  // this is an eval expression
     fscrGlobalCode = 1 << 12,  // this is a global script
-    fscrDeferFncParse = 1 << 13,  // parser: defer creation of AST's for non-global code
+    // Unused = 1 << 13,
     fscrDeferredFncExpression = 1 << 14,  // the function decl node we deferred is an expression,
                                           // i.e., not a declaration statement
     fscrDeferredFnc = 1 << 15,  // the function we are parsing is deferred

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2379,7 +2379,7 @@ namespace Js
 
                     if (isDebugOrAsmJsReparse)
                     {
-                        grfscr &= ~fscrDeferFncParse; // Disable deferred parsing if doing a debug/asm.js re-parse
+                        grfscr &= ~fscrWillDeferFncParse; // Disable deferred parsing if not DeferNested, or doing a debug/asm.js re-parse
                     }
 
                     if (isDebugOrAsmJsReparse)

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -2003,10 +2003,14 @@ namespace Js
         // the script.
         // TODO: yongqu handle non-global code.
         ULONG grfscr = fscrGlobalCode | ((loadScriptFlag & LoadScriptFlag_Expression) == LoadScriptFlag_Expression ? fscrReturnExpression : 0);
-        if(((loadScriptFlag & LoadScriptFlag_disableDeferredParse) != LoadScriptFlag_disableDeferredParse) &&
-            (length > Parser::GetDeferralThreshold(sourceContextInfo->IsSourceProfileLoaded())))
+
+        if((loadScriptFlag & LoadScriptFlag_disableDeferredParse) != LoadScriptFlag_disableDeferredParse)
         {
-            grfscr |= fscrDeferFncParse;
+            grfscr |= fscrCanDeferFncParse;
+            if(length > Parser::GetDeferralThreshold(sourceContextInfo->IsSourceProfileLoaded()))
+            {
+                grfscr |= fscrWillDeferFncParse;
+            }
         }
 
         if((loadScriptFlag & LoadScriptFlag_disableAsmJs) == LoadScriptFlag_disableAsmJs)

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2763,7 +2763,7 @@ void ByteCodeGenerator::EmitOneFunction(ParseNodeFnc *pnodeFnc)
 
     // Note: Don't check the actual attributes on the functionInfo here, since CanDefer has been cleared while
     // we're generating byte code.
-    if (deferParseFunction->IsDeferred() || (funcInfo->originalAttributes & Js::FunctionInfo::Attributes::CanDefer))
+    if (deferParseFunction->IsDeferred() || funcInfo->canDefer)
     {
         Js::ScopeInfo::SaveEnclosingScopeInfo(this, funcInfo);
     }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -740,7 +740,10 @@ void ByteCodeGenerator::FinalizeFuncInfos()
 
     FOREACH_SLIST_ENTRY(FuncInfo*, funcInfo, this->funcInfosToFinalize)
     {
-        funcInfo->byteCodeFunction->SetAttributes(funcInfo->originalAttributes);
+        if (funcInfo->canDefer)
+        {
+            funcInfo->byteCodeFunction->SetAttributes((Js::FunctionInfo::Attributes)(funcInfo->byteCodeFunction->GetAttributes() | Js::FunctionInfo::Attributes::CanDefer));
+        }
     }
     NEXT_SLIST_ENTRY;
 

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -53,8 +53,8 @@ FuncInfo::FuncInfo(
     firstTmpReg(Js::Constants::NoRegister),
     curTmpReg(Js::Constants::NoRegister),
     argsPlaceHolderSlotCount(0),
-    originalAttributes(Js::FunctionInfo::Attributes::None),
 
+    canDefer(false),
     callsEval(false),
     childCallsEval(false),
     hasArguments(false),
@@ -118,9 +118,9 @@ FuncInfo::FuncInfo(
     {
         // Disable (re-)deferral of this function temporarily. Add it to the list of FuncInfo's to be processed when 
         // byte code gen is done.
-        this->originalAttributes = byteCodeFunction->GetAttributes();
+        this->canDefer = !!(byteCodeFunction->GetAttributes() & Js::FunctionInfo::Attributes::CanDefer);
         byteCodeGenerator->AddFuncInfoToFinalizationSet(this);
-        byteCodeFunction->SetAttributes((Js::FunctionInfo::Attributes)(this->originalAttributes & ~Js::FunctionInfo::Attributes::CanDefer));
+        byteCodeFunction->SetAttributes((Js::FunctionInfo::Attributes)(byteCodeFunction->GetAttributes() & ~Js::FunctionInfo::Attributes::CanDefer));
     }
 }
 

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -117,8 +117,8 @@ public:
     Js::RegSlot firstTmpReg;
     Js::RegSlot curTmpReg;
     int argsPlaceHolderSlotCount;   // count of place holder slots for same name args and destructuring patterns
-    Js::FunctionInfo::Attributes originalAttributes;
 
+    uint canDefer : 1;
     uint callsEval : 1;
     uint childCallsEval : 1;
     uint hasArguments : 1;

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -905,7 +905,7 @@ namespace Js
             if ((ULONG)sourceLength > deferParseThreshold && !PHASE_OFF1(Phase::DeferParsePhase))
             {
                 // Defer function bodies declared inside large dynamic blocks.
-                grfscr |= fscrDeferFncParse;
+                grfscr |= fscrWillDeferFncParse;
             }
 
             grfscr = grfscr | fscrDynamicCode;


### PR DESCRIPTION
Let the parser track heuristic and functional reasons for non-deferral separately by splitting one existing fscr bit into two. Functions that cannot be deferred for functional reasons will not be redeferral candidates, but functions that were initially not deferred for heuristic reasons, e.g. small scripts, will become candidates for redeferral. Also fix an issue exposed by this change where FunctionInfo attribute bits set during byte code generation could be cleared in FuncInfo finalization.