### PR TITLE
OS#17436985: Fix stack overflow in SimpleDataCacheWrapper::SeekReadStreamToBlockHelper

### DIFF
--- a/lib/Runtime/Language/SimpleDataCacheWrapper.cpp
+++ b/lib/Runtime/Language/SimpleDataCacheWrapper.cpp
@@ -91,8 +91,13 @@ namespace Js
         HRESULT hr = E_FAIL;
 
         IFFAILRET(AutoSystemInfo::GetJscriptFileVersion(&jscriptMajorVersion, &jscriptMinorVersion));
+
+        Assert(this->bytesWrittenInBlock == 0);
+
         IFFAILRET(Write(jscriptMajorVersion));
         IFFAILRET(Write(jscriptMinorVersion));
+
+        Assert(this->bytesWrittenInBlock == sizeof(DWORD) * 2);
 
         return hr;
     }
@@ -198,6 +203,10 @@ namespace Js
                 *bytesInBlock = byteCount;
             }
             return S_OK;
+        }
+        else if (currentBlockType == BlockType_Invalid || byteCount == 0)
+        {
+            return E_FAIL;
         }
 
 #ifdef ENABLE_WININET_PROFILE_DATA_CACHE

--- a/lib/Runtime/Language/SimpleDataCacheWrapper.h
+++ b/lib/Runtime/Language/SimpleDataCacheWrapper.h
@@ -69,8 +69,13 @@ namespace Js
 #ifdef ENABLE_WININET_PROFILE_DATA_CACHE
             ULONG bytesWritten = 0;
             hr = this->outStream->Write(&data, sizeof(T), &bytesWritten);
+            Assert(bytesWritten == sizeof(T) || FAILED(hr) || hr == S_FALSE);
             bytesWrittenInBlock += bytesWritten;
             // hr is S_FALSE if bytesRead < sizeOf(T)
+            if (hr == S_FALSE)
+            {
+                hr = E_FAIL;
+            }
 #endif
             return hr;
         }
@@ -84,8 +89,13 @@ namespace Js
             ULONG bytesSize = sizeof(T) * len;
             ULONG bytesWritten = 0;
             hr = this->outStream->Write(data, bytesSize, &bytesWritten);
+            Assert(bytesWritten == bytesSize || FAILED(hr) || hr == S_FALSE);
             bytesWrittenInBlock += bytesWritten;
             // hr is S_FALSE if bytesRead < bytesSize
+            if (hr == S_FALSE)
+            {
+                hr = E_FAIL;
+            }
 #endif
             return hr;
         }
@@ -98,7 +108,12 @@ namespace Js
 #ifdef ENABLE_WININET_PROFILE_DATA_CACHE
             ULONG bytesRead = 0;
             hr = this->inStream->Read(data, sizeof(T), &bytesRead);
+            Assert(bytesRead == sizeof(T) || FAILED(hr) || hr == S_FALSE);
             // hr is S_FALSE if bytesRead < sizeOf(T)
+            if (hr == S_FALSE)
+            {
+                hr = E_FAIL;
+            }
 #endif
             return hr;
         }
@@ -112,7 +127,12 @@ namespace Js
             ULONG bytesSize = sizeof(T) * len;
             ULONG bytesRead = 0;
             hr = this->inStream->Read(data, bytesSize, &bytesRead);
+            Assert(bytesRead == bytesSize || FAILED(hr) || hr == S_FALSE);
             // hr is S_FALSE if bytesRead < bytesSize
+            if (hr == S_FALSE)
+            {
+                hr = E_FAIL;
+            }
 #endif
             return hr;
         }


### PR DESCRIPTION
It's possible for IStream::Read to return S_FALSE without actually reading any bytes from the stream. In that case we will infinitely recurse looking for a valid block because S_FALSE is not a failed HRESULT. To make sure we don't hit this, check to see if we failed to read the block type and bail early. Also convert S_FALSE into E_FAIL in the read and write functions of SimpleDataCacheWrapper to make it fail earlier.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/17436985
