### PR TITLE
OS#17494821 - Exprgen:CAS:x64::DEBUG JIT is causing a bad code gen

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -353,8 +353,16 @@ namespace Js
 
     Var JavascriptOperators::TypeofElem_UInt32(Var instance, uint32 index, ScriptContext* scriptContext)
     {
-        if (JavascriptOperators::IsNumberFromNativeArray(instance, index, scriptContext))
-            return scriptContext->GetLibrary()->GetNumberTypeDisplayString();
+        try
+        {
+            if (JavascriptOperators::IsNumberFromNativeArray(instance, index, scriptContext))
+                return scriptContext->GetLibrary()->GetNumberTypeDisplayString();
+        }
+        catch (const JavascriptException& err)
+        {
+            err.GetAndClear();  // discard exception object
+            return scriptContext->GetLibrary()->GetUndefinedDisplayString();
+        }
 
 #if FLOATVAR
         return TypeofElem(instance, Js::JavascriptNumber::ToVar(index, scriptContext), scriptContext);
@@ -367,8 +375,16 @@ namespace Js
 
     Var JavascriptOperators::TypeofElem_Int32(Var instance, int32 index, ScriptContext* scriptContext)
     {
-        if (JavascriptOperators::IsNumberFromNativeArray(instance, index, scriptContext))
-            return scriptContext->GetLibrary()->GetNumberTypeDisplayString();
+        try
+        {
+            if (JavascriptOperators::IsNumberFromNativeArray(instance, index, scriptContext))
+                return scriptContext->GetLibrary()->GetNumberTypeDisplayString();
+        }
+        catch (const JavascriptException& err)
+        {
+            err.GetAndClear();  // discard exception object
+            return scriptContext->GetLibrary()->GetUndefinedDisplayString();
+        }
 
 #if FLOATVAR
         return TypeofElem(instance, Js::JavascriptNumber::ToVar(index, scriptContext), scriptContext);


### PR DESCRIPTION
When the buffer for an Int16Array 'i16' has been detached, an exception is thrown executing the line:

 var k = typeof(i16[(ary[(((((undefined )) >= 0 ? 6 : 0)) & 0XF)]) & 255]); 

There is a difference in the behaviour between SimpleJIT and FullJIT because in the first case the exception is caught in JavascriptOperators::TypeofElem(), returning 'undefined' as type. With FullJIT, instead, the exception is unhandled.

The commit adda a catch handler in JavascriptOperators::TypeofElem_UInt32 and JavascriptOperators::TypeofElem_Int32)to catch all exceptions that may arise from a call to JavascriptOperators::IsNumberFromNativeArray, and return 'undefined'.
