### PR TITLE
OS#17542375 Correct possible overflow of deferred stubs array

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -415,6 +415,7 @@ private:
     ParseNodeFnc * m_currentNodeDeferredFunc; // current function or NULL
     ParseNodeProg * m_currentNodeProg; // current program
     DeferredFunctionStub *m_currDeferredStub;
+    uint m_currDeferredStubCount;
     int32 * m_pCurrentAstSize;
     ParseNodePtr * m_ppnodeScope;  // function list tail
     ParseNodePtr * m_ppnodeExprScope; // function expression list tail

--- a/test/Basics/bug_os17542375.js
+++ b/test/Basics/bug_os17542375.js
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// With pageheap:2 we should not hit an AV
+
+function foo() {
+   var r = {};
+   var b = {};
+   var a = {};
+   a.$ = r;
+
+   function foo1() {
+   }
+   function foo2() {
+   }
+    return r.noConflict = function(b) {
+        return a.$ === r && (a.$ = Wb), b && a.jQuery === r && (a.jQuery = Vb), r
+    }, b || (a.jQuery = a.$ = r), r
+}
+
+foo();
+console.log('pass');

--- a/test/Basics/rlexe.xml
+++ b/test/Basics/rlexe.xml
@@ -414,4 +414,11 @@
       <tags>exclude_test,exclude_jshost,exclude_dynapogo</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_os17542375.js</files>
+      <compile-flags>-UseParserStateCache -ParserStateCache -Force:DeferParse -pageheap:2</compile-flags>
+      <tags>exclude_test,exclude_jshost</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When undeferring a function with deferred stubs, we try and use those stubs to determine if expressions beginning with a left paren are nested lambda functions. We do this when we see a left paren and the next deferred stub is a lambda function starting at the same character. Unfortunately we don't keep track of the count of deferred stubs in the current deferred stubs array. If all of the nested functions in the function we're undefering are located in source before the left paren character, we should not check for the next deferred stub as this would overflow the array and cause a possible AV.

Fix this by tracking the count of stubs in the current deferred stubs array.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/17542375
