### PR TITLE
add NaN check for simple Sets

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -292,9 +292,15 @@ namespace Js {
            {
                return taggedInt;
            }
-
 #if FLOATVAR
-           return value;
+           if (typeId == TypeIds_Number)
+           {
+               // NaN could have sign bit set, but that isn't observable so canonicalize to positive NaN
+               double numberValue = JavascriptNumber::GetValue(value);
+               return JavascriptNumber::IsNan(numberValue)
+                   ? JavascriptNumber::ToVar(JavascriptNumber::NaN)
+                   : value;
+           }
 #else
            return nullptr;
 #endif


### PR DESCRIPTION
It is possible for sign bit to be set on NaNs (e.g. when they are the result of some math operations), so canonicalize them when adding to simple set in order to avoid duplicating entries.

We can do this because the sign bit on NaN is not observable to JS code.

OS: 17498790