### PR TITLE
fix construction of proxied class

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -2190,6 +2190,16 @@ namespace Js
             {
                 AnalysisAssert(newCount == ((ushort)args.Info.Count) + 1);
                 newValues[args.Info.Count] = newTarget;
+
+                // If the function we're calling is a class constructor, it expects newTarget
+                // as the first arg so it knows how to construct "this". (We can leave the
+                // extra copy of newTarget at the end of the arguments; it's harmless so
+                // there's no need to introduce additional complexity here.)
+                FunctionInfo* functionInfo = JavascriptOperators::GetConstructorFunctionInfo(targetObj, scriptContext);
+                if (functionInfo && functionInfo->IsClassConstructor())
+                {
+                    newValues[0] = newTarget;
+                }
             }
 
             Js::Arguments arguments(calleeInfo, newValues);


### PR DESCRIPTION
Minimum repro:

```javascript
class A {}
const p = new Proxy(A, {});
Reflect.construct(p, [], A);
```

Reflect.construct passes new.target as an extra arg on the end, but the class constructor expects new.target as arg zero. Proxy needs to be responsible for putting the argument in the correct place when calling a class constructor. Current behavior is that the class constructor tries to get function info about arg zero (some newly-initialized object), and throws "TypeError: Object doesn't support this action".

Fixes #5225
