### PR TITLE
Fix the message for implicit Symbol.toString to make it more descriptive 

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -410,3 +410,6 @@ RT_ERROR_MSG(WASMERR_SharedNoMaximum, 7032, "", "Shared memory must have a maxim
 
 // Wabt Errors
 RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)
+
+// Implicit Conversion Errors
+RT_ERROR_MSG(JSERR_ImplicitStrConv, 7300, "No implicit conversion of %s to String", "Cannot implicitly convert to String", kjstTypeError, 0)

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -312,7 +312,7 @@ namespace Js
     {
         if (requestContext->GetThreadContext()->RecordImplicitException())
         {
-            JavascriptError::ThrowTypeError(requestContext, VBSERR_OLENoPropOrMethod, _u("ToString"));
+            JavascriptError::ThrowTypeError(requestContext, JSERR_ImplicitStrConv, _u("Symbol"));
         }
 
         return requestContext->GetLibrary()->GetEmptyString();

--- a/test/es6/ES6Symbol.js
+++ b/test/es6/ES6Symbol.js
@@ -185,14 +185,14 @@ var tests = [
     {
         name: "Symbol primitive toString should throw a type error",
         body: function() {
-            assert.throws(function() { 'string' + Symbol.iterator; }, TypeError, "Symbol primitives throw on implicit string conversion", "Object doesn't support property or method 'ToString'");
+            assert.throws(function() { 'string' + Symbol.iterator; }, TypeError, "Symbol primitives throw on implicit string conversion", "No implicit conversion of Symbol to String");
         }
     },
     {
         name: "String(symbol) behavior",
         body: function() {
             assert.areEqual('Symbol(description)', String(Symbol('description')), "String(Symbol('description')) === 'Symbol(description)'");
-            assert.throws(function () { new String(Symbol('description')); }, TypeError, "Symbol as an argument to new String() throws", "Object doesn't support property or method 'ToString'");
+            assert.throws(function () { new String(Symbol('description')); }, TypeError, "Symbol as an argument to new String() throws", "No implicit conversion of Symbol to String");
         }
     },
     {
@@ -827,8 +827,8 @@ var tests = [
         body: function() {
             var x = Symbol();
 
-            assert.throws(function() { "str" + x; }, TypeError, "Adding a string and a symbol throws TypeError", "Object doesn't support property or method 'ToString'");
-            assert.throws(function() { x + "str"; }, TypeError, "Adding a symbol and a string throws TypeError", "Object doesn't support property or method 'ToString'");
+            assert.throws(function() { "str" + x; }, TypeError, "Adding a string and a symbol throws TypeError", "No implicit conversion of Symbol to String");
+            assert.throws(function() { x + "str"; }, TypeError, "Adding a symbol and a string throws TypeError", "No implicit conversion of Symbol to String");
             assert.throws(function() { 10 + x; }, TypeError, "Adding a number and a symbol throws TypeError", "Number expected");
             assert.throws(function() { x + 10; }, TypeError, "Adding a symbol and a number throws TypeError", "Number expected");
         }

--- a/test/es6module/dynamic-module-import-specifier.js
+++ b/test/es6module/dynamic-module-import-specifier.js
@@ -133,7 +133,7 @@ var tests = [
             testNonStringSpecifier("1/0", "URIError", "Infinity");
             testNonStringSpecifier("1.123456789012345678901", "URIError", "1.1234567890123457");
             testNonStringSpecifier("-1.123456789012345678901", "URIError", "-1.1234567890123457");
-            testNonStringSpecifier('Symbol("abc")', "TypeError", "Object doesn't support property or method 'ToString'");
+            testNonStringSpecifier('Symbol("abc")', "TypeError", "No implicit conversion of Symbol to String");
             testNonStringSpecifier("{}", "URIError", "[object Object]");
         }
     },

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -116,7 +116,7 @@ Test 1 passed. Expected Error: TypeError: WebAssembly.Module expected
 Test 2 passed. Expected Error: TypeError: WebAssembly.Module expected
 Test 3 passed. Expected Error: TypeError: WebAssembly.Module expected
 Test 4 passed. Expected Error: Error: Doesn't support toString
-Test 5 passed. Expected Error: TypeError: Object doesn't support property or method 'ToString'
+Test 5 passed. Expected Error: TypeError: No implicit conversion of Symbol to String
 6/6 tests passed
 
 new WebAssembly.Instance tests


### PR DESCRIPTION
-Changed error message for implicit conversion of Symbols to Strings
-Added new runtime error message in string table