### PR TITLE
Only capture recycler stats if telemetry provider is enabled.

### DIFF
--- a/lib/Common/Memory/RecyclerTelemetryInfo.h
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.h
@@ -28,6 +28,7 @@ namespace Memory
         virtual LPFILETIME GetLastScriptExecutionEndTime() const = 0;
         virtual bool TransmitTelemetry(RecyclerTelemetryInfo& rti) = 0;
         virtual bool TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char* msg) = 0;
+        virtual bool IsTelemetryProviderEnabled() const = 0;
         virtual bool IsThreadBound() const = 0;
         virtual DWORD GetCurrentScriptThreadID() const = 0;
     };
@@ -94,7 +95,6 @@ namespace Memory
         inline const uint16 GetPassCount() const { return this->passCount; }
         const GUID& GetRecyclerID() const;
         bool GetIsConcurrentEnabled() const;
-        bool ShouldCaptureRecyclerTelemetry() const;
         bool IsOnScriptThread() const;
 
         AllocatorDecommitStats* GetThreadPageAllocator_decommitStats() { return &this->threadPageAllocator_decommitStats; }
@@ -109,6 +109,7 @@ namespace Memory
         DWORD mainThreadID;
         RecyclerTelemetryHostInterface * hostInterface;
         Js::Tick recyclerStartTime;
+        bool inPassActiveState;
 
         // TODO: update list below to SList.  Need to ensure we have same allocation semantics (specifically heap allocs, no exceptions on failure)
         RecyclerTelemetryGCPassStats* lastPassStats;
@@ -123,7 +124,8 @@ namespace Memory
         AllocatorDecommitStats recyclerWithBarrierPageAllocator_decommitStats;
 #endif
 
-        bool ShouldTransmit();
+        bool ShouldStartTelemetryCapture() const;
+        bool ShouldTransmit() const;
         void FreeGCPassStats();
         void Reset();
         void FillInSizeData(IdleDecommitPageAllocator* allocator, AllocatorSizes* sizes) const;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -682,6 +682,16 @@ bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::TransmitTelemet
 #endif
 }
 
+
+bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::IsTelemetryProviderEnabled() const
+{
+#if defined(ENABLE_BASIC_TELEMETRY) && defined(NTBUILD)
+    return Js::IsTelemetryProviderEnabled();
+#else
+    return false;
+#endif
+}
+
 bool ThreadContext::ThreadContextRecyclerTelemetryHostInterface::TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char * msg)
 {
 #if defined(ENABLE_BASIC_TELEMETRY) && defined(NTBUILD)

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1842,6 +1842,7 @@ private:
         virtual bool TransmitTelemetryError(const RecyclerTelemetryInfo& rti, const char * msg);
         virtual bool ThreadContextRecyclerTelemetryHostInterface::IsThreadBound() const;
         virtual DWORD ThreadContextRecyclerTelemetryHostInterface::GetCurrentScriptThreadID() const;
+        virtual bool IsTelemetryProviderEnabled() const;
 
     private:
         ThreadContext * tc;


### PR DESCRIPTION
This will avoid most work in scenarios where telemetry data is not being captured, which is for the majority of users when we actually ship. 