### PR TITLE
Should use large count (OS# 17406027)

### DIFF
--- a/lib/Runtime/Base/CrossSite.cpp
+++ b/lib/Runtime/Base/CrossSite.cpp
@@ -464,7 +464,7 @@ namespace Js
 
         if (callerHostScriptContext == calleeHostScriptContext || (callerHostScriptContext == nullptr && !calleeHostScriptContext->HasCaller()))
         {
-            return JavascriptFunction::CallFunction<true>(function, entryPoint, args);
+            return JavascriptFunction::CallFunction<true>(function, entryPoint, args, true /*useLargeArgCount*/);
         }
 
 #if DBG_DUMP || defined(PROFILE_EXEC) || defined(PROFILE_MEM)
@@ -536,7 +536,7 @@ namespace Js
             }
             wasDispatchExCallerPushed = TRUE;
 
-            result = JavascriptFunction::CallFunction<true>(function, entryPoint, args);
+            result = JavascriptFunction::CallFunction<true>(function, entryPoint, args, true /*useLargeArgCount*/);
             ScriptContext* callerScriptContext = callerHostScriptContext->GetScriptContext();
             result = CrossSite::MarshalVar(callerScriptContext, result);
         },

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -644,7 +644,7 @@ namespace Js
         ///
         /// Call the [[Call]] method on the function object
         ///
-        return JavascriptFunction::CallFunction<true>(pFunc, pFunc->GetEntryPoint(), args);
+        return JavascriptFunction::CallFunction<true>(pFunc, pFunc->GetEntryPoint(), args, true /*useLargeArgCount*/);
     }
 
     Var JavascriptFunction::CallRootFunctionInScript(JavascriptFunction* func, Arguments args)
@@ -930,7 +930,7 @@ namespace Js
         }
         else
         {
-            functionResult = CallFunction<true>(functionObj, functionObj->GetEntryPoint(), newArgs);
+            functionResult = CallFunction<true>(functionObj, functionObj->GetEntryPoint(), newArgs, true /*useLargeArgCount*/);
         }
 
         return

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -99,6 +99,38 @@ var tests = [
 
         assert.throws(()=> {arr.splice(4294967290, 0, 200, 201, 202, 203, 204, 205, 206);});
     }
+  },
+  {
+    name: "Passing args count near 2**16 should not fire assert (OS# 17406027)",
+    body: function () {
+      try {
+        eval.call(...(new Array(2**16)));
+      } catch (e) { }
+      
+      try {
+        eval.call(...(new Array(2**16+1)));
+      } catch (e) { }
+      
+      try {
+        var sc1 = WScript.LoadScript(`function foo() {}`, "samethread");
+        sc1.foo(...(new Array(2**16)));
+      } catch(e) { }
+      
+      try {
+        var sc2 = WScript.LoadScript(`function foo() {}`, "samethread");
+        sc2.foo(...(new Array(2**16+1)));
+      } catch(e) { }
+
+      try {
+        function foo() {}
+        Reflect.construct(foo, new Array(2**16-3));
+      } catch(e) { }
+
+      try {
+        function foo() {}
+        Reflect.construct(foo, new Array(2**16-2));
+      } catch(e) { }
+    }
   }
   
 ];


### PR DESCRIPTION
We didn't pass 'useLargeArgsCount' in these scenarios, which are legitimate cases.
Entrycall, cross-site and Reflect.construct
Fixed them.
