### PR TITLE
WASM: NYI M128 globals + case type strenghtening

### DIFF
--- a/lib/Common/Core/Assertions.h
+++ b/lib/Common/Core/Assertions.h
@@ -95,6 +95,10 @@ extern int IsInAssert;
 #define CompileAssert(e) static_assert(e, #e)
 #endif
 
+#ifndef CompileAssertMsg
+#define CompileAssertMsg(e, msg) static_assert(e, msg)
+#endif
+
 // We set IsPointer<T>::IsTrue to true if T is a pointer type
 // Otherwise, it's set to false
 template <class T>

--- a/lib/Runtime/Library/WebAssemblyEnvironment.cpp
+++ b/lib/Runtime/Library/WebAssemblyEnvironment.cpp
@@ -150,10 +150,7 @@ void WebAssemblyEnvironment::SetGlobalInternal(uint32 offset, T val)
 
 Wasm::WasmConstLitNode WebAssemblyEnvironment::GetGlobalValue(Wasm::WasmGlobal* global) const
 {
-    if (!global)
-    {
-        Js::Throw::InternalError();
-    }
+    AssertOrFailFast(global);
     Wasm::WasmConstLitNode cnst;
     uint32 offset = module->GetOffsetForGlobal(global);
 
@@ -163,18 +160,18 @@ Wasm::WasmConstLitNode WebAssemblyEnvironment::GetGlobalValue(Wasm::WasmGlobal* 
     case Wasm::WasmTypes::I64: cnst.i64 = GetGlobalInternal<int64>(offset); break;
     case Wasm::WasmTypes::F32: cnst.f32 = GetGlobalInternal<float>(offset); break;
     case Wasm::WasmTypes::F64: cnst.f64 = GetGlobalInternal<double>(offset); break;
+#ifdef ENABLE_WASM_SIMD
+    case Wasm::WasmTypes::M128: AssertOrFailFastMsg(UNREACHED, "Wasm.Simd globals not supported");
+#endif
     default:
-        Js::Throw::InternalError();
+        Wasm::WasmTypes::CompileAssertCases<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
     }
     return cnst;
 }
 
 void WebAssemblyEnvironment::SetGlobalValue(Wasm::WasmGlobal* global, Wasm::WasmConstLitNode cnst)
 {
-    if (!global)
-    {
-        Js::Throw::InternalError();
-    }
+    AssertOrFailFast(global);
     uint32 offset = module->GetOffsetForGlobal(global);
 
     switch (global->GetType())
@@ -183,8 +180,11 @@ void WebAssemblyEnvironment::SetGlobalValue(Wasm::WasmGlobal* global, Wasm::Wasm
     case Wasm::WasmTypes::I64: SetGlobalInternal<int64>(offset, cnst.i64); break;
     case Wasm::WasmTypes::F32: SetGlobalInternal<float>(offset, cnst.f32); break;
     case Wasm::WasmTypes::F64: SetGlobalInternal<double>(offset, cnst.f64); break;
+#ifdef ENABLE_WASM_SIMD
+    case Wasm::WasmTypes::M128: AssertOrFailFastMsg(UNREACHED, "Wasm.Simd globals not supported");
+#endif
     default:
-        Js::Throw::InternalError();
+        Wasm::WasmTypes::CompileAssertCases<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
     }
 }
 

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -272,17 +272,20 @@ Var WebAssemblyInstance::CreateExportObject(WebAssemblyModule * wasmModule, Scri
                 case Wasm::WasmTypes::I32:
                     obj = JavascriptNumber::ToVar(cnst.i32, scriptContext);
                     break;
+                case Wasm::WasmTypes::I64:
+                    JavascriptError::ThrowTypeErrorVar(wasmModule->GetScriptContext(), WASMERR_InvalidTypeConversion, _u("i64"), _u("Var"));
                 case Wasm::WasmTypes::F32:
                     obj = JavascriptNumber::New(cnst.f32, scriptContext);
                     break;
                 case Wasm::WasmTypes::F64:
                     obj = JavascriptNumber::New(cnst.f64, scriptContext);
                     break;
-                case Wasm::WasmTypes::I64:
-                    JavascriptError::ThrowTypeError(wasmModule->GetScriptContext(), WASMERR_InvalidTypeConversion);
+#ifdef ENABLE_WASM_SIMD
+                case Wasm::WasmTypes::M128:
+                    JavascriptError::ThrowTypeErrorVar(wasmModule->GetScriptContext(), WASMERR_InvalidTypeConversion, _u("m128"), _u("Var"));
+#endif
                 default:
-                    Assert(UNREACHED);
-                    break;
+                    Wasm::WasmTypes::CompileAssertCases<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
                 }
             }
             JavascriptOperators::OP_SetProperty(exportsNamespace, propertyRecord->GetPropertyId(), obj, scriptContext);
@@ -412,9 +415,12 @@ void WebAssemblyInstance::LoadImports(
             case Wasm::WasmTypes::I32: cnst.i32 = JavascriptConversion::ToInt32(prop, ctx); break;
             case Wasm::WasmTypes::F32: cnst.f32 = (float)JavascriptConversion::ToNumber(prop, ctx); break;
             case Wasm::WasmTypes::F64: cnst.f64 = JavascriptConversion::ToNumber(prop, ctx); break;
-            case Wasm::WasmTypes::I64: Js::JavascriptError::ThrowTypeError(ctx, WASMERR_InvalidTypeConversion);
+            case Wasm::WasmTypes::I64: Js::JavascriptError::ThrowTypeErrorVar(ctx, WASMERR_InvalidTypeConversion, _u("Var"), _u("i64"));
+#ifdef ENABLE_WASM_SIMD
+            case Wasm::WasmTypes::M128: Js::JavascriptError::ThrowTypeErrorVar(ctx, WASMERR_InvalidTypeConversion, _u("Var"), _u("m128"));
+#endif
             default:
-                Js::Throw::InternalError();
+                Wasm::WasmTypes::CompileAssertCases<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
             }
             env->SetGlobalValue(global, cnst);
             break;

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -519,7 +519,12 @@ WebAssemblyModule::AttachCustomInOutTracingReader(Wasm::WasmFunctionInfo* func, 
         case Wasm::Local::I64: node.op = Wasm::wbPrintI64; break;
         case Wasm::Local::F32: node.op = Wasm::wbPrintF32; break;
         case Wasm::Local::F64: node.op = Wasm::wbPrintF64; break;
+#ifdef ENABLE_WASM_SIMD
+        // todo:: Add support to print m128 argument values
+        case Wasm::WasmTypes::M128: continue;
+#endif
         default:
+            Wasm::WasmTypes::CompileAssertCasesNoFailFast<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
             throw Wasm::WasmCompilationException(_u("Unknown param type"));
         }
         customReader->AddNode(node);
@@ -559,11 +564,19 @@ WebAssemblyModule::AttachCustomInOutTracingReader(Wasm::WasmFunctionInfo* func, 
         case Wasm::WasmTypes::I64: node.op = Wasm::wbPrintI64; break;
         case Wasm::WasmTypes::F32: node.op = Wasm::wbPrintF32; break;
         case Wasm::WasmTypes::F64: node.op = Wasm::wbPrintF64; break;
+#ifdef ENABLE_WASM_SIMD
+        // todo:: Add support to print m128 return values
+        case Wasm::WasmTypes::M128: goto SkipReturnPrint;
+#endif
         default:
+            Wasm::WasmTypes::CompileAssertCasesNoFailFast<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
             throw Wasm::WasmCompilationException(_u("Unknown return type"));
         }
         customReader->AddNode(node);
     }
+#ifdef ENABLE_WASM_SIMD
+SkipReturnPrint:
+#endif
     endNode.op = Wasm::wbPrintNewLine;
     customReader->AddNode(endNode);
 

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -1067,6 +1067,24 @@ void WasmBinaryReader::ReadGlobalSection()
     for (uint32 i = 0; i < numGlobals; ++i)
     {
         WasmTypes::WasmType type = ReadWasmType(len);
+        
+        if (!WasmTypes::IsLocalType(type))
+        {
+            ThrowDecodingError(_u("Invalid global type %u"), type);
+        }
+        switch (type)
+        {
+        case WasmTypes::I32: break; // Handled
+        case WasmTypes::I64: break; // Handled
+        case WasmTypes::F32: break; // Handled
+        case WasmTypes::F64: break; // Handled
+#ifdef ENABLE_WASM_SIMD
+        case WasmTypes::M128: ThrowDecodingError(_u("m128 globals not supported"));
+#endif
+        default:
+            WasmTypes::CompileAssertCases<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
+        }
+        
         bool isMutable = ReadMutableValue();
         WasmNode globalNode = ReadInitExpr();
         GlobalReferenceTypes::Type refType = GlobalReferenceTypes::Const;

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -692,6 +692,8 @@ void WasmBinaryReader::ConstNode()
         m_funcState.count += Simd::VEC_WIDTH;
         break;
 #endif
+    default:
+        WasmTypes::CompileAssertCases<Wasm::WasmTypes::I32, Wasm::WasmTypes::I64, Wasm::WasmTypes::F32, Wasm::WasmTypes::F64, WASM_M128_CHECK_TYPE>();
     }
 }
 

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -208,6 +208,7 @@ Js::AsmJsRetType WasmToAsmJs::GetAsmJsReturnType(WasmTypes::WasmType wasmType)
         return Js::AsmJsRetType::Float32x4;
 #endif
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Unknown return type %u"), wasmType);
     }
 }
@@ -228,6 +229,7 @@ Js::AsmJsVarType WasmToAsmJs::GetAsmJsVarType(WasmTypes::WasmType wasmType)
         return Js::AsmJsVarType::Float32x4;
 #endif
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Unknown var type %u"), wasmType);
     }
 }
@@ -607,10 +609,6 @@ void WasmBytecodeGenerator::EnregisterLocals()
     {
         WasmTypes::WasmType type = m_funcInfo->GetLocal(i);
         WasmRegisterSpace* regSpace = GetRegisterSpace(type);
-        if (regSpace == nullptr)
-        {
-            throw WasmCompilationException(_u("Unable to find local register space"));
-        }
         m_locals[i] = WasmLocal(regSpace->AcquireRegister(), type);
 
         // Zero only the locals not corresponding to formal parameters.
@@ -1006,6 +1004,7 @@ void WasmBytecodeGenerator::EmitLoadConst(EmitInfo dst, WasmConstLitNode cnst)
     }
 #endif
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Unknown type %u"), dst.type);
     }
 }
@@ -1229,6 +1228,7 @@ PolymorphicEmitInfo WasmBytecodeGenerator::EmitCall()
             }
             // Fall through
         default:
+            WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
             throw WasmCompilationException(_u("Unknown argument type %u"), info.type);
         }
 
@@ -1318,7 +1318,12 @@ PolymorphicEmitInfo WasmBytecodeGenerator::EmitCall()
             case WasmTypes::I64:
                 convertOp = Js::OpCodeAsmJs::Conv_VTL;
                 break;
+#ifdef ENABLE_WASM_SIMD
+            case WasmTypes::M128:
+                throw WasmCompilationException(_u("Return type: m128 not supported in import calls"));
+#endif
             default:
+                WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
                 throw WasmCompilationException(_u("Unknown call return type %u"), singleResType);
             }
             Js::RegSlot location = GetRegisterSpace(singleResType)->AcquireTmpRegister();
@@ -1832,6 +1837,7 @@ Js::OpCodeAsmJs WasmBytecodeGenerator::GetLoadOp(WasmTypes::WasmType wasmType)
             return Js::OpCodeAsmJs::Ld_Int;
         }
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Unknown load operator %u"), wasmType);
     }
 }
@@ -1867,6 +1873,7 @@ Js::OpCodeAsmJs WasmBytecodeGenerator::GetReturnOp(WasmTypes::WasmType type)
             return Js::OpCodeAsmJs::Return_Int;
         }
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Unknown return type %u"), type);
     }
     return retOp;
@@ -2052,7 +2059,8 @@ WasmRegisterSpace* WasmBytecodeGenerator::GetRegisterSpace(WasmTypes::WasmType t
         return mTypedRegisterAllocator.GetRegisterSpace(WAsmJs::SIMD);
 #endif
     default:
-        return nullptr;
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
+        throw WasmCompilationException(_u("Unknown type %u"), type);
     }
 }
 

--- a/lib/WasmReader/WasmParseTree.cpp
+++ b/lib/WasmReader/WasmParseTree.cpp
@@ -86,7 +86,7 @@ bool IsLocalType(WasmTypes::WasmType type)
         return false;
     }
 #endif
-    return type > WasmTypes::Void && type < WasmTypes::Limit;
+    return type >= WasmTypes::FirstLocalType && type < WasmTypes::Limit;
 }
 
 uint32 GetTypeByteSize(WasmType type)

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -46,8 +46,62 @@ namespace Wasm
 #endif
             Limit,
             Ptr,
-            Any
+            Any,
+
+            FirstLocalType = I32,
+            AllLocalTypes = 
+                  1 << I32
+                | 1 << I64
+                | 1 << F32
+                | 1 << F64
+#ifdef ENABLE_WASM_SIMD
+                | 1 << M128
+#endif
         };
+
+        namespace SwitchCaseChecks
+        {
+            template<WasmType... T>
+            struct bv;
+
+            template<>
+            struct bv<>
+            {
+                static constexpr uint value = 0;
+            };
+
+            template<WasmType... K>
+            struct bv<Limit, K...>
+            {
+                static constexpr uint value = bv<K...>::value;
+            };
+
+            template<WasmType K1, WasmType... K>
+            struct bv<K1, K...>
+            {
+                static constexpr uint value = (1 << K1) | bv<K...>::value;
+            };
+        }
+
+#ifdef ENABLE_WASM_SIMD
+#define WASM_M128_CHECK_TYPE Wasm::WasmTypes::M128
+#else
+#define WASM_M128_CHECK_TYPE Wasm::WasmTypes::Limit
+#endif
+
+        template<WasmType... T>
+        __declspec(noreturn) void CompileAssertCases()
+        {
+            CompileAssertMsg(SwitchCaseChecks::bv<T...>::value == AllLocalTypes, "WasmTypes missing in switch-case");
+            AssertOrFailFastMsg(UNREACHED, "The WasmType case should have been handled");
+        }
+
+        template<WasmType... T>
+        void CompileAssertCasesNoFailFast()
+        {
+            CompileAssertMsg(SwitchCaseChecks::bv<T...>::value == AllLocalTypes, "WasmTypes missing in switch-case");
+            AssertMsg(UNREACHED, "The WasmType case should have been handled");
+        }
 
         extern const char16* const strIds[Limit];
 

--- a/lib/WasmReader/WasmSignature.cpp
+++ b/lib/WasmReader/WasmSignature.cpp
@@ -155,6 +155,7 @@ Js::ArgSlot WasmSignature::GetParamSize(Js::ArgSlot index) const
         break;
 #endif
     default:
+        WasmTypes::CompileAssertCasesNoFailFast<WasmTypes::I32, WasmTypes::I64, WasmTypes::F32, WasmTypes::F64, WASM_M128_CHECK_TYPE>();
         throw WasmCompilationException(_u("Invalid param type"));
     }
 }

--- a/test/wasm/baselines/global.baseline
+++ b/test/wasm/baselines/global.baseline
@@ -58,6 +58,6 @@ import: 78.145
 impInit: 78.145
 
 Invalid cases
-Should be invalid type conversion: Invalid WebAssembly type conversion
-Should be invalid type conversion: Invalid WebAssembly type conversion
+Should be invalid type conversion: Invalid WebAssembly type conversion Var to i64
+Should be invalid type conversion: Invalid WebAssembly type conversion i64 to Var
 Should be invalid init expr: initializer expression can only use imported globals


### PR DESCRIPTION
Make it explicit that we don't support Wasm m128 globals at this time.

Strengthen switch-cases with WasmTypes to make sure we always handled the main types.
This will cause compile errors when we add new types to make sure we correctly handled them everywhere

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5245)
<!-- Reviewable:end -->
