### PR TITLE
redirect NewScObjectNoArg to NewScObject for proxies

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5794,8 +5794,9 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
         JavascriptProxy * proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
         if (proxy)
         {
+            // Proxies require special handling, so go to main NewScObject path
             Arguments args(CallInfo(CallFlags_New, 1), &instance);
-            return proxy->ConstructorTrap(args, requestContext, 0);
+            return JavascriptOperators::NewScObject(instance, args, requestContext, nullptr);
         }
 
         FunctionInfo* functionInfo = JavascriptOperators::GetConstructorFunctionInfo(instance, requestContext);

--- a/test/es6/newProxy.js
+++ b/test/es6/newProxy.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let calledHandler = false;
+var func0 = function () {
+};
+var func1 = function () {
+  var v0 = new Proxy(func0, proxyHandler);
+  new v0().a;
+};
+var proxyHandler = {get: function () {
+    calledHandler = true;
+}};
+func1()
+func1()
+func1()
+
+print(calledHandler ? "Fail" : "Pass");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -84,6 +84,11 @@
   </test>
   <test>
     <default>
+      <files>newProxy.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>es6IsConcatSpreadable.js</files>
       <compile-flags>-es6tolength -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
This fixes bug where NewScObjectNoArg incorrectly calls proxy trap.

OS: 17473181