### PR TITLE
Initialize local value table in path dependent branch folding for IntConstOpnds

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -4646,7 +4646,18 @@ BasicBlock::CheckLegalityAndFoldPathDepBranches(GlobOpt* globOpt)
             StackSym* src1Sym = instr->GetSrc1()->GetStackSym();
             FindValueInLocalThenGlobalValueTableAndUpdate(globOpt, localSymToValueMap, instr, instr->GetDst()->GetSym(), src1Sym);
         }
-        else if (!instr->GetSrc1()->IsIntConstOpnd())
+        else if (instr->GetSrc1()->IsIntConstOpnd())
+        {
+            Value **localValue = localSymToValueMap->FindOrInsertNew(instr->GetDst()->GetSym());
+            *localValue = globOpt->NewValue(IntConstantValueInfo::New(globOpt->alloc, instr->GetSrc1()->AsIntConstOpnd()->AsInt32()));
+        }
+        else if (instr->GetSrc1()->IsInt64ConstOpnd())
+        {
+            Value **localValue = localSymToValueMap->FindOrInsertNew(instr->GetDst()->GetSym());
+            int64 intValue = instr->GetSrc1()->AsInt64ConstOpnd()->GetValue();
+            *localValue = globOpt->NewValue(Int64ConstantValueInfo::New(globOpt->alloc, intValue));
+        }
+        else
         {
             ValueType src1Value = instr->GetSrc1()->GetValueType();
             Value **localValue = localSymToValueMap->FindOrInsertNew(instr->GetDst()->GetSym());

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -4649,13 +4649,12 @@ BasicBlock::CheckLegalityAndFoldPathDepBranches(GlobOpt* globOpt)
         else if (instr->GetSrc1()->IsIntConstOpnd())
         {
             Value **localValue = localSymToValueMap->FindOrInsertNew(instr->GetDst()->GetSym());
-            *localValue = globOpt->NewValue(IntConstantValueInfo::New(globOpt->alloc, instr->GetSrc1()->AsIntConstOpnd()->AsInt32()));
+            *localValue = globOpt->GetIntConstantValue(instr->GetSrc1()->AsIntConstOpnd()->AsInt32(), instr);
         }
         else if (instr->GetSrc1()->IsInt64ConstOpnd())
         {
             Value **localValue = localSymToValueMap->FindOrInsertNew(instr->GetDst()->GetSym());
-            int64 intValue = instr->GetSrc1()->AsInt64ConstOpnd()->GetValue();
-            *localValue = globOpt->NewValue(Int64ConstantValueInfo::New(globOpt->alloc, intValue));
+            *localValue = globOpt->GetIntConstantValue(instr->GetSrc1()->AsInt64ConstOpnd()->GetValue(), instr);
         }
         else
         {

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6525,7 +6525,7 @@ GlobOpt::CanProveConditionalBranch(IR::Instr *instr, Value *src1Val, Value *src2
     //Assert(!src2Var || !Js::JavascriptOperators::IsObject(src2Var));
 
     int64 left64, right64;
-    int left, right;
+    int32 left, right;
     int32 constVal;
 
     switch (instr->m_opcode)


### PR DESCRIPTION
We were not adding value of IntConstOpnd in the local value table, nor were we initializing it to null.
This caused to incorrectly read value from the global value table, which might be inaccurate.
