### PR TITLE
Fix ARM64 LEA legalization

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2520,54 +2520,6 @@ Instr::HoistSrc2(Js::OpCode assignOpcode, RegNum regNum, StackSym *newSym)
     return newInstr;
 }
 
-///----------------------------------------------------------------------------
-///
-/// Instr::HoistIndirOffset
-///
-///     Replace the offset of the given indir with a new symbol, which becomes the indir index.
-///     Assign the new symbol by creating an assignment from the constant offset.
-///
-///----------------------------------------------------------------------------
-
-Instr *
-Instr::HoistIndirOffset(IR::IndirOpnd *indirOpnd, RegNum regNum)
-{
-    int32 offset = indirOpnd->GetOffset();
-    if (indirOpnd->GetIndexOpnd())
-    {
-        Assert(indirOpnd->GetBaseOpnd());
-        return HoistIndirOffsetAsAdd(indirOpnd, indirOpnd->GetBaseOpnd(), offset, regNum);
-    }
-    IntConstOpnd *offsetOpnd = IntConstOpnd::New(offset, TyInt32, this->m_func);
-    RegOpnd *indexOpnd = RegOpnd::New(StackSym::New(TyMachReg, this->m_func), regNum, TyMachReg, this->m_func);
-
-#if defined(DBG) && defined(_M_ARM)
-    if (regNum == SCRATCH_REG)
-    {
-        AssertMsg(indirOpnd->GetBaseOpnd()->GetReg()!= SCRATCH_REG, "Why both are SCRATCH_REG");
-        if (this->GetSrc1() && this->GetSrc1()->IsRegOpnd())
-        {
-            Assert(this->GetSrc1()->AsRegOpnd()->GetReg() != SCRATCH_REG);
-        }
-        if (this->GetSrc2() && this->GetSrc2()->IsRegOpnd())
-        {
-            Assert(this->GetSrc2()->AsRegOpnd()->GetReg() != SCRATCH_REG);
-        }
-        if (this->GetDst() && this->GetDst()->IsRegOpnd())
-        {
-            Assert(this->GetDst()->AsRegOpnd()->GetReg() != SCRATCH_REG);
-        }
-    }
-#endif
-    // Clear the offset and add a new reg as the index.
-    indirOpnd->SetOffset(0);
-    indirOpnd->SetIndexOpnd(indexOpnd);
-
-    Instr *instrAssign = Lowerer::InsertMove(indexOpnd, offsetOpnd, this);
-    indexOpnd->m_sym->SetIsIntConst(offset);
-    return instrAssign;
-}
-
 IndirOpnd *
 Instr::HoistMemRefAddress(MemRefOpnd *const memRefOpnd, const Js::OpCode loadOpCode)
 {
@@ -2638,71 +2590,6 @@ Opnd *Instr::DeepReplace(Opnd *const oldOpnd, Opnd *const newOpnd)
 
     // Do this last because Replace will delete oldOpnd
     return Replace(oldOpnd, newOpnd);
-}
-
-Instr *
-Instr::HoistIndirOffsetAsAdd(IR::IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset, RegNum regNum)
-{
-        IR::RegOpnd *newBaseOpnd = IR::RegOpnd::New(StackSym::New(TyMachPtr, this->m_func), regNum, TyMachPtr, this->m_func);
-
-        IR::IntConstOpnd *src2 = IR::IntConstOpnd::New(offset, TyInt32, this->m_func);
-        IR::Instr * instrAdd = IR::Instr::New(Js::OpCode::ADD, newBaseOpnd, baseOpnd, src2, this->m_func);
-
-        this->InsertBefore(instrAdd);
-
-        orgOpnd->ReplaceBaseOpnd(newBaseOpnd);
-        orgOpnd->SetOffset(0);
-
-        return instrAdd;
-}
-
-Instr *
-Instr::HoistIndirIndexOpndAsAdd(IR::IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, IR::Opnd *indexOpnd, RegNum regNum)
-{
-        IR::RegOpnd *newBaseOpnd = IR::RegOpnd::New(StackSym::New(TyMachPtr, this->m_func), regNum, TyMachPtr, this->m_func);
-
-        IR::Instr * instrAdd = IR::Instr::New(Js::OpCode::ADD, newBaseOpnd, baseOpnd, indexOpnd->UseWithNewType(TyMachPtr, this->m_func), this->m_func);
-
-        this->InsertBefore(instrAdd);
-
-        orgOpnd->ReplaceBaseOpnd(newBaseOpnd);
-        orgOpnd->SetIndexOpnd(nullptr);
-
-        return instrAdd;
-}
-
-Instr *
-Instr::HoistSymOffsetAsAdd(IR::SymOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset, RegNum regNum)
-{
-        IR::IndirOpnd *newIndirOpnd = IR::IndirOpnd::New(baseOpnd->AsRegOpnd(), 0, TyMachPtr, this->m_func);
-        this->Replace(orgOpnd, newIndirOpnd); // Replace SymOpnd with IndirOpnd
-        return this->HoistIndirOffsetAsAdd(newIndirOpnd, baseOpnd, offset, regNum);
-}
-
-///----------------------------------------------------------------------------
-///
-/// Instr::HoistSymOffset
-///
-///     Replace the given sym with an indir using the given base and offset.
-///     (This is used, for instance, to hoist a sym offset that is too large to encode.)
-///
-///----------------------------------------------------------------------------
-
-Instr *
-Instr::HoistSymOffset(SymOpnd *symOpnd, RegNum baseReg, uint32 offset, RegNum regNum)
-{
-    IR::RegOpnd *baseOpnd = IR::RegOpnd::New(nullptr, baseReg, TyMachPtr, this->m_func);
-    IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, offset, symOpnd->GetType(), this->m_func);
-    if (symOpnd == this->GetDst())
-    {
-        this->ReplaceDst(indirOpnd);
-    }
-    else
-    {
-        this->ReplaceSrc(symOpnd, indirOpnd);
-    }
-
-    return this->HoistIndirOffset(indirOpnd, regNum);
 }
 
 Opnd *

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -265,11 +265,6 @@ public:
     void            FreeSrc2();
     Opnd *          ReplaceSrc2(Opnd * newSrc);
     Instr *         HoistSrc2(Js::OpCode assignOpcode, RegNum regNum = RegNOREG, StackSym *newSym = nullptr);
-    Instr *         HoistIndirOffset(IndirOpnd *indirOpnd, RegNum regNum = RegNOREG);
-    Instr *         HoistSymOffset(SymOpnd *symOpnd, RegNum baseReg, uint32 offset, RegNum regNum = RegNOREG);
-    Instr *         HoistIndirOffsetAsAdd(IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset,  RegNum regNum);
-    Instr *         HoistSymOffsetAsAdd(SymOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset,  RegNum regNum);
-    Instr *         HoistIndirIndexOpndAsAdd(IR::IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, IR::Opnd *indexOpnd, RegNum regNum);
     IndirOpnd *     HoistMemRefAddress(MemRefOpnd *const memRefOpnd, const Js::OpCode loadOpCode);
     Opnd *          UnlinkSrc(Opnd *src);
     Opnd *          ReplaceSrc(Opnd *oldSrc, Opnd * newSrc);

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -362,6 +362,12 @@ private:
     void            GenerateFastBrBReturn(IR::Instr * instr);
 
 public:
+    static IR::Instr *Lowerer::HoistIndirOffset(IR::Instr* instr, IR::IndirOpnd *indirOpnd, RegNum regNum);
+    static IR::Instr *Lowerer::HoistIndirOffsetAsAdd(IR::Instr* instr, IR::IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset, RegNum regNum);
+    static IR::Instr *Lowerer::HoistIndirIndexOpndAsAdd(IR::Instr* instr, IR::IndirOpnd *orgOpnd, IR::Opnd *baseOpnd, IR::Opnd *indexOpnd, RegNum regNum);
+    static IR::Instr *Lowerer::HoistSymOffset(IR::Instr *instr, IR::SymOpnd *symOpnd, RegNum baseReg, uint32 offset, RegNum regNum);
+    static IR::Instr *Lowerer::HoistSymOffsetAsAdd(IR::Instr* instr, IR::SymOpnd *orgOpnd, IR::Opnd *baseOpnd, int offset, RegNum regNum);
+
     static IR::LabelInstr *     InsertLabel(const bool isHelper, IR::Instr *const insertBeforeInstr);
 
     static IR::Instr *          InsertMove(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const insertBeforeInstr, bool generateWriteBarrier = true);

--- a/lib/Backend/arm/LegalizeMD.cpp
+++ b/lib/Backend/arm/LegalizeMD.cpp
@@ -266,7 +266,7 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
 
     if (indirOpnd->GetIndexOpnd() != NULL && offset != 0)
     {
-        IR::Instr *addInstr = instr->HoistIndirOffset(indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+        IR::Instr *addInstr = Lowerer::HoistIndirOffset(instr, indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(addInstr, fPostRegAlloc);
         return;
     }
@@ -288,7 +288,7 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
     }
 
     // Offset is too large, so hoist it and replace it with an index, only valid for Thumb & Thumb2
-    IR::Instr *addInstr = instr->HoistIndirOffset(indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+    IR::Instr *addInstr = Lowerer::HoistIndirOffset(instr, indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
     LegalizeMD::LegalizeInstr(addInstr, fPostRegAlloc);
 }
 
@@ -334,7 +334,7 @@ void LegalizeMD::LegalizeSymOffset(
         }
 
         IR::RegOpnd *baseOpnd = IR::RegOpnd::New(NULL, baseReg, TyMachPtr, instr->m_func);
-        IR::Instr* instrAdd = instr->HoistSymOffsetAsAdd(symOpnd, baseOpnd, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+        IR::Instr* instrAdd = Lowerer::HoistSymOffsetAsAdd(instr, symOpnd, baseOpnd, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(instrAdd, fPostRegAlloc);
         return;
     }
@@ -351,7 +351,7 @@ void LegalizeMD::LegalizeSymOffset(
     }
     else
     {
-        newInstr = instr->HoistSymOffset(symOpnd, baseReg, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+        newInstr = Lowerer::HoistSymOffset(instr, symOpnd, baseReg, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(newInstr, fPostRegAlloc);
     }
 }
@@ -621,14 +621,14 @@ void LegalizeMD::LegalizeIndirOpndForVFP(IR::Instr* insertInstr, IR::IndirOpnd *
             indexOpnd = newIndexOpnd;
         }
 
-        insertInstr->HoistIndirIndexOpndAsAdd(indirOpnd, baseOpnd, indexOpnd, fPostRegAlloc? SCRATCH_REG : RegNOREG);
+        Lowerer::HoistIndirIndexOpndAsAdd(insertInstr, indirOpnd, baseOpnd, indexOpnd, fPostRegAlloc? SCRATCH_REG : RegNOREG);
     }
 
     if (IS_CONST_UINT10((offset < 0? -offset: offset)))
     {
         return;
     }
-    IR::Instr* instrAdd = insertInstr->HoistIndirOffsetAsAdd(indirOpnd, indirOpnd->GetBaseOpnd(), offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+    IR::Instr* instrAdd = Lowerer::HoistIndirOffsetAsAdd(insertInstr, indirOpnd, indirOpnd->GetBaseOpnd(), offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
     LegalizeMD::LegalizeInstr(instrAdd, fPostRegAlloc);
 }
 

--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -152,6 +152,7 @@ void EncoderMD::CanonicalizeLea(IR::Instr * instr)
         indirOpnd->Free(this->m_func);
     }
     instr->m_opcode = Js::OpCode::ADD;
+    Assert(instr->GetSrc1()->GetSize() == instr->GetSrc2()->GetSize());
 }
 
 bool

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -376,13 +376,14 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
             Lowerer::HoistIndirIndexOpndAsAdd(instr, indirOpnd, baseOpnd, indexOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         }
     }
-    else if (indirOpnd->GetIndexOpnd() != NULL && offset != 0)
+    else if (indirOpnd->GetIndexOpnd() != nullptr && offset != 0)
     {
         // Can't have both offset and index, so hoist the offset and try again.
         IR::Instr *addInstr = Lowerer::HoistIndirOffset(instr, indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(addInstr, fPostRegAlloc);
         if (instr->m_opcode == Js::OpCode::LEA)
         {
+            AssertOrFailFastMsg(indirOpnd->GetBaseOpnd() != nullptr && indirOpnd->GetBaseOpnd()->GetSize() == TySize[TyMachPtr], "Base operand of LEA must have pointer-width!");
             correctSize(instr, indirOpnd);
         }
         return;
@@ -408,6 +409,7 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
     {
         // Only one opcode with this form right now
         Assert(instr->m_opcode == Js::OpCode::LEA);
+        AssertOrFailFastMsg(indirOpnd->GetBaseOpnd() != nullptr && indirOpnd->GetBaseOpnd()->GetSize() == TySize[TyMachPtr], "Base operand of LEA must have pointer-width!");
         if (offset != 0)
         {
             // Should have already handled this case

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -315,7 +315,41 @@ IR::Instr * LegalizeMD::LegalizeLoad(IR::Instr *instr, uint opndNum, LegalForms 
 
 void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpnd, LegalForms forms, bool fPostRegAlloc)
 {
-   int32 offset = indirOpnd->GetOffset();
+    // For LEA, we have special handling of indiropnds
+    auto correctSize = [](IR::Instr* instr, IR::IndirOpnd* indirOpnd)
+    {
+        // If the base and index operands on an LEA are different sizes, grow the smaller one,
+        // matching the larger size but keeping the correct signedness for the type
+        IR::RegOpnd* baseOpnd = indirOpnd->GetBaseOpnd();
+        IR::RegOpnd* indexOpnd = indirOpnd->GetIndexOpnd();
+        if (   baseOpnd != nullptr
+            && indexOpnd != nullptr
+            && baseOpnd->GetSize() != indexOpnd->GetSize()
+            )
+        {
+            if (baseOpnd->GetSize() < indexOpnd->GetSize())
+            {
+                IRType largerType = indexOpnd->GetType();
+                Assert(IRType_IsSignedInt(largerType) || IRType_IsUnsignedInt(largerType));
+                IRType sourceType = baseOpnd->GetType();
+                IRType targetType = IRType_IsSignedInt(sourceType) ? IRType_EnsureSigned(largerType) : IRType_EnsureUnsigned(largerType);
+                IR::Instr* movInstr = Lowerer::InsertMove(baseOpnd->UseWithNewType(targetType, instr->m_func), baseOpnd, instr, false);
+                indirOpnd->SetBaseOpnd(movInstr->GetDst()->AsRegOpnd());
+            }
+            else
+            {
+                Assert(indexOpnd->GetSize() < baseOpnd->GetSize());
+                IRType largerType = baseOpnd->GetType();
+                Assert(IRType_IsSignedInt(largerType) || IRType_IsUnsignedInt(largerType));
+                IRType sourceType = indexOpnd->GetType();
+                IRType targetType = IRType_IsSignedInt(sourceType) ? IRType_EnsureSigned(largerType) : IRType_EnsureUnsigned(largerType);
+                IR::Instr* movInstr = Lowerer::InsertMove(indexOpnd->UseWithNewType(targetType, instr->m_func), indexOpnd, instr, false);
+                indirOpnd->SetIndexOpnd(movInstr->GetDst()->AsRegOpnd());
+            }
+        }
+    };
+
+    int32 offset = indirOpnd->GetOffset();
 
     if (indirOpnd->IsFloat())
     {
@@ -339,14 +373,18 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
                 indexOpnd = newIndexOpnd;
             }
 
-            instr->HoistIndirIndexOpndAsAdd(indirOpnd, baseOpnd, indexOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+            Lowerer::HoistIndirIndexOpndAsAdd(instr, indirOpnd, baseOpnd, indexOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         }
     }
     else if (indirOpnd->GetIndexOpnd() != NULL && offset != 0)
     {
         // Can't have both offset and index, so hoist the offset and try again.
-        IR::Instr *addInstr = instr->HoistIndirOffset(indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+        IR::Instr *addInstr = Lowerer::HoistIndirOffset(instr, indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(addInstr, fPostRegAlloc);
+        if (instr->m_opcode == Js::OpCode::LEA)
+        {
+            correctSize(instr, indirOpnd);
+        }
         return;
     }
 
@@ -368,8 +406,23 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
     }
     if (forms & L_IndirU12Lsl12)
     {
-        if (IS_CONST_UINT12(offset) || IS_CONST_UINT12LSL12(offset))
+        // Only one opcode with this form right now
+        Assert(instr->m_opcode == Js::OpCode::LEA);
+        if (offset != 0)
         {
+            // Should have already handled this case
+            Assert(indirOpnd->GetIndexOpnd() == nullptr);
+            if (IS_CONST_UINT12(offset) || IS_CONST_UINT12LSL12(offset))
+            {
+                return;
+            }
+        }
+        else
+        {
+            if (indirOpnd->GetIndexOpnd() != nullptr)
+            {
+                correctSize(instr, indirOpnd);
+            }
             return;
         }
     }
@@ -384,7 +437,7 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
     }
 
     // Offset is too large, so hoist it and replace it with an index
-    IR::Instr *addInstr = instr->HoistIndirOffset(indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+    IR::Instr *addInstr = Lowerer::HoistIndirOffset(instr, indirOpnd, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
     LegalizeMD::LegalizeInstr(addInstr, fPostRegAlloc);
 }
 
@@ -453,7 +506,7 @@ void LegalizeMD::LegalizeSymOffset(
     }
     else
     {
-        newInstr = instr->HoistSymOffset(symOpnd, baseReg, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
+        newInstr = Lowerer::HoistSymOffset(instr, symOpnd, baseReg, offset, fPostRegAlloc ? SCRATCH_REG : RegNOREG);
         LegalizeMD::LegalizeInstr(newInstr, fPostRegAlloc);
     }
 }


### PR DESCRIPTION
Because we weren't checking the types of things, there were a few ways that the conversion of LEA instructions to ADD instructions on ARM64 could go wrong. This changeset fixes legalization of these instructions to properly handle all of the cases.