### PR TITLE
Indicate how bytecode serializer allocates return buffer

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -3819,7 +3819,7 @@ JsErrorCode JsSerializeScriptCore(const byte *script, size_t cb,
         // However, the PAL defines DWORD for us on linux as unsigned int so the cast is safe here.
         HRESULT hr = Js::ByteCodeSerializer::SerializeToBuffer(scriptContext,
             tempAllocator, static_cast<DWORD>(cSourceCodeLength), utf8Code,
-            functionBody, functionBody->GetHostSrcInfo(), false, &buffer,
+            functionBody, functionBody->GetHostSrcInfo(), &buffer,
             (DWORD*) bufferSize, dwFlags);
         END_TEMP_ALLOCATOR(tempAllocator, scriptContext);
 

--- a/lib/Parser/BGParseManager.cpp
+++ b/lib/Parser/BGParseManager.cpp
@@ -541,10 +541,9 @@ void BGParseWorkItem::ParseUTF8Core(Js::ScriptContext* scriptContext)
             this->script,
             functionBody,
             functionBody->GetHostSrcInfo(),
-            true, // allocateBuffer
             &this->bufferReturn,
             &this->bufferReturnBytes,
-            GENERATE_BYTE_CODE_PARSER_STATE
+            GENERATE_BYTE_CODE_PARSER_STATE | GENERATE_BYTE_CODE_COTASKMEMALLOC
         );
         END_TEMP_ALLOCATOR(tempAllocator, scriptContext);
         Assert(this->parseHR == S_OK);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -2229,7 +2229,7 @@ namespace Js
 #ifdef ENABLE_WININET_PROFILE_DATA_CACHE
         byte* serializeParserStateCacheBuffer = parserStateCacheBuffer;
         DWORD serializeParserStateCacheSize = parserStateCacheByteCount;
-        DWORD dwFlags = GENERATE_BYTE_CODE_PARSER_STATE;
+        DWORD dwFlags = GENERATE_BYTE_CODE_PARSER_STATE | GENERATE_BYTE_CODE_ALLOC_ANEW;
         DebugOnly(auto url = !srcInfo->sourceContextInfo->isHostDynamicDocument ? srcInfo->sourceContextInfo->url : this->GetUrl());
 
         // If we already have a parser state cache serialized into a buffer, we should skip creating it again
@@ -2242,7 +2242,7 @@ namespace Js
             BEGIN_TEMP_ALLOCATOR(tempAllocator, this, _u("ByteCodeSerializer"));
             hr = Js::ByteCodeSerializer::SerializeToBuffer(this,
                 tempAllocator, (DWORD)cbLength, pszSrc, func->GetFunctionBody(),
-                func->GetHostSrcInfo(), true, &serializeParserStateCacheBuffer,
+                func->GetHostSrcInfo(), &serializeParserStateCacheBuffer,
                 &serializeParserStateCacheSize, dwFlags);
             END_TEMP_ALLOCATOR(tempAllocator, this);
 
@@ -2410,7 +2410,7 @@ namespace Js
 
                 return Js::ByteCodeSerializer::SerializeToBuffer(this,
                     alloc, static_cast<DWORD>(cSourceCodeLength), utf8Code,
-                    functionBody, functionBody->GetHostSrcInfo(), false, buffer,
+                    functionBody, functionBody->GetHostSrcInfo(), buffer,
                     bufferSize, dwFlags);
             }
             else

--- a/lib/Runtime/ByteCode/ByteCodeSerializeFlags.h
+++ b/lib/Runtime/ByteCode/ByteCodeSerializeFlags.h
@@ -4,6 +4,11 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#define GENERATE_BYTE_CODE_BUFFER_LIBRARY 0x00000001
-#define GENERATE_BYTE_CODE_FOR_NATIVE 0x00000002
-#define GENERATE_BYTE_CODE_PARSER_STATE 0x00000004
+#define GENERATE_BYTE_CODE_BUFFER_LIBRARY   0x00000001
+#define GENERATE_BYTE_CODE_FOR_NATIVE       0x00000002
+#define GENERATE_BYTE_CODE_PARSER_STATE     0x00000004
+// When the return buffer needs to be allocated while generating bytecode, use one
+// of these flags to indicate how to allocate the memory. The absence of both flags
+// indicates that no allocation is needed.
+#define GENERATE_BYTE_CODE_COTASKMEMALLOC   0x00000008
+#define GENERATE_BYTE_CODE_ALLOC_ANEW       0x00000010

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.h
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.h
@@ -167,7 +167,7 @@ namespace Js
     struct ByteCodeSerializer
     {
         // Serialize a function body.
-        static HRESULT SerializeToBuffer(ScriptContext * scriptContext, ArenaAllocator * alloc, DWORD sourceByteLength, LPCUTF8 utf8Source, FunctionBody * function, SRCINFO const* srcInfo, bool allocateBuffer, byte ** buffer, DWORD * bufferBytes, DWORD dwFlags = 0);
+        static HRESULT SerializeToBuffer(ScriptContext * scriptContext, ArenaAllocator * alloc, DWORD sourceByteLength, LPCUTF8 utf8Source, FunctionBody * function, SRCINFO const* srcInfo, byte ** buffer, DWORD * bufferBytes, DWORD dwFlags = 0);
 
         // Deserialize a function body. The content of utf8Source must be the same as was originally passed to SerializeToBuffer
         static HRESULT DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex = Js::Constants::InvalidSourceIndex);


### PR DESCRIPTION
This change allows for callers to ByteCodeSerializer to specify if the buffer containing the serialized bytecode (and parser cache state) should be allocated with ANew or CoTaskMemAlloc. The caller is then responsible for freeing the memory appropriately after use.