### PR TITLE
Update ICU character classification

### DIFF
--- a/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.ICU.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.ICU.cpp
@@ -224,7 +224,7 @@ namespace PlatformAgnostic
 
         bool IsWhitespace(codepoint_t ch)
         {
-            return u_isUWhiteSpace(ch) == 1;
+            return u_hasBinaryProperty(ch, UCHAR_WHITE_SPACE);
         }
 
         template<bool toUpper, bool useInvariant>
@@ -258,12 +258,12 @@ namespace PlatformAgnostic
 
         bool IsIdStart(codepoint_t ch)
         {
-            return u_isIDStart(ch);
+            return u_hasBinaryProperty(ch, UCHAR_ID_START);
         }
 
         bool IsIdContinue(codepoint_t ch)
         {
-            return u_isIDPart(ch);
+            return u_hasBinaryProperty(ch, UCHAR_ID_CONTINUE);
         }
 
         int LogicalStringCompare(const char16* string1, const char16* string2)

--- a/test/DebuggerCommon/ES6_intl_simple_attach.js
+++ b/test/DebuggerCommon/ES6_intl_simple_attach.js
@@ -18,16 +18,16 @@ function Run() {
 
     WScript.Echo('PASSED');/**bp:
     locals(1);
-	evaluate('coll',4);
-	evaluate('numFormat',4);
-	evaluate('dttmFormat',4);
-	evaluate('coll.compare.toString() == \'function() {\\n    [native code]\\n}\'');
+    evaluate('coll',4);
+    evaluate('numFormat',4);
+    evaluate('dttmFormat',4);
+    evaluate('coll.compare.toString() == \'function() {\\n    [native code]\\n}\'');
     evaluate('coll.resolvedOptions.toString() == \'function() {\\n    [native code]\\n}\'');
     evaluate('numFormat.format.toString() == \'function() {\\n    [native code]\\n}\'');
     evaluate('numFormat.resolvedOptions.toString() == \'function() {\\n    [native code]\\n}\'');
     evaluate('dttmFormat.format.toString() == \'function() {\\n    [native code]\\n}\'');
     evaluate('dttmFormat.resolvedOptions.toString() == \'function() {\\n    [native code]\\n}\'');
-	**/
+    **/
 }
 
 var x; /**bp:evaluate('Intl.Collator')**/

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -32,16 +32,14 @@
     <default>
       <compile-flags>-debuglaunch -dbgbaseline:IntlInit.js.dbg.baseline -Intl</compile-flags>
       <files>IntlInit.js</files>
-      <!-- xplat-todo: enable on xplat when Intl is supported on xplat (Microsoft/ChakraCore#2919) -->
-      <tags>require_winglob,exclude_xplat,Intl</tags>
+      <tags>Intl</tags>
     </default>
   </test>
   <test>
     <default>
       <files>ES6_intl_stepinto.js</files>
       <compile-flags>-dbgbaseline:ES6_intl_stepinto.js.dbg.baseline -Intl</compile-flags>
-      <!-- xplat-todo: enable on xplat when Intl is supported on xplat (Microsoft/ChakraCore#2919) -->
-      <tags>require_winglob,exclude_xplat,Intl</tags>
+      <tags>Intl</tags>
     </default>
   </test>
   <test>
@@ -220,8 +218,7 @@
       <files>ES6_intl_simple_attach.js</files>
       <compile-flags>-dbgbaseline:ES6_intl_simple_attach.js.dbg.baseline -Intl</compile-flags>
       <baseline>ES6_intl_simple_attach.js.baseline</baseline>
-      <!-- xplat-todo: enable on xplat when Intl is supported on xplat (Microsoft/ChakraCore#2919) -->
-      <tags>require_winglob,exclude_xplat,Intl</tags>
+      <tags>Intl,require_winglob</tags>
     </default>
   </test>
   <test>
@@ -293,8 +290,7 @@
     <default>
       <files>ES6_intl_stepinto_libexpandos.js</files>
       <compile-flags>-debuglaunch -dbgbaseline:ES6_intl_stepinto_libexpandos.js.dbg.baseline -Intl</compile-flags>
-      <!-- xplat-todo: enable on xplat when Intl is supported on xplat (Microsoft/ChakraCore#2919) -->
-      <tags>require_winglob,exclude_xplat,Intl</tags>
+      <tags>Intl</tags>
     </default>
   </test>
   <test>

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -218,6 +218,7 @@
       <files>ES6_intl_simple_attach.js</files>
       <compile-flags>-dbgbaseline:ES6_intl_simple_attach.js.dbg.baseline -Intl</compile-flags>
       <baseline>ES6_intl_simple_attach.js.baseline</baseline>
+      <!-- This test is still require_winglob because it has winglob-specific output in the .dbg.baseline -->
       <tags>Intl,require_winglob</tags>
     </default>
   </test>

--- a/test/Scanner/rlexe.xml
+++ b/test/Scanner/rlexe.xml
@@ -4,7 +4,6 @@
     <default>
       <files>NumericLiteralSuffix.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>require_winglob</tags> <!-- Microsoft/ChakraCore#3777: Fix this test under ICU -->
     </default>
   </test>
   <test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -525,7 +525,7 @@
       <files>unicode_6_identifiers_utf8.js</files>
       <baseline>unicode_6_identifiers_utf8.baseline</baseline>
       <compile-flags> -ES6Unicode</compile-flags>
-      <tags>exclude_win7,require_winglob,exclude_noicu</tags> <!-- Microsoft/ChakraCore#3777: Fix this test under ICU -->
+      <tags>exclude_win7,exclude_noicu</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -166,6 +166,10 @@ if args.static != None:
 
 if sys.platform == 'darwin':
     not_tags.add('exclude_mac')
+
+if 'require_icu' in not_tags or 'exclude_noicu' in not_tags:
+    not_tags.add('Intl')
+
 not_compile_flags = None
 
 # use -j flag to specify number of parallel processes

--- a/test/utf8/OS_2977448.js
+++ b/test/utf8/OS_2977448.js
@@ -7,8 +7,9 @@ try {
     // Ensure that character classifier does not incorrectly classify \u2e2f as a letter.
     eval("ⸯ");
 } catch (e) {
-    if (e instanceof SyntaxError)
-    {
+    if (e instanceof SyntaxError) {
         WScript.Echo("PASS");
+    } else {
+        WScript.Echo(e);
     }
 }

--- a/test/utf8/rlexe.xml
+++ b/test/utf8/rlexe.xml
@@ -16,7 +16,6 @@
   <test>
     <default>
       <files>OS_2977448.js</files>
-      <tags>require_winglob</tags>
     </default>
   </test>
   <test>
@@ -39,7 +38,7 @@
     <default>
       <files>bugGH2656.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
-      <tags>require_winglob,exclude_noicu</tags> <!-- Microsoft/ChakraCore#3777: Fix this test under ICU -->
+      <tags>exclude_noicu</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
For reasons I don't entirely understand, u_isIDStart only checks against Unicode 3, which we never noticed in the documentation. u_hasBinaryProperty with the UCHAR_ID_START property uses the latest Unicode rules.