### PR TITLE
Adding a configuration flag for setting the allocation policy limit.

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1431,7 +1431,7 @@ FLAGNR(Boolean, RecyclerVerifyMark    , "verify concurrent gc", false)
 #endif
 FLAGR (Number,  LowMemoryCap          , "Memory cap indicating a low-memory process", DEFAULT_CONFIG_LowMemoryCap)
 FLAGNR(Number,  NewPagesCapDuringBGSweeping, "New pages count allowed to be allocated during background sweeping", DEFAULT_CONFIG_NewPagesCapDuringBGSweeping)
-FLAGR (Number,  AllocPolicyLimit      , "Memory allocation policy limit in MB (default: -1).", DEFAULT_CONFIG_AllocationPolicyLimit)
+FLAGR (Number,  AllocPolicyLimit      , "Memory allocation policy limit in MB (default: -1, which means no allocation policy limit).", DEFAULT_CONFIG_AllocationPolicyLimit)
 #ifdef RUNTIME_DATA_COLLECTION
 FLAGNR(String,  RuntimeDataOutputFile, "Filename to write the dynamic profile info", nullptr)
 #endif

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -524,6 +524,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_LowMemoryCap         (0xB900000) // 185 MB - based on memory cap for process on low-capacity device
 #define DEFAULT_CONFIG_NewPagesCapDuringBGSweeping    (15000 * 4)
 #define DEFAULT_CONFIG_MaxSingleAllocSizeInMB  (2048)
+#define DEFAULT_CONFIG_AllocationPolicyLimit    (-1)
 
 #define DEFAULT_CONFIG_MaxCodeFill          (500)
 #define DEFAULT_CONFIG_MaxLoopsPerFunction  (10)
@@ -1430,6 +1431,7 @@ FLAGNR(Boolean, RecyclerVerifyMark    , "verify concurrent gc", false)
 #endif
 FLAGR (Number,  LowMemoryCap          , "Memory cap indicating a low-memory process", DEFAULT_CONFIG_LowMemoryCap)
 FLAGNR(Number,  NewPagesCapDuringBGSweeping, "New pages count allowed to be allocated during background sweeping", DEFAULT_CONFIG_NewPagesCapDuringBGSweeping)
+FLAGR (Number,  AllocPolicyLimit      , "Memory allocation policy limit in MB (default: -1).", DEFAULT_CONFIG_AllocationPolicyLimit)
 #ifdef RUNTIME_DATA_COLLECTION
 FLAGNR(String,  RuntimeDataOutputFile, "Filename to write the dynamic profile info", nullptr)
 #endif

--- a/lib/Common/Memory/AllocationPolicyManager.h
+++ b/lib/Common/Memory/AllocationPolicyManager.h
@@ -41,6 +41,11 @@ public:
         context(NULL),
         memoryAllocationCallback(NULL)
     {
+        Js::Number limitMB = Js::Configuration::Global.flags.AllocPolicyLimit;
+        if (limitMB > 0)
+        {
+            memoryLimit = (size_t)limitMB * 1024 * 1024;
+        }
     }
 
     ~AllocationPolicyManager()

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -2648,7 +2648,6 @@ bool Recycler::DoExternalAllocation(size_t size, ExternalAllocFunc externalAlloc
     AutoExternalAllocation externalAllocation(this, size);
     if (externalAllocFunc())
     {
-        this->AddExternalMemoryUsage(size);
         externalAllocation.allocationSucceeded = true;
         return true;
     }

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -86,6 +86,7 @@ namespace Js
         virtual bool IsArrayBuffer() = 0;
         virtual bool IsSharedArrayBuffer() = 0;
         virtual bool IsWebAssemblyArrayBuffer() { return false; }
+        virtual bool IsProjectionArrayBuffer() { return false; }
         virtual ArrayBuffer * GetAsArrayBuffer() = 0;
         virtual SharedArrayBuffer * GetAsSharedArrayBuffer() { return nullptr; }
         virtual void AddParent(ArrayBufferParent* parent) { }
@@ -325,7 +326,8 @@ namespace Js
         // take over ownership. a CoTaskMemAlloc'ed buffer passed in via projection.
         static ProjectionArrayBuffer* Create(byte* buffer, DECLSPEC_GUARD_OVERFLOW uint32 length, DynamicType * type);
         virtual void Dispose(bool isShutdown) override;
-        virtual void Finalize(bool isShutdown) override {};
+        virtual void Finalize(bool isShutdown) override;
+        virtual bool IsProjectionArrayBuffer() override { return true; }
     private:
         ProjectionArrayBuffer(uint32 length, DynamicType * type);
         ProjectionArrayBuffer(byte* buffer, uint32 length, DynamicType * type);

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -86,7 +86,6 @@ namespace Js
         virtual bool IsArrayBuffer() = 0;
         virtual bool IsSharedArrayBuffer() = 0;
         virtual bool IsWebAssemblyArrayBuffer() { return false; }
-        virtual bool IsProjectionArrayBuffer() { return false; }
         virtual ArrayBuffer * GetAsArrayBuffer() = 0;
         virtual SharedArrayBuffer * GetAsSharedArrayBuffer() { return nullptr; }
         virtual void AddParent(ArrayBufferParent* parent) { }
@@ -327,7 +326,6 @@ namespace Js
         static ProjectionArrayBuffer* Create(byte* buffer, DECLSPEC_GUARD_OVERFLOW uint32 length, DynamicType * type);
         virtual void Dispose(bool isShutdown) override;
         virtual void Finalize(bool isShutdown) override;
-        virtual bool IsProjectionArrayBuffer() override { return true; }
     private:
         ProjectionArrayBuffer(uint32 length, DynamicType * type);
         ProjectionArrayBuffer(byte* buffer, uint32 length, DynamicType * type);

--- a/lib/Runtime/Library/SharedArrayBuffer.cpp
+++ b/lib/Runtime/Library/SharedArrayBuffer.cpp
@@ -617,6 +617,8 @@ namespace Js
             {
                 return false;
             }
+
+            this->GetRecycler()->AddExternalMemoryUsage(growSize);
         }
         else
         {


### PR DESCRIPTION
The flag is useful for testing purposes and for setting the policy limit in non-JSRT scenarios.
- Fixed some missing `ReportExternalMemoryFree` calls.
Not having those was tripping consistency asserts in memory policy manager in debug and could potentially result in false OOMs in release.

Fixes:https://github.com/Microsoft/ChakraCore/issues/5031
