### PR TITLE
Updating thread verification asserts to only fire if we're actually collecting telemetry

### DIFF
--- a/lib/Common/Memory/RecyclerTelemetryInfo.cpp
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.cpp
@@ -34,12 +34,12 @@ namespace Memory
 
     RecyclerTelemetryInfo::~RecyclerTelemetryInfo()
     {
-        AssertOnValidThread(this, RecyclerTelemetryInfo::~RecyclerTelemetryInfo);
         if (this->hostInterface != nullptr && this->passCount > 0)
         {
+            AssertOnValidThread(this, RecyclerTelemetryInfo::~RecyclerTelemetryInfo);
             this->hostInterface->TransmitTelemetry(*this);
+            this->FreeGCPassStats();
         }
-        this->FreeGCPassStats();
     }
 
     const GUID& RecyclerTelemetryInfo::GetRecyclerID() const
@@ -195,10 +195,9 @@ namespace Memory
 
     void RecyclerTelemetryInfo::FreeGCPassStats()
     {
-        AssertOnValidThread(this, RecyclerTelemetryInfo::FreeGCPassStats);
-
         if (this->lastPassStats != nullptr)
         {
+            AssertOnValidThread(this, RecyclerTelemetryInfo::FreeGCPassStats);
             RecyclerTelemetryGCPassStats* head = this->lastPassStats->next;
             RecyclerTelemetryGCPassStats* curr = head;
 #ifdef DBG


### PR DESCRIPTION
In the MemGC case, some code paths are hit that validate the threading assumption in RecyclerTelemetryInfo.  However, that's OK since in MemGC we're not collecting any telemetry data yet.  This change relaxes these asserts to only fire in the event we're collecting telemetry data. 