### PR TITLE
Fix errors in construction of bound Functions

### DIFF
--- a/test/UnitTestFramework/UnitTestFramework.js
+++ b/test/UnitTestFramework/UnitTestFramework.js
@@ -26,6 +26,7 @@
 //     example: testRunner.LoadModule(source, 'samethread', false);
 //
 //   How to use assert:
+//     assert.strictEqual(expected, actual, "those two should be strictly equal (i.e. === comparison)");
 //     assert.areEqual(expected, actual, "those two should be equal (i.e. deep equality of objects using ===)");
 //     assert.areNotEqual(expected, actual, "those two should NOT be equal");
 //     assert.areAlmostEqual(expected, actual, "those two should be almost equal, numerically (allows difference by epsilon)");
@@ -407,6 +408,10 @@ var assert = function assert() {
     }
 
     return {
+        strictEqual: function strictEqual(expected, actual, message) {
+            validate(expected === actual, "strictEqual", message);
+        },
+
         areEqual: function areEqual(expected, actual, message) {
             /// <summary>
             /// IMPORTANT: NaN compares equal.<br/>

--- a/test/es6/boundConstruction.js
+++ b/test/es6/boundConstruction.js
@@ -1,0 +1,108 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+//setup code
+let constructionCount = 0;
+let functionCallCount = 0;
+function a(arg1, arg2) {
+    this[arg1] = arg2;
+    ++functionCallCount;
+}
+
+const trapped = new Proxy(a, {
+    construct: function (x, y, z) {
+        ++constructionCount;
+        return Reflect.construct(x, y, z);
+    }
+});
+
+const noTrap = new Proxy(a, {});
+
+const boundObject = {};
+
+const boundFunc = a.bind(boundObject, "prop-name");
+
+const boundTrapped = trapped.bind(boundObject, "prop-name");
+const boundUnTrapped = noTrap.bind(boundObject, "prop-name");
+
+const tests = [
+    {
+        name : "Construct trapped bound proxy with new",
+        body : function() {
+            constructionCount = 0;
+            functionCallCount = 0;
+            const obj = new boundTrapped("prop-value");
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.areEqual("prop-value", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, constructionCount, "bound proxy should be constructed once");
+            assert.areEqual(1, functionCallCount, "bound proxy function should be called once");
+            assert.strictEqual(a.prototype, obj.__proto__, "constructed object should be instance of original function");
+        }
+    },
+    {
+        name : "Construct trapped bound proxy with Reflect",
+        body : function() {
+            class newTarget {}
+            constructionCount = 0;
+            functionCallCount = 0;
+            const obj = Reflect.construct(boundTrapped, ["prop-value-2"], newTarget);
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.strictEqual(newTarget.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, constructionCount, "bound proxy should be constructed once");
+            assert.areEqual(1, functionCallCount, "bound proxy function should be called once");
+        }
+    },
+    {
+        name : "Construct bound proxy with new",
+        body : function() {
+            functionCallCount = 0;
+            const obj = new boundUnTrapped("prop-value");
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.areEqual("prop-value", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, functionCallCount, "bound proxy function should be called once");
+            assert.strictEqual(a.prototype, obj.__proto__, "constructed object should be instance of original function");
+        }
+    },
+    {
+        name : "Construct bound proxy with Reflect",
+        body : function() {
+            class newTarget {}
+            functionCallCount = 0;
+            const obj = Reflect.construct(boundUnTrapped, ["prop-value-2"], newTarget);
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.strictEqual(newTarget.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, functionCallCount, "bound proxy function should be called once");
+        }
+    },
+    {
+        name : "Construct bound function with Reflect",
+        body : function() {
+            class newTarget {}
+            functionCallCount = 0;
+            const obj = Reflect.construct(boundFunc, ["prop-value-2"], newTarget);
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.strictEqual(newTarget.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, functionCallCount, "bound function should be called once");
+        }
+    },
+    {
+        name : "Construct bound function with new",
+        body : function() {
+            functionCallCount = 0;
+            const obj = new boundFunc("prop-value-2");
+            assert.areNotEqual(boundObject, obj, "bound function should ignore bound this when constructing");
+            assert.strictEqual(a.prototype, obj.__proto__, "bound function should use explicit newTarget if provided");
+            assert.areEqual("prop-value-2", obj["prop-name"], "bound function should keep bound arguments when constructing");
+            assert.areEqual(1, functionCallCount, "bound function should be called once");
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" }); 

--- a/test/es6/proxytest9.baseline
+++ b/test/es6/proxytest9.baseline
@@ -77,9 +77,6 @@ constructor trap
 constructor trap
 get trap prototype
 constructor trap
-constructor trap
-get trap prototype
-constructor trap
 true
 get trap m
 def

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -569,6 +569,12 @@
   </test>
   <test>
     <default>
+      <files>boundConstruction.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>CrossContextSpreadfunctionCall.js</files>
     </default>
   </test>


### PR DESCRIPTION
Revisiting boundProxies found what I hope are the right fixes this time.

This PR addresses the following issues:
1. Constructing bound Proxy would call construct trap twice or if there wasn't a construct trap targetFunction would be called twice,
2. Reflect.construct in construct trap of bound Proxy would attempt to construct "this" and error as it's not a constructor (issue 4918)
3. Constructing a bound function via Reflect with a newTarget would ignore the newTarget.

Added test cases for these points and some related patterns that do work but weren't being tested and  which some other ways of fixing points 1-3 would break.

Also corrected the baseline for proxytest9.js which was testing the incorrect behaviour of construct traps for bound proxies being called twice.

The interaction of bound functions and proxies is complex enough that I'm afraid I'm confident that there'll be one or more bugs left after this, but this should be a reasonable improvement from the current state.

@sethbrenith I borrowed your test case from 4918 as the starting point for the cases here, I hope that's ok. Note I split it into two as it highlighted 2 different issues.

Fixes: #4918
Fixes: #5151 