### PR TITLE
[MSFT 17513966] Handle case where a non-path type changes to a path type during enumeration

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -336,8 +336,7 @@ namespace Js
 
         if (!typeHandlerToEnumerate->IsPathTypeHandler())
         {
-            AssertMsg(false, "Can only enumerate PathTypeHandler if types don't match.");
-            Js::Throw::InternalError();
+            return typeHandlerToEnumerate->FindNextProperty(scriptContext, index, propertyStringName, propertyId, attributes, type, typeToEnumerate, flags, instance, info);
         }
 
         PathTypeHandlerBase* pathTypeToEnumerate = (PathTypeHandlerBase*)typeHandlerToEnumerate;


### PR DESCRIPTION
It's now normal for, e.g., null or simple type to evolve to a path type.