### PR TITLE
quiet a spurious assertion

### DIFF
--- a/lib/Runtime/Library/SubString.cpp
+++ b/lib/Runtime/Library/SubString.cpp
@@ -40,8 +40,9 @@ namespace Js
 #if SYSINFO_IMAGE_BASE_AVAILABLE
         AssertMsg(AutoSystemInfo::IsJscriptModulePointer((void*)originalFullStringReference)
             || recycler->IsValidObject((void*)originalFullStringReference)
-            || (VirtualTableInfo<PropertyRecord>::HasVirtualTable((void*)originalFullStringReference) && ((PropertyRecord*)originalFullStringReference)->IsBound()),
-            "Owning pointer for SubString must be static or GC pointer, or property record bound by thread allocator");
+            || (VirtualTableInfo<PropertyRecord>::HasVirtualTable((void*)originalFullStringReference) && ((PropertyRecord*)originalFullStringReference)->IsBound())
+            || (string->GetLength() == 1 && originalFullStringReference == scriptContext->GetLibrary()->GetCharStringCache().GetStringForChar(string->GetString()[0])->UnsafeGetBuffer()),
+            "Owning pointer for SubString must be static or GC pointer, property record bound by thread allocator, or character buffer in global string cache");
 #endif
 
         return RecyclerNew(recycler, SubString, originalFullStringReference, subString, length, scriptContext);


### PR DESCRIPTION
I recently added an assertion to make sure that the owning reference for SubStrings points to something reasonable. I missed a case, which happens in the following minimum repro:

```javascript
("" + [undefined, undefined]).trim()
```

Array.prototype.toString generates a CompoundString with only one character. GetSz on the CompoundString has a special case for single-character strings, where it points to the same buffer as the copy of that string in the script context's cache. Then `trim` tries to make a substring, but asserts that we've done something wrong. The assertion is wrong (this operation is safe) because the buffer is held alive by the collection of single-character strings.

(`trim` could easily avoid allocating a new SubString in this case, but that's beyond the scope of this change.)

Fixes OS:17642622
