### PR TITLE
Adding capture & transmission of Recycler telemetry

### DIFF
--- a/bin/GCStress/GCStress.cpp
+++ b/bin/GCStress/GCStress.cpp
@@ -273,7 +273,7 @@ void SimpleRecyclerTest()
         AUTO_NESTED_HANDLED_EXCEPTION_TYPE(ExceptionType_DisableCheck);
 #endif
 
-        recyclerInstance = HeapNewZ(Recycler, nullptr, &pageAllocator, Js::Throw::OutOfMemory, Js::Configuration::Global.flags);
+        recyclerInstance = HeapNewZ(Recycler, nullptr, &pageAllocator, Js::Throw::OutOfMemory, Js::Configuration::Global.flags, nullptr);
 
         recyclerInstance->Initialize(false /* forceInThread */, nullptr /* threadService */);
 

--- a/bin/GCStress/GCStress.vcxproj
+++ b/bin/GCStress/GCStress.vcxproj
@@ -31,8 +31,10 @@
         $(ChakraCommonMemoryLib);
         $(ChakraRuntimePlatformAgnostic);
         $(ChakraCommonLinkDependencies);
+        Ole32.lib;
         Advapi32.lib;
-        %(AdditionalDependencies)</AdditionalDependencies>
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories);$(SdkLibPath)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/lib/Common/Common/Chakra.Common.Common.vcxproj
+++ b/lib/Common/Common/Chakra.Common.Common.vcxproj
@@ -69,6 +69,7 @@
     <ClInclude Include="MathUtil.h" />
     <ClInclude Include="NumberUtilities.h" />
     <ClInclude Include="NumberUtilitiesBase.h" />
+    <ClInclude Include="ObservableValue.h" />
     <ClInclude Include="RejitReason.h" />
     <ClInclude Include="RejitReasons.h" />
     <ClInclude Include="SmartFpuControl.h" />

--- a/lib/Common/Common/Chakra.Common.Common.vcxproj.filters
+++ b/lib/Common/Common/Chakra.Common.Common.vcxproj.filters
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Api.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)DateUtilities.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Event.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Int32Math.cpp" />
@@ -38,6 +37,7 @@
     <ClInclude Include="NumberUtilitiesBase.h" />
     <ClInclude Include="SmartFpuControl.h" />
     <ClInclude Include="Int64Math.h" />
+    <ClInclude Include="ObservableValue.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Jobs.inl" />

--- a/lib/Common/Common/ObservableValue.h
+++ b/lib/Common/Common/ObservableValue.h
@@ -1,0 +1,51 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+template<class T>
+class ObservableValueObserver
+{
+public:
+    virtual void ValueChanged(const T& newVal, const T& oldVal) = 0;
+};
+
+
+template<class T>
+class ObservableValue final
+{
+private:
+    T value;
+    ObservableValueObserver<T>* observer;
+
+    void SetValue(const T newValue)
+    {
+        if (observer != nullptr && newValue != this->value)
+        {
+            observer->ValueChanged(newValue, this->value);
+        }
+        this->value = newValue;
+    }
+
+public:
+    ObservableValue(T val, ObservableValueObserver<T>* observer) :
+        observer(observer),
+        value(val)
+    {
+    }
+
+    ObservableValue(ObservableValue<T>& other) = delete;
+
+    void operator= (const T value)
+    {
+        this->SetValue(value);
+    }
+
+    operator T() const
+    {
+        return this->value;
+    }
+};
+

--- a/lib/Common/Common/Tick.h
+++ b/lib/Common/Common/Tick.h
@@ -109,7 +109,6 @@ namespace Js {
     // Construction
     public:
                 TickDelta();
-    private:
                 TickDelta(int64 lnDelta);
 
     // Properties

--- a/lib/Common/Memory/AllocatorTelemetryStats.h
+++ b/lib/Common/Memory/AllocatorTelemetryStats.h
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "Common/Tick.h"
+
+struct AllocatorDecommitStats
+{
+    Js::Tick lastLeaveDecommitRegion;
+    Js::TickDelta maxDeltaBetweenDecommitRegionLeaveAndDecommit;
+    int64 numDecommitCalls;
+    int64 numPagesDecommitted;
+    int64 numFreePageCount;
+};
+
+struct AllocatorSizes
+{
+    size_t usedBytes;
+    size_t reservedBytes;
+    size_t committedBytes;
+    size_t numberOfSegments;
+};

--- a/lib/Common/Memory/BucketStatsReporter.h
+++ b/lib/Common/Memory/BucketStatsReporter.h
@@ -2,6 +2,11 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "HeapBucketStats.h"
+
 namespace Memory
 {
 
@@ -67,6 +72,8 @@ public:
     {
         DUMP_FRAGMENTATION_STATS_ONLY(DumpHeader());
     }
+
+    HeapBucketStats* GetTotalStats() { return &total; }
 
     bool IsEtwEnabled() const
     {

--- a/lib/Common/Memory/Chakra.Common.Memory.vcxproj
+++ b/lib/Common/Memory/Chakra.Common.Memory.vcxproj
@@ -76,6 +76,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerObjectGraphDumper.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerPageAllocator.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerSweep.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerTelemetryInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerWriteBarrierManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SmallFinalizableHeapBlock.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SmallFinalizableHeapBucket.cpp" />
@@ -98,6 +99,7 @@
   <ItemGroup>
     <ClInclude Include="AllocationPolicyManager.h" />
     <ClInclude Include="Allocator.h" />
+    <ClInclude Include="AllocatorTelemetryStats.h" />
     <ClInclude Include="amd64\XDataAllocator.h">
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
     </ClInclude>
@@ -144,6 +146,7 @@
     <ClInclude Include="RecyclerRootPtr.h" />
     <ClInclude Include="RecyclerSweep.h" />
     <ClInclude Include="RecyclerSweepManager.h" />
+    <ClInclude Include="RecyclerTelemetryInfo.h" />
     <ClInclude Include="RecyclerWeakReference.h" />
     <ClInclude Include="RecyclerWriteBarrierManager.h" />
     <ClInclude Include="SectionAllocWrapper.h" />
@@ -157,6 +160,8 @@
     <ClInclude Include="MemoryLogger.h" />
     <ClInclude Include="StressTest.h" />
     <ClInclude Include="VirtualAllocWrapper.h" />
+    <ClInclude Include="RecyclerWaitReason.h" />
+    <ClInclude Include="RecyclerWaitReasonInc.h" />
     <ClInclude Include="WriteBarrierMacros.h" />
     <ClInclude Include="XDataAllocator.h" />
   </ItemGroup>

--- a/lib/Common/Memory/Chakra.Common.Memory.vcxproj.filters
+++ b/lib/Common/Memory/Chakra.Common.Memory.vcxproj.filters
@@ -59,6 +59,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerSweepManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)DelayDeletingFunctionTable.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)HeapBucketStats.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)RecyclerTelemetryInfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Allocator.h" />
@@ -124,6 +125,11 @@
     <ClInclude Include="BucketStatsReporter.h" />
     <ClInclude Include="RecyclerSweepManager.h" />
     <ClInclude Include="HeapBucketStats.h" />
+    <ClInclude Include="RecyclerTelemetryInfo.h" />
+    <ClInclude Include="AllocatorTelemetryStats.h" />
+    <ClInclude Include="HeapBucketStats.h" />
+    <ClInclude Include="RecyclerWaitReason.h" />
+    <ClInclude Include="RecyclerWaitReasonInc.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="HeapBlock.inl" />

--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -2,6 +2,12 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+namespace Memory
+{
+
 enum CollectionState
 {
     Collection_Mark                 = 0x00000001,
@@ -95,3 +101,5 @@ enum CollectionState
 
     CollectionStateConcurrentMarkWeakRef = Collection_ConcurrentMark | Collection_ExecutingConcurrent | Collection_WeakRefMark,
 };
+
+}

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -1360,7 +1360,8 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
         {
             SweepState stateReturned = (this->freeCount == 0) ? SweepStateFull : state;
-            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**37**] heapBlock swept. State returned:"), stateReturned, recycler->collectionState);
+            CollectionState collectionState = recycler->collectionState;
+            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**37**] heapBlock swept. State returned:"), stateReturned, collectionState);
         }
 #endif
         return (this->freeCount == 0) ? SweepStateFull : state;
@@ -1425,7 +1426,8 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
         {
             SweepState stateReturned = (this->freeCount == 0) ? SweepStateFull : state;
-            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**38**] heapBlock swept. State returned:"), stateReturned, recycler->collectionState);
+            CollectionState collectionState = recycler->collectionState;
+            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**38**] heapBlock swept. State returned:"), stateReturned, collectionState);
         }
 #endif
         // We always need to check the free count as we may have allocated from this block during concurrent sweep.

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -9,6 +9,8 @@
 
 class ScriptMemoryDumper;
 
+#include "HeapBucketStats.h"
+
 namespace Memory
 {
 #ifdef RECYCLER_PAGE_HEAP
@@ -44,6 +46,7 @@ class  RecyclerSweep;
 class MarkContext;
 
 #if ENABLE_MEM_STATS
+
 #ifdef DUMP_FRAGMENTATION_STATS
 #define DUMP_FRAGMENTATION_STATS_ONLY(x) x
 #define DUMP_FRAGMENTATION_STATS_IS(x) x

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1541,7 +1541,8 @@ HeapBucketT<TBlockType>::PrepareForAllocationsDuringConcurrentSweep(TBlockType *
                 if (this->GetRecycler()->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
                 {
                     size_t currentHeapBlockCount = QueryDepthInterlockedSList(allocableHeapBlockListHead);
-                    Output::Print(_u("[GC #%d] [HeapBucket 0x%p] Starting allocations during  concurrent sweep with %d blocks. [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, currentHeapBlockCount, this->GetRecycler()->collectionState);
+                    CollectionState collectionState = this->GetRecycler()->collectionState;
+                    Output::Print(_u("[GC #%d] [HeapBucket 0x%p] Starting allocations during  concurrent sweep with %d blocks. [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, currentHeapBlockCount, collectionState);
                     Output::Print(_u("[GC #%d] [HeapBucket 0x%p] The heapBlockList has %d blocks. Total heapBlockCount is %d.\n\n"), this->GetRecycler()->collectionCount, this, HeapBlockList::Count(this->heapBlockList), this->heapBlockCount);
                 }
 #endif
@@ -1790,7 +1791,8 @@ HeapBucketT<TBlockType>::FinishConcurrentSweep()
 #ifdef RECYCLER_TRACE
         if (this->GetRecycler()->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
         {
-            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] starting FinishConcurrentSweep [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, this->GetRecycler()->collectionState);
+            CollectionState collectionState = this->GetRecycler()->collectionState;
+            Output::Print(_u("[GC #%d] [HeapBucket 0x%p] starting FinishConcurrentSweep [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, collectionState);
         }
 #endif
 
@@ -1827,7 +1829,8 @@ HeapBucketT<TBlockType>::AppendAllocableHeapBlockList(TBlockType * list)
 #ifdef RECYCLER_TRACE
     if (this->GetRecycler()->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
     {
-        Output::Print(_u("[GC #%d] [HeapBucket 0x%p] in AppendAllocableHeapBlockList [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, this->GetRecycler()->collectionState);
+        CollectionState collectionState = this->GetRecycler()->collectionState;
+        Output::Print(_u("[GC #%d] [HeapBucket 0x%p] in AppendAllocableHeapBlockList [CollectionState: %d] \n"), this->GetRecycler()->collectionCount, this, collectionState);
     }
 #endif
     // Add the list to the end of the current list

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -2,6 +2,9 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
 namespace Memory
 {
 #if ENABLE_MEM_STATS

--- a/lib/Common/Memory/IdleDecommitPageAllocator.cpp
+++ b/lib/Common/Memory/IdleDecommitPageAllocator.cpp
@@ -76,9 +76,12 @@ IdleDecommitPageAllocator::EnterIdleDecommit()
 IdleDecommitSignal
 IdleDecommitPageAllocator::LeaveIdleDecommit(bool allowTimer)
 {
-
     Assert(this->idleDecommitEnterCount > 0);
     Assert(this->maxFreePageCount == maxIdleDecommitFreePageCount);
+
+#ifdef ENABLE_BASIC_TELEMETRY
+    this->GetDecommitStats()->lastLeaveDecommitRegion = Js::Tick::Now();
+#endif
 
 #ifdef IDLE_DECOMMIT_ENABLED
     Assert(!hasDecommitTimer);

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -6,6 +6,10 @@
 #include "PageAllocatorDefines.h"
 #include "Exceptions/ExceptionBase.h"
 
+#ifdef ENABLE_BASIC_TELEMETRY
+#include "AllocatorTelemetryStats.h"
+#endif
+
 #ifdef PROFILE_MEM
 struct PageMemoryData;
 #endif
@@ -746,6 +750,12 @@ public:
 #if DBG_DUMP
     char16 const * debugName;
 #endif
+
+#ifdef ENABLE_BASIC_TELEMETRY
+    AllocatorDecommitStats* GetDecommitStats() { return this->decommitStats; }
+    void SetDecommitStats(AllocatorDecommitStats* val) { this->decommitStats = val; }
+#endif
+
 protected:
     void InitVirtualAllocator(TVirtualAlloc * virtualAllocator);
 
@@ -902,6 +912,10 @@ private:
     PageMemoryData * memoryData;
 #endif
 
+#ifdef ENABLE_BASIC_TELEMETRY
+    AllocatorDecommitStats* decommitStats;
+#endif
+
     size_t usedBytes;
     PageAllocatorType type;
 
@@ -943,6 +957,14 @@ private:
     void SubUsedBytes(size_t bytes);
     void AddNumberOfSegments(size_t segmentCount);
     void SubNumberOfSegments(size_t segmentCount);
+
+public:
+    size_t GetReservedBytes() const { return this->reservedBytes; };
+    size_t GetCommittedBytes() const { return this->committedBytes; }
+    size_t GetUsedBytes() const { return this->usedBytes; }
+    size_t GetNumberOfSegments() const { return this->numberOfSegments; }
+
+private:
 
     bool RequestAlloc(size_t byteCount)
     {

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -5,6 +5,9 @@
 #pragma once
 
 #include "CollectionState.h"
+#include "RecyclerTelemetryInfo.h"
+#include "RecyclerWaitReason.h"
+#include "Common/ObservableValue.h"
 
 namespace Js
 {
@@ -710,6 +713,10 @@ class Recycler
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     friend class AutoProtectPages;
 #endif
+#ifdef ENABLE_BASIC_TELEMETRY
+    friend class RecyclerTelemetryInfo;
+#endif
+
 
     template <typename T> friend class RecyclerWeakReference;
     template <typename T> friend class WeakReferenceHashTable;
@@ -779,12 +786,12 @@ private:
             _recycler(recycler),
             _exitState(exitState)
         {
-            _recycler->collectionState = entryState;
+            _recycler->SetCollectionState(entryState);
         }
 
         ~AutoSwitchCollectionStates()
         {
-            _recycler->collectionState = _exitState;
+            _recycler->SetCollectionState(_exitState);
         }
 
     private:
@@ -798,7 +805,39 @@ private:
     uint collectionFinishReason;
 #endif
 
-    CollectionState collectionState;
+    class CollectionStateChangedObserver : public ObservableValueObserver<CollectionState>
+    {
+    private:
+        Recycler* recycler;
+    public:
+        CollectionStateChangedObserver(Recycler* recycler)
+        {
+            this->recycler = recycler;
+        }
+
+        virtual void ValueChanged(const CollectionState& newVal, const CollectionState& oldVal)
+        {
+#ifdef ENABLE_BASIC_TELEMETRY
+            if (oldVal == CollectionState::CollectionStateNotCollecting && newVal != CollectionState::CollectionStateNotCollecting && newVal != CollectionState::Collection_PreCollection)
+            {
+                this->recycler->GetRecyclerTelemetryInfo().StartPass();
+            }
+            else if (oldVal != CollectionState::CollectionStateNotCollecting && oldVal != CollectionState::Collection_PreCollection && newVal == CollectionState::CollectionStateNotCollecting)
+            {
+                this->recycler->GetRecyclerTelemetryInfo().EndPass();
+            }
+#endif
+        }
+    };
+
+    CollectionStateChangedObserver collectionStateChangedObserver;
+    ObservableValue<CollectionState> collectionState;
+
+    inline void SetCollectionState(CollectionState newState)
+    {
+        this->collectionState = newState;
+    }
+
     JsUtil::ThreadService *threadService;
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool allowAllocationsDuringConcurrentSweepForCollection;
@@ -1126,6 +1165,11 @@ private:
         return this->autoHeap.GetDefaultHeap();
     }
 
+    HeapInfo * GetHeapInfo()
+    {
+        return this->autoHeap.GetDefaultHeap();
+    }
+
 #ifdef PROFILE_MEM
     RecyclerMemoryData * memoryData;
 #endif
@@ -1142,6 +1186,22 @@ private:
     RecyclerWatsonTelemetryBlock localTelemetryBlock;
     RecyclerWatsonTelemetryBlock * telemetryBlock;
 #endif
+
+#ifdef ENABLE_BASIC_TELEMETRY
+private:
+    RecyclerTelemetryInfo telemetryStats;
+    GUID recyclerID;
+public:
+    GUID& GetRecyclerID() { return this->recyclerID; }
+#endif
+  
+
+public:
+    bool GetIsInScript() { return this->isInScript; }
+    bool GetIsScriptActive() { return this->isScriptActive; }
+
+private:
+
 #ifdef RECYCLER_STATS
     RecyclerCollectionStats collectionStats;
     void PrintHeapBlockStats(char16 const * name, HeapBlock::HeapBlockType type);
@@ -1170,7 +1230,8 @@ public:
 #endif
 public:
 
-    Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllocator * pageAllocator, void(*outOfMemoryFunc)(), Js::ConfigFlagsTable& flags);
+    Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllocator * pageAllocator, void(*outOfMemoryFunc)(), Js::ConfigFlagsTable& flags, RecyclerTelemetryHostInterface* hostInterface);
+
     ~Recycler();
 
     void Initialize(const bool forceInThread, JsUtil::ThreadService *threadService, const bool deferThreadStartup = false
@@ -1785,7 +1846,10 @@ private:
 
     template <CollectionFlags flags>
     BOOL TryFinishConcurrentCollect();
-    BOOL WaitForConcurrentThread(DWORD waitTime);
+
+    BOOL WaitForConcurrentThread(DWORD waitTime, RecyclerWaitReason caller = RecyclerWaitReason::Other);
+    void FlushBackgroundPages();
+
     BOOL FinishConcurrentCollect(CollectionFlags flags);
     void FinishTransferSwept(CollectionFlags flags);
     BOOL FinishConcurrentCollectWrapped(CollectionFlags flags);
@@ -1881,6 +1945,10 @@ private:
     // in projection ExternalMark allowing allocating VarToDispEx. This is the common flag
     // while we have debug only flag for each of the two scenarios.
     bool isCollectionDisabled;
+
+#ifdef ENABLE_BASIC_TELEMETRY
+    RecyclerTelemetryInfo& GetRecyclerTelemetryInfo() { return this->telemetryStats; }
+#endif
 
 #ifdef TRACK_ALLOC
 public:

--- a/lib/Common/Memory/RecyclerTelemetryInfo.cpp
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.cpp
@@ -1,0 +1,276 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "CommonMemoryPch.h"
+
+
+#ifdef ENABLE_BASIC_TELEMETRY
+
+#include "Recycler.h"
+#include "HeapBucketStats.h"
+#include "BucketStatsReporter.h"
+#include <psapi.h>
+
+namespace Memory
+{
+#ifdef DBG
+#define AssertOnValidThread(recyclerTelemetryInfo, loc) { AssertMsg(this->IsOnScriptThread(), STRINGIZE("Unexpected thread ID at " ## loc)); }
+#else
+#define AssertOnValidThread(recyclerTelemetryInfo, loc)
+#endif
+
+    RecyclerTelemetryInfo::RecyclerTelemetryInfo(Recycler * recycler, RecyclerTelemetryHostInterface* hostInterface) :
+        passCount(0),
+        hostInterface(hostInterface),
+        lastPassStats(nullptr),
+        recyclerStartTime(Js::Tick::Now()),
+        abortTelemetryCapture(false)
+    {
+        this->recycler = recycler;
+        mainThreadID = ::GetCurrentThreadId();
+    }
+
+    RecyclerTelemetryInfo::~RecyclerTelemetryInfo()
+    {
+        AssertOnValidThread(this, RecyclerTelemetryInfo::~RecyclerTelemetryInfo);
+        if (this->hostInterface != nullptr && this->passCount > 0)
+        {
+            this->hostInterface->TransmitTelemetry(*this);
+        }
+        this->FreeGCPassStats();
+    }
+
+    const GUID& RecyclerTelemetryInfo::GetRecyclerID() const
+    {
+        return this->recycler->GetRecyclerID();
+    }
+
+    bool RecyclerTelemetryInfo::GetIsConcurrentEnabled() const
+    {
+        return this->recycler->IsConcurrentEnabled();
+    }
+
+    bool RecyclerTelemetryInfo::ShouldCaptureRecyclerTelemetry() const
+    {
+        return this->hostInterface != nullptr && this->abortTelemetryCapture == false;
+    }
+
+    void RecyclerTelemetryInfo::FillInSizeData(IdleDecommitPageAllocator* allocator, AllocatorSizes* sizes) const
+    {
+        sizes->committedBytes = allocator->GetCommittedBytes();
+        sizes->reservedBytes = allocator->GetReservedBytes();
+        sizes->usedBytes = allocator->GetUsedBytes();
+        sizes->numberOfSegments = allocator->GetNumberOfSegments();
+    }
+
+    void RecyclerTelemetryInfo::StartPass()
+    {
+        Js::Tick start = Js::Tick::Now();
+        if (!this->ShouldCaptureRecyclerTelemetry())
+        {
+            return;
+        }
+
+        AssertOnValidThread(this, RecyclerTelemetryInfo::StartPass);
+#if DBG
+        // validate state of existing GC pass stats structs
+        uint16 count = 0;
+        if (this->lastPassStats != nullptr)
+        {
+            RecyclerTelemetryGCPassStats* head = this->lastPassStats->next;
+            RecyclerTelemetryGCPassStats* curr = head;
+            do
+            {
+                AssertMsg(curr->isGCPassActive == false, "unexpected value for isGCPassActive");
+                count++;
+                curr = curr->next;
+            } while (curr != head);
+        }
+        AssertMsg(count == this->passCount, "RecyclerTelemetryInfo::StartPass() - mismatch between passCount and count.");
+#endif
+
+        RecyclerTelemetryGCPassStats* p = HeapNewNoThrow(RecyclerTelemetryGCPassStats);
+        if (p == nullptr)
+        {
+            // failed to allocate memory - disable any further telemetry capture for this recycler 
+            // and free any existing GC stats we've accumulated
+            this->abortTelemetryCapture = true;
+            FreeGCPassStats();
+            this->hostInterface->TransmitTelemetryError(*this, "Memory Allocation Failed");
+        }
+        else
+        {
+            passCount++;
+            memset(p, 0, sizeof(RecyclerTelemetryGCPassStats));
+            if (this->lastPassStats == nullptr)
+            {
+                p->next = p;
+            }
+            else
+            {
+                p->next = lastPassStats->next;
+                this->lastPassStats->next = p;
+            }
+            this->lastPassStats = p;
+
+            this->lastPassStats->isGCPassActive = true;
+            this->lastPassStats->passStartTimeTick = Js::Tick::Now();
+            GetSystemTimePreciseAsFileTime(&this->lastPassStats->passStartTimeFileTime);
+            if (this->hostInterface != nullptr)
+            {
+                LPFILETIME ft = this->hostInterface->GetLastScriptExecutionEndTime();
+                this->lastPassStats->lastScriptExecutionEndTime = *ft;
+            }
+
+            this->lastPassStats->processCommittedBytes_start = RecyclerTelemetryInfo::GetProcessCommittedBytes();
+            this->lastPassStats->processAllocaterUsedBytes_start = PageAllocator::GetProcessUsedBytes();
+            this->lastPassStats->isInScript = this->recycler->GetIsInScript();
+            this->lastPassStats->isScriptActive = this->recycler->GetIsScriptActive();
+
+            this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerLeafPageAllocator(), &this->lastPassStats->threadPageAllocator_start);
+            this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerPageAllocator(), &this->lastPassStats->recyclerLeafPageAllocator_start);
+            this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerLargeBlockPageAllocator(), &this->lastPassStats->recyclerLargeBlockPageAllocator_start);
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+            this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerWithBarrierPageAllocator(), &this->lastPassStats->recyclerWithBarrierPageAllocator_start);
+#endif
+            this->lastPassStats->startPassProcessingElapsedTime = Js::Tick::Now() - start;
+        }
+
+
+    }
+
+    void RecyclerTelemetryInfo::EndPass()
+    {
+        if (!this->ShouldCaptureRecyclerTelemetry())
+        {
+            return;
+        }
+
+        Js::Tick start = Js::Tick::Now();
+
+        AssertOnValidThread(this, RecyclerTelemetryInfo::EndPass);
+
+        this->lastPassStats->isGCPassActive = false;
+        this->lastPassStats->passEndTimeTick = Js::Tick::Now();
+
+        this->lastPassStats->processCommittedBytes_end = RecyclerTelemetryInfo::GetProcessCommittedBytes();
+        this->lastPassStats->processAllocaterUsedBytes_end = PageAllocator::GetProcessUsedBytes();
+
+        this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerLeafPageAllocator(), &this->lastPassStats->threadPageAllocator_end);
+        this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerPageAllocator(), &this->lastPassStats->recyclerLeafPageAllocator_end);
+        this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerLargeBlockPageAllocator(), &this->lastPassStats->recyclerLargeBlockPageAllocator_end);
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+        this->FillInSizeData(this->recycler->GetHeapInfo()->GetRecyclerWithBarrierPageAllocator(), &this->lastPassStats->recyclerWithBarrierPageAllocator_end);
+#endif
+
+        // get bucket stats
+        Js::Tick bucketStatsStart = Js::Tick::Now();
+        BucketStatsReporter bucketReporter(this->recycler);
+        this->recycler->GetHeapInfo()->GetBucketStats(bucketReporter);
+        memcpy(&this->lastPassStats->bucketStats, bucketReporter.GetTotalStats(), sizeof(HeapBucketStats));
+        this->lastPassStats->computeBucketStatsElapsedTime = Js::Tick::Now() - bucketStatsStart;
+
+        this->lastPassStats->endPassProcessingElapsedTime = Js::Tick::Now() - start;
+
+        if (ShouldTransmit() && this->hostInterface != nullptr)
+        {
+            if (this->hostInterface->TransmitTelemetry(*this))
+            {
+                this->lastTransmitTime = this->lastPassStats->passEndTimeTick;
+                Reset();
+            }
+        }
+    }
+
+    void RecyclerTelemetryInfo::Reset()
+    {
+        FreeGCPassStats();
+        memset(&this->threadPageAllocator_decommitStats, 0, sizeof(AllocatorDecommitStats));
+        memset(&this->recyclerLeafPageAllocator_decommitStats, 0, sizeof(AllocatorDecommitStats));
+        memset(&this->recyclerLargeBlockPageAllocator_decommitStats, 0, sizeof(AllocatorDecommitStats));
+        memset(&this->threadPageAllocator_decommitStats, 0, sizeof(AllocatorDecommitStats));
+    }
+
+    void RecyclerTelemetryInfo::FreeGCPassStats()
+    {
+        AssertOnValidThread(this, RecyclerTelemetryInfo::FreeGCPassStats);
+
+        if (this->lastPassStats != nullptr)
+        {
+            RecyclerTelemetryGCPassStats* head = this->lastPassStats->next;
+            RecyclerTelemetryGCPassStats* curr = head;
+#ifdef DBG
+            uint16 freeCount = 0;
+#endif
+            do
+            {
+                RecyclerTelemetryGCPassStats* next = curr->next;
+                HeapDelete(curr);
+                curr = next;
+#ifdef DBG
+                freeCount++;
+#endif
+            } while (curr != head);
+#ifdef DBG
+            AssertMsg(freeCount == this->passCount, "Unexpected mismatch between freeCount and passCount");
+#endif
+            this->lastPassStats = nullptr;
+            this->passCount = 0;
+        }
+    }
+
+    bool RecyclerTelemetryInfo::ShouldTransmit()
+    {
+        // for now, try to transmit telemetry when we have >= 16
+        return (this->hostInterface != nullptr &&  this->passCount >= 16);
+    }
+
+    void RecyclerTelemetryInfo::IncrementUserThreadBlockedCount(Js::TickDelta waitTime, RecyclerWaitReason caller)
+    {
+#ifdef DBG
+        if (this->ShouldCaptureRecyclerTelemetry())
+        {
+            AssertMsg(this->lastPassStats != nullptr && this->lastPassStats->isGCPassActive == true, "unexpected Value in  RecyclerTelemetryInfo::IncrementUserThreadBlockedCount");
+        }
+#endif
+
+        if (this->ShouldCaptureRecyclerTelemetry() && this->lastPassStats != nullptr)
+        {
+            AssertOnValidThread(this, RecyclerTelemetryInfo::IncrementUserThreadBlockedCount);
+            this->lastPassStats->uiThreadBlockedTimes[caller] += waitTime;
+        }
+    }
+
+    bool RecyclerTelemetryInfo::IsOnScriptThread() const
+    {
+        bool isValid = false;
+        if (this->hostInterface != nullptr)
+        {
+            if (this->hostInterface->IsThreadBound())
+            {
+                isValid = ::GetCurrentThreadId() == this->hostInterface->GetCurrentScriptThreadID();
+            }
+            else
+            {
+                isValid = ::GetCurrentThreadId() == this->mainThreadID;
+            }
+        }
+        return isValid;
+    }
+
+    size_t RecyclerTelemetryInfo::GetProcessCommittedBytes()
+    {
+        HANDLE process = GetCurrentProcess();
+        PROCESS_MEMORY_COUNTERS memCounters = { 0 };
+        size_t committedBytes = 0;
+        if (GetProcessMemoryInfo(process, &memCounters, sizeof(PROCESS_MEMORY_COUNTERS)))
+        {
+            committedBytes = memCounters.PagefileUsage;
+        }
+        return committedBytes;
+    }
+
+}
+#endif

--- a/lib/Common/Memory/RecyclerTelemetryInfo.h
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.h
@@ -1,0 +1,140 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "CommonDefines.h"
+#include "RecyclerWaitReason.h"
+#include "Common/Tick.h"
+#include "AllocatorTelemetryStats.h"
+#include "HeapBucketStats.h"
+
+#ifdef ENABLE_BASIC_TELEMETRY
+#include "Windows.h"
+#endif
+
+namespace Memory
+{
+    class Recycler;
+    class IdleDecommitPageAllocator;
+    class RecyclerTelemetryInfo;
+
+    // struct that defines an interface with host on how we can get key data stats
+    class RecyclerTelemetryHostInterface
+    {
+    public:
+        virtual LPFILETIME GetLastScriptExecutionEndTime() const = 0;
+        virtual bool TransmitTelemetry(RecyclerTelemetryInfo& rti) = 0;
+        virtual bool TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char* msg) = 0;
+        virtual bool IsThreadBound() const = 0;
+        virtual DWORD GetCurrentScriptThreadID() const = 0;
+    };
+
+#ifdef ENABLE_BASIC_TELEMETRY
+
+    /**
+     *  struct with all data we want to capture for a specific GC pass.
+     *
+     *  This forms a linked list, one for each per-stats pass.
+     *  The last element in the list points to the head instead of nullptr.
+     */
+    struct RecyclerTelemetryGCPassStats
+    {
+        FILETIME passStartTimeFileTime;
+        Js::Tick passStartTimeTick;
+        Js::Tick passEndTimeTick;
+        Js::TickDelta startPassProcessingElapsedTime;
+        Js::TickDelta endPassProcessingElapsedTime;
+        Js::TickDelta computeBucketStatsElapsedTime;
+        FILETIME lastScriptExecutionEndTime;
+        RecyclerTelemetryGCPassStats* next;
+        Js::TickDelta uiThreadBlockedTimes[static_cast<size_t>(RecyclerWaitReason::Other) + 1];
+        bool isInScript;
+        bool isScriptActive;
+        bool isGCPassActive;
+
+        size_t processAllocaterUsedBytes_start;
+        size_t processAllocaterUsedBytes_end;
+        size_t processCommittedBytes_start;
+        size_t processCommittedBytes_end;
+
+        HeapBucketStats bucketStats;
+
+        AllocatorSizes threadPageAllocator_start;
+        AllocatorSizes threadPageAllocator_end;
+        AllocatorSizes recyclerLeafPageAllocator_start;
+        AllocatorSizes recyclerLeafPageAllocator_end;
+        AllocatorSizes recyclerLargeBlockPageAllocator_start;
+        AllocatorSizes recyclerLargeBlockPageAllocator_end;
+
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+        AllocatorSizes recyclerWithBarrierPageAllocator_start;
+        AllocatorSizes recyclerWithBarrierPageAllocator_end;
+#endif
+    };
+
+    /**
+     *
+     */
+    class RecyclerTelemetryInfo
+    {
+    public:
+        RecyclerTelemetryInfo(Recycler* recycler, RecyclerTelemetryHostInterface* hostInterface);
+        ~RecyclerTelemetryInfo();
+
+        void StartPass();
+        void EndPass();
+        void IncrementUserThreadBlockedCount(Js::TickDelta waitTime, RecyclerWaitReason source);
+        
+        inline const Js::Tick& GetRecyclerStartTime() const { return this->recyclerStartTime;  }
+        inline const RecyclerTelemetryGCPassStats* GetLastPassStats() const { return this->lastPassStats; }
+        inline const Js::Tick& GetLastTransmitTime() const { return this->lastTransmitTime; }
+        inline const uint16 GetPassCount() const { return this->passCount; }
+        const GUID& GetRecyclerID() const;
+        bool GetIsConcurrentEnabled() const;
+        bool ShouldCaptureRecyclerTelemetry() const;
+        bool IsOnScriptThread() const;
+
+        AllocatorDecommitStats* GetThreadPageAllocator_decommitStats() { return &this->threadPageAllocator_decommitStats; }
+        AllocatorDecommitStats* GetRecyclerLeafPageAllocator_decommitStats() { return &this->recyclerLeafPageAllocator_decommitStats; }
+        AllocatorDecommitStats* GetRecyclerLargeBlockPageAllocator_decommitStats() { return &this->recyclerLargeBlockPageAllocator_decommitStats; }
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+        AllocatorDecommitStats* GetRecyclerWithBarrierPageAllocator_decommitStats() { return &this->recyclerWithBarrierPageAllocator_decommitStats; }
+#endif
+
+    private:
+        Recycler* recycler;
+        DWORD mainThreadID;
+        RecyclerTelemetryHostInterface * hostInterface;
+        Js::Tick recyclerStartTime;
+
+        // TODO: update list below to SList.  Need to ensure we have same allocation semantics (specifically heap allocs, no exceptions on failure)
+        RecyclerTelemetryGCPassStats* lastPassStats;
+        Js::Tick lastTransmitTime;
+        uint16 passCount;
+        bool abortTelemetryCapture;
+
+        AllocatorDecommitStats threadPageAllocator_decommitStats;
+        AllocatorDecommitStats recyclerLeafPageAllocator_decommitStats;
+        AllocatorDecommitStats recyclerLargeBlockPageAllocator_decommitStats;
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+        AllocatorDecommitStats recyclerWithBarrierPageAllocator_decommitStats;
+#endif
+
+        bool ShouldTransmit();
+        void FreeGCPassStats();
+        void Reset();
+        void FillInSizeData(IdleDecommitPageAllocator* allocator, AllocatorSizes* sizes) const;
+
+        static size_t GetProcessCommittedBytes();
+    };
+#else
+    class RecyclerTelemetryInfo
+    {
+    };
+#endif // #ifdef ENABLE_BASIC_TELEMETRY
+
+}
+

--- a/lib/Common/Memory/RecyclerWaitReason.h
+++ b/lib/Common/Memory/RecyclerWaitReason.h
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "Core/CommonTypedefs.h"
+
+enum RecyclerWaitReason : uint8
+{
+#define P(n) n,
+#include "RecyclerWaitReasonInc.h"
+#undef P
+};

--- a/lib/Common/Memory/RecyclerWaitReasonInc.h
+++ b/lib/Common/Memory/RecyclerWaitReasonInc.h
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifndef P
+  #error P not defined
+#endif
+
+P(WaitReasonNone)
+P(RescanMark)
+P(DoParallelMark)
+P(RequestConcurrentCallbackWrapper)
+P(CollectOnConcurrentThread)
+P(FinishConcurrentCollect)
+P(Other)
+

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -225,7 +225,7 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLS
 #ifdef RECYCLER_TRACE
             if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MemoryAllocationPhase) && CONFIG_FLAG_RELEASE(Verbose))
             {
-                Output::Print(_u("[**33**]FreeListAlloc: Object 0x%p from HeapBlock 0x%p used for allocation during ConcurrentSweep [CollectionState: %d] \n"), memBlock, heapBlock, recycler->collectionState);
+                Output::Print(_u("[**33**]FreeListAlloc: Object 0x%p from HeapBlock 0x%p used for allocation during ConcurrentSweep [CollectionState: %d] \n"), memBlock, heapBlock, static_cast<CollectionState>(recycler->collectionState));
             }
 #endif
         }

--- a/lib/Common/Util/Chakra.Common.Util.vcxproj
+++ b/lib/Common/Util/Chakra.Common.Util.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props"/>
+  <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
   <PropertyGroup Label="Globals">
     <TargetName>Chakra.Common.Util</TargetName>
@@ -36,6 +36,6 @@
   <ItemGroup>
     <ClInclude Include="Pinned.h" />
   </ItemGroup>
-  <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')"/>
+  <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -345,6 +345,7 @@ namespace Js
 #endif
 
 #ifdef ENABLE_BASIC_TELEMETRY
+        // TODO - allocate this on the Heap instead of using a custom allocator?
         this->telemetry = Anew(this->TelemetryAllocator(), Js::ScriptContextTelemetry, this);
 #endif
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -35,7 +35,8 @@
 
 #ifdef ENABLE_BASIC_TELEMETRY
 #include "Telemetry.h"
-#endif
+#include "Recycler/RecyclerTelemetryTransmitter.h"
+#endif // ENABLE_BASIC_TELEMETRY
 
 const int TotalNumberOfBuiltInProperties = Js::PropertyIds::_countJSOnlyProperty;
 
@@ -208,6 +209,7 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     , noJsReentrancy(false)
 #endif
     , emptyStringPropertyRecord(nullptr)
+    , recyclerTelemetryHostInterface(this)
 {
     pendingProjectionContextCloseList = JsUtil::List<IProjectionContext*, ArenaAllocator>::New(GetThreadAlloc());
     hostScriptContextStack = Anew(GetThreadAlloc(), JsUtil::Stack<HostScriptContext*>, GetThreadAlloc());
@@ -662,11 +664,49 @@ public:
     }
 };
 
+LPFILETIME ThreadContext::ThreadContextRecyclerTelemetryHostInterface::GetLastScriptExecutionEndTime() const
+{
+#if defined(ENABLE_BASIC_TELEMETRY) && defined(NTBUILD)
+    return &(tc->telemetryBlock->lastScriptEndTime);
+#else
+    return nullptr;
+#endif
+}
+
+bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::TransmitTelemetry(RecyclerTelemetryInfo& rti)
+{
+#if defined(ENABLE_BASIC_TELEMETRY) && defined(NTBUILD)
+    return Js::TransmitRecyclerTelemetry(rti);
+#else
+    return false;
+#endif
+}
+
+bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char * msg)
+{
+#if defined(ENABLE_BASIC_TELEMETRY) && defined(NTBUILD)
+    return Js::TransmitRecyclerTelemetryError(rti, msg);
+#else
+    return false;
+#endif
+}
+
+bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::IsThreadBound() const
+{
+    return this->tc->IsThreadBound(); 
+}
+
+
+DWORD ThreadContext::ThreadContextRecyclerTelemetryHostInterface::GetCurrentScriptThreadID() const
+{
+    return this->tc->GetCurrentThreadId();
+}
+
 Recycler* ThreadContext::EnsureRecycler()
 {
     if (recycler == NULL)
     {
-        AutoRecyclerPtr newRecycler(HeapNew(Recycler, GetAllocationPolicyManager(), &pageAllocator, Js::Throw::OutOfMemory, Js::Configuration::Global.flags));
+        AutoRecyclerPtr newRecycler(HeapNew(Recycler, GetAllocationPolicyManager(), &pageAllocator, Js::Throw::OutOfMemory, Js::Configuration::Global.flags, &recyclerTelemetryHostInterface));
         newRecycler->Initialize(isOptimizedForManyInstances, &threadService); // use in-thread GC when optimizing for many instances
         newRecycler->SetCollectionWrapper(this);
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -885,6 +885,7 @@ public:
 
 #ifdef ENABLE_BASIC_TELEMETRY
     GUID activityId;
+    LPFILETIME GetLastScriptExecutionEndTime() const;
 #endif
     void *tridentLoadAddress;
 
@@ -1826,6 +1827,26 @@ private:
 
     DWORD threadId;
 #endif
+
+private:
+    class ThreadContextRecyclerTelemetryHostInterface : public RecyclerTelemetryHostInterface
+    {
+    public:
+        ThreadContextRecyclerTelemetryHostInterface(ThreadContext* tc) :
+            tc(tc)
+        {
+        }
+
+        virtual LPFILETIME GetLastScriptExecutionEndTime() const;
+        virtual bool TransmitTelemetry(RecyclerTelemetryInfo& rti);
+        virtual bool TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char * msg);
+        virtual bool ThreadContextRecyclerTelemetryHostInterface::IsThreadBound() const;
+        virtual DWORD ThreadContextRecyclerTelemetryHostInterface::GetCurrentScriptThreadID() const;
+
+    private:
+        ThreadContext * tc;
+    };
+    ThreadContextRecyclerTelemetryHostInterface recyclerTelemetryHostInterface;
 };
 
 extern void(*InitializeAdditionalProperties)(ThreadContext *threadContext);


### PR DESCRIPTION
Updated Recycler & associated classes to capture & transmit GC-related telemetry data.  This includes:

  - PageAllocator sizes
  - Total Bytes used by the recycler (across all HeapBuckets)
  - Amount of time GC blocks the UI thread
  - Number of pages de-committed for each allocator.
  -  Microsecond time values for how long we spend computing the telemetry statistics.

The actual data we collect will evolve as we start digging into it 
  
We define a "GC Pass" as the period from when the Recycler's CollectionState  transitions from `Not Collecting` and then transitions back to `Not Collecting` . We compute most stats based on this "Pass".  We currently attempt to transmit data when we have 16 passes accumulated.  Again, this will be tweaked as dig into specific telemetry data flowing back indicating frequency of GC passes & frequency of transmissions.

Capturing MemGC stats is out-of-scope at this time.

There are still some TODOs pending based on early feedback, namely:
  - [ ] Run benchmarks and get a feel for impact on those.
  - [x] Fine-tune the assertions about which thread we're running on
  - [x] include indicators if Concurrent GC is enabled. 