### PR TITLE
Avoid hoisting speculation guards in simplejit

### DIFF
--- a/test/FlowGraph/for_of_try_catch.js
+++ b/test/FlowGraph/for_of_try_catch.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    for(abcd of [])
+    {
+        try {
+        } catch(e) {
+        }
+        try {
+        } catch(e) {
+        }
+    }
+}
+
+test0();
+test0();
+test0();
+
+console.log("PASSED");

--- a/test/FlowGraph/rlexe.xml
+++ b/test/FlowGraph/rlexe.xml
@@ -9,13 +9,19 @@
   <test>
     <default>
       <files>weird1.js</files>
-      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -werexceptionsupport -oopjit- -off:bailonnoprofile -off:cachedScope</compile-flags>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -oopjit- -off:bailonnoprofile -off:cachedScope</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>weird2.js</files>
-      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -werexceptionsupport -bgjit- -loopinterpretcount:1 -oopjit- -off:simplejit -force:inline</compile-flags>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -bgjit- -loopinterpretcount:1 -oopjit- -off:simplejit -force:inline</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>for_of_try_catch.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -bgjit- -oopjit- -off:jitloopbody</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
There are issues with region determination for try/catch/finally and
the blocks added for the speculation guard hoisting in simplejit (in
fulljit, regions are determined earlier and avoid this issue).

OS 17538614
