### PR TITLE
Constructing object on chained proxy

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -2136,7 +2136,9 @@ namespace Js
                 {
                     JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedFunction, _u("construct"));
                 }
-                if (!isCtorSuperCall)
+
+                // args.Values[0] will be null in the case where NewTarget is initially provided by proxy.
+                if (!isCtorSuperCall || !args.Values[0])
                 {
                     newThisObject = JavascriptOperators::NewScObjectNoCtor(targetObj, scriptContext);
                     args.Values[0] = newThisObject;

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -429,6 +429,22 @@ var tests = [
             assert.isUndefined(withtrap.noTrap);
         }
     },
+    {
+        name: "Constructing object from a proxy object (which has proxy as target) should not fire an Assert (OS# 17516464)",
+        body() {
+            function Foo(a) {
+                this.x = a;
+            }
+            var proxy = new Proxy(Foo, {});
+            var proxy1 = new Proxy(proxy, {});
+            var proxy2 = new Proxy(proxy1, {});
+            var obj1 = new proxy2(10);
+            assert.areEqual(10, obj1.x);
+
+            var obj2 = Reflect.construct(proxy2, [20]);
+            assert.areEqual(20, obj2.x);
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
In the functiontrap we don't create an object if the target itself is proxy. However as we provide NewTarget flag, the nested functiontrap will try to take the args[0] which later
leads to Assert as it was null.
Fixed that by constructing an object if the args[0] is null even if the NewTarget flag is passed.
