### PR TITLE
pack dictionary entries better

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -288,18 +288,14 @@ typedef JsUtil::BaseDictionary<ValueNumberPair, Value *, JitArenaAllocator> Valu
 namespace JsUtil
 {
     template <>
-    class ValueEntry<StackLiteralInitFldData> : public BaseValueEntry<StackLiteralInitFldData>
+    inline void ClearValue<StackLiteralInitFldData>::Clear(StackLiteralInitFldData* value)
     {
-    public:
-        void Clear()
-        {
 #if DBG
-            this->value.propIds = nullptr;
-            this->value.currentInitFldCount = (uint)-1;
+        value->propIds = nullptr;
+        value->currentInitFldCount = (uint)-1;
 #endif
-        }
-    };
-};
+    }
+}
 
 typedef JsUtil::BaseDictionary<IntConstType, StackSym *, JitArenaAllocator> IntConstantToStackSymMap;
 typedef JsUtil::BaseDictionary<int32, Value *, JitArenaAllocator> IntConstantToValueMap;

--- a/lib/Runtime/Base/RegexPatternMruMap.h
+++ b/lib/Runtime/Base/RegexPatternMruMap.h
@@ -12,13 +12,8 @@ namespace Js
 namespace JsUtil
 {
     template <>
-    class ValueEntry<Js::RegexPatternMruMap::MruDictionaryData>: public BaseValueEntry<Js::RegexPatternMruMap::MruDictionaryData>
+    inline void ClearValue<Js::RegexPatternMruMap::MruDictionaryData>::Clear(Js::RegexPatternMruMap::MruDictionaryData* value)
     {
-    public:
-        void Clear()
-        {
-            this->value = 0;
-        }
-    };
-
-};
+        *value = 0;
+    }
+}

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -424,12 +424,8 @@ namespace Js
 namespace JsUtil
 {
     template <>
-    class ValueEntry<Js::ByteCodeWriter::CacheIdUnit>: public BaseValueEntry<Js::ByteCodeWriter::CacheIdUnit>
+    inline void ClearValue<Js::ByteCodeWriter::CacheIdUnit>::Clear(Js::ByteCodeWriter::CacheIdUnit* value)
     {
-    public:
-        void Clear()
-        {
-            this->value = 0;
-        }
-    };
-};
+        *value = 0;
+    }
+}

--- a/lib/Runtime/Types/SimpleDictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/SimpleDictionaryPropertyDescriptor.h
@@ -62,13 +62,12 @@ namespace Js
 
 namespace JsUtil
 {
-    template <typename TPropertyIndex>
-    class ValueEntry<Js::SimpleDictionaryPropertyDescriptor<TPropertyIndex> >: public BaseValueEntry<Js::SimpleDictionaryPropertyDescriptor<TPropertyIndex>>
+    template <class TPropertyIndex>
+    struct ClearValue<Js::SimpleDictionaryPropertyDescriptor<TPropertyIndex>>
     {
-    public:
-        void Clear()
+        static inline void Clear(Js::SimpleDictionaryPropertyDescriptor<TPropertyIndex>* value)
         {
-            this->value = 0;
+            *value = 0;
         }
     };
 }


### PR DESCRIPTION
When reading Jimmy's change yesterday, I noticed an opportunity for ~~causing obnoxious merge conflicts~~ reducing memory usage. We frequently have recycler entries that are one pointer and two ints, but they take up 24 bytes instead of 16 due to inefficient packing. With this change, we can ask the compiler to put the `next` integer wherever leads to a smaller representation: either after the value or after the key. On Teams this reduces the size of `Js::Utf8SourceInfo.{FunctionBodyDictionary}.entries` by 550 kB, `ThreadContext::RecyclableData.typesWithProtoPropertyCache.entries` and `NativeEntryPointData(Func).{SharedPropertyGuardDictionary}.entries` by 65 kB each, and a couple of other smaller dictionaries.

This change also simplifies the `Clear` method on dictionary entries to use `TValue()` or `TKey()` to reset integral values to zero. A few more complicated types still require specializations.