### PR TITLE
[MSFT 17535796] On depoloymorphication, write the slot index discovered during GlobOpt into the ObjTypeSpecFldInfo as well as the opnd field

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1170,6 +1170,9 @@ GlobOpt::ProcessPropOpInTypeCheckSeq(IR::Instr* instr, IR::PropertySymOpnd *opnd
                 opnd->SetSlotIndex(slotIndex);
                 opnd->SetUsesAuxSlot(auxSlot);
 
+                opnd->GetObjTypeSpecInfo()->SetSlotIndex(slotIndex);
+                opnd->GetObjTypeSpecInfo()->SetUsesAuxSlot(auxSlot);
+
                 isSpecialized = true;
                 if (isTypeCheckedOut)
                 {

--- a/lib/Backend/ObjTypeSpecFldInfo.cpp
+++ b/lib/Backend/ObjTypeSpecFldInfo.cpp
@@ -77,6 +77,14 @@ ObjTypeSpecFldInfo::TryDepolymorphication(JITTypeHolder type, uint16 slotIndex, 
     }
 }
 
+void
+ObjTypeSpecFldInfo::SetUsesAuxSlot(bool usesAuxSlot)
+{
+    ObjTypeSpecFldInfoFlags flags = GetFlags();
+    flags.usesAuxSlot = usesAuxSlot;
+    m_data.flags = flags.flags;
+}
+
 bool
 ObjTypeSpecFldInfo::UsesAuxSlot() const
 {
@@ -198,6 +206,13 @@ uint16
 ObjTypeSpecFldInfo::GetSlotIndex() const
 {
     return m_data.slotIndex;
+}
+
+void
+ObjTypeSpecFldInfo::SetSlotIndex(uint16 slotIndex)
+{
+    Assert(m_data.slotIndex == Js::Constants::NoSlot || m_data.slotIndex == slotIndex);
+    m_data.slotIndex = slotIndex;
 }
 
 uint16

--- a/lib/Backend/ObjTypeSpecFldInfo.h
+++ b/lib/Backend/ObjTypeSpecFldInfo.h
@@ -137,6 +137,7 @@ public:
         m_data.polymorphicInfoArray = polymorphicInfoArray->GetRaw();
     }
 
+    void SetUsesAuxSlot(bool usesAuxSlot);
     bool UsesAuxSlot() const;
     bool UsesAccessor() const;
     bool IsRootObjectNonConfigurableFieldLoad() const;
@@ -199,6 +200,7 @@ public:
 
     Js::PropertyId GetPropertyId() const;
     uint16 GetSlotIndex() const;
+    void SetSlotIndex(uint16 slotIndex);
     uint16 * GetSlotIndices() const;
     uint16 GetFixedFieldCount() const;
 


### PR DESCRIPTION
That way it will be copied into the set that supports the runtime equivalence check.