### PR TITLE
Fix REM instruction's profile info

### DIFF
--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1211,7 +1211,7 @@ namespace Js
         /* allow one op of the modulus to be optimized - anyway */
         if (divideTypeInfo[profileId].IsUninitialized())
         {
-            divideTypeInfo[profileId] = ValueType::GetInt(true);
+            divideTypeInfo[profileId] = isModByPowerOf2 ? ValueType::GetInt(true) : ValueType::Float;
         }
         else
         {

--- a/test/Optimizer/rembug.js
+++ b/test/Optimizer/rembug.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+var protoObj1 = {};
+var arrObj0 = {};
+var uic8 = new Uint8ClampedArray(256);
+var IntArr0 = [];
+arrObj0[undefined] = protoObj1;
+arrObj0.length = undefined;
+function v43() {
+  for (var _strvar0 in uic8) {
+    for (var _strvar0 in arrObj0) {
+      arrObj0[_strvar0] = 1[1];
+      if (!arrObj0[0]) {
+        IntArr0[-1 % 2147483647 >= 0 ? 1 : 0] = 1;
+        arrObj0[0] = 1;
+      }
+    }
+  }
+}
+v43();
+if (IntArr0[1] === undefined) {
+  print("Passed");
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1550,4 +1550,10 @@
       <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>rembug.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1  -loopinterpretcount:1 -oopjit- -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We use the valueType to overload info where it is a modulus by 2. Fix the case were we were always setting this bit to represent modulus by 2.
