### PR TITLE
Clean-up auxptr typing

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -988,7 +988,7 @@ namespace Js
     Var
     FunctionBody::GetFormalsPropIdArrayOrNullObj()
     {
-        Var formalsPropIdArray = this->GetAuxPtrWithLock(AuxPointerType::FormalsPropIdArray);
+        Var formalsPropIdArray = this->GetAuxPtrWithLock<AuxPointerType::FormalsPropIdArray>();
         if (formalsPropIdArray == nullptr)
         {
             return GetScriptContext()->GetLibrary()->GetNull();
@@ -1001,16 +1001,16 @@ namespace Js
     {
         if (checkForNull)
         {
-            Assert(this->GetAuxPtrWithLock(AuxPointerType::FormalsPropIdArray));
+            Assert(this->GetAuxPtrWithLock<AuxPointerType::FormalsPropIdArray>());
         }
-        return static_cast<PropertyIdArray*>(this->GetAuxPtrWithLock(AuxPointerType::FormalsPropIdArray));
+        return this->GetAuxPtrWithLock<AuxPointerType::FormalsPropIdArray>();
     }
 
     void
     FunctionBody::SetFormalsPropIdArray(PropertyIdArray * propIdArray)
     {
-        AssertMsg(propIdArray == nullptr || this->GetAuxPtrWithLock(AuxPointerType::FormalsPropIdArray) == nullptr, "Already set?");
-        this->SetAuxPtr(AuxPointerType::FormalsPropIdArray, propIdArray);
+        AssertMsg(propIdArray == nullptr || this->GetAuxPtrWithLock<AuxPointerType::FormalsPropIdArray>() == nullptr, "Already set?");
+        this->SetAuxPtr<AuxPointerType::FormalsPropIdArray>(propIdArray);
     }
 
     ByteBlock*
@@ -1907,7 +1907,7 @@ namespace Js
             {
                 return string;
             }
-            this->SetAuxPtr(AuxPointerType::CachedSourceString, nullptr);
+            this->SetAuxPtr<AuxPointerType::CachedSourceString>(nullptr);
         }
         return nullptr;
     }
@@ -1923,13 +1923,13 @@ namespace Js
 
     RecyclerWeakReference<JavascriptString> * ParseableFunctionInfo::GetCachedSourceStringWeakRef()
     {
-        return static_cast<RecyclerWeakReference<JavascriptString> *>(this->GetAuxPtr(AuxPointerType::CachedSourceString));
+        return this->GetAuxPtr<AuxPointerType::CachedSourceString>();
     }
 
     void ParseableFunctionInfo::SetCachedSourceStringWeakRef(RecyclerWeakReference<JavascriptString> * weakRef)
     {
         Assert(this->GetCachedSourceString() == nullptr);
-        this->SetAuxPtr(AuxPointerType::CachedSourceString, weakRef);
+        this->SetAuxPtr<AuxPointerType::CachedSourceString>(weakRef);
     }
 
     FunctionInfoArray ParseableFunctionInfo::GetNestedFuncArray()
@@ -2053,12 +2053,12 @@ namespace Js
     // Function object type list methods
     FunctionProxy::FunctionTypeWeakRefList* FunctionProxy::GetFunctionObjectTypeList() const
     {
-        return static_cast<FunctionTypeWeakRefList*>(this->GetAuxPtr(AuxPointerType::FunctionObjectTypeList));
+        return this->GetAuxPtr<AuxPointerType::FunctionObjectTypeList>();
     }
 
     void FunctionProxy::SetFunctionObjectTypeList(FunctionProxy::FunctionTypeWeakRefList* list)
     {
-        this->SetAuxPtr(AuxPointerType::FunctionObjectTypeList, list);
+        this->SetAuxPtr<AuxPointerType::FunctionObjectTypeList>(list);
     }
 
     template <typename Fn>
@@ -4036,7 +4036,7 @@ namespace Js
 //        Assert(CanDoStackNestedFunc());
         Assert(parentFunctionBody->DoStackNestedFunc());
 
-        this->SetAuxPtr(AuxPointerType::StackNestedFuncParent, this->GetScriptContext()->GetRecycler()->CreateWeakReferenceHandle(parentFunctionInfo));
+        this->SetAuxPtr<AuxPointerType::StackNestedFuncParent>(this->GetScriptContext()->GetRecycler()->CreateWeakReferenceHandle(parentFunctionInfo));
     }
 
     FunctionInfo * FunctionBody::GetStackNestedFuncParentStrongRef()
@@ -4047,12 +4047,12 @@ namespace Js
 
     RecyclerWeakReference<FunctionInfo> * FunctionBody::GetStackNestedFuncParent()
     {
-        return static_cast<RecyclerWeakReference<FunctionInfo>*>(this->GetAuxPtr(AuxPointerType::StackNestedFuncParent));
+        return this->GetAuxPtr<AuxPointerType::StackNestedFuncParent>();
     }
 
     FunctionInfo * FunctionBody::GetAndClearStackNestedFuncParent()
     {
-        if (this->GetAuxPtr(AuxPointerType::StackNestedFuncParent))
+        if (this->GetAuxPtr<AuxPointerType::StackNestedFuncParent>())
         {
             FunctionInfo * parentFunctionInfo = GetStackNestedFuncParentStrongRef();
             ClearStackNestedFuncParent();
@@ -4063,7 +4063,7 @@ namespace Js
 
     void FunctionBody::ClearStackNestedFuncParent()
     {
-        this->SetAuxPtr(AuxPointerType::StackNestedFuncParent, nullptr);
+        this->SetAuxPtr<AuxPointerType::StackNestedFuncParent>(nullptr);
     }
 
     void FunctionBody::CreateCacheIdToPropertyIdMap(uint rootObjectLoadInlineCacheStart, uint rootObjectLoadMethodInlineCacheStart,
@@ -5157,7 +5157,7 @@ namespace Js
 
         // Set other state back to before parse as well
         this->SetStackNestedFunc(false);
-        this->SetAuxPtr(AuxPointerType::StackNestedFuncParent, nullptr);
+        this->SetAuxPtr<AuxPointerType::StackNestedFuncParent>(nullptr);
         this->SetReparsed(true);
 #if DBG
         char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
@@ -6053,18 +6053,18 @@ namespace Js
         {
             return;
         }
-        this->SetAuxPtr(AuxPointerType::ForInCacheArray, AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->GetEnumeratorAllocator(), EnumeratorCache, profiledForInLoopCount));
+        this->SetAuxPtr<AuxPointerType::ForInCacheArray>(AllocatorNewArrayZ(CacheAllocator, this->GetScriptContext()->GetEnumeratorAllocator(), EnumeratorCache, profiledForInLoopCount));
     }
 
     EnumeratorCache * FunctionBody::GetForInCache(uint index)
     {
         Assert(index < this->GetProfiledForInLoopCount());
-        return &((EnumeratorCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray))[index];
+        return &this->GetAuxPtr<AuxPointerType::ForInCacheArray>()[index];
     }
 
     EnumeratorCache * FunctionBody::GetForInCacheArray()
     {
-        return ((EnumeratorCache *)this->GetAuxPtrWithLock(AuxPointerType::ForInCacheArray));
+        return this->GetAuxPtrWithLock<AuxPointerType::ForInCacheArray>();
     }
 
     void FunctionBody::CleanUpForInCache(bool isShutdown)
@@ -6074,7 +6074,7 @@ namespace Js
         {
             return;
         }
-        EnumeratorCache * forInCacheArray = (EnumeratorCache *)this->GetAuxPtr(AuxPointerType::ForInCacheArray);
+        EnumeratorCache * forInCacheArray = this->GetAuxPtr<AuxPointerType::ForInCacheArray>();
         if (forInCacheArray)
         {
             if (isShutdown)
@@ -6084,7 +6084,7 @@ namespace Js
             else
             {
                 AllocatorDeleteArray(CacheAllocator, this->GetScriptContext()->GetEnumeratorAllocator(), profiledForInLoopCount, forInCacheArray);
-                this->SetAuxPtr(AuxPointerType::ForInCacheArray, nullptr);
+                this->SetAuxPtr<AuxPointerType::ForInCacheArray>(nullptr);
             }
         }
     }
@@ -6360,7 +6360,7 @@ namespace Js
     AsmJsFunctionInfo* FunctionBody::AllocateAsmJsFunctionInfo()
     {
         Assert( !this->GetAsmJsFunctionInfo() );
-        this->SetAuxPtr(AuxPointerType::AsmJsFunctionInfo, RecyclerNew( m_scriptContext->GetRecycler(), AsmJsFunctionInfo));
+        this->SetAuxPtr<AuxPointerType::AsmJsFunctionInfo>(RecyclerNew( m_scriptContext->GetRecycler(), AsmJsFunctionInfo));
         return this->GetAsmJsFunctionInfo();
     }
 
@@ -6368,7 +6368,7 @@ namespace Js
     {
         Assert( !this->GetAsmJsModuleInfo() );
         Recycler* rec = m_scriptContext->GetRecycler();
-        this->SetAuxPtr(AuxPointerType::AsmJsModuleInfo, RecyclerNew(rec, AsmJsModuleInfo, rec));
+        this->SetAuxPtr<AuxPointerType::AsmJsModuleInfo>(RecyclerNew(rec, AsmJsModuleInfo, rec));
         return this->GetAsmJsModuleInfo();
     }
 #endif
@@ -6528,11 +6528,11 @@ namespace Js
         return runtimeData;
     }
 
+    template<Js::FunctionProxy::AuxPointerType auxType>
     FunctionCodeGenRuntimeData * FunctionBody::EnsureCodeGenRuntimeDataCommon(
         Recycler *const recycler,
         __in_range(0, profiledCallSiteCount - 1) const ProfileId profiledCallSiteId,
-        FunctionBody *const inlinee,
-        AuxPointerType auxType)
+        FunctionBody *const inlinee)
     {
         Assert(recycler);
         Assert(profiledCallSiteId < profiledCallSiteCount);
@@ -6544,7 +6544,7 @@ namespace Js
             this->SetAuxPtr(auxType, codeGenRuntimeData);
         }
 
-        Field(FunctionCodeGenRuntimeData *)* codeGenRuntimeData = static_cast<Field(FunctionCodeGenRuntimeData *)*>(this->GetAuxPtr(auxType));
+        Field(FunctionCodeGenRuntimeData *)* codeGenRuntimeData = this->GetAuxPtr<auxType>();
         Field(FunctionCodeGenRuntimeData *) const inlineeData = codeGenRuntimeData[profiledCallSiteId];
         if (inlineeData == nullptr)
         {
@@ -6577,7 +6577,7 @@ namespace Js
         __in_range(0, profiledCallSiteCount - 1) const ProfileId profiledCallSiteId,
         FunctionBody *const inlinee)
     {
-        return EnsureCodeGenRuntimeDataCommon(recycler, profiledCallSiteId, inlinee, AuxPointerType::CodeGenRuntimeData);
+        return EnsureCodeGenRuntimeDataCommon<AuxPointerType::CodeGenRuntimeData>(recycler, profiledCallSiteId, inlinee);
     }
 
     FunctionCodeGenRuntimeData * FunctionBody::EnsureCallbackInlineeCodeGenRuntimeData(
@@ -6585,7 +6585,7 @@ namespace Js
         __in_range(0, profiledCallSiteCount - 1) const ProfileId profiledCallSiteId,
         FunctionBody *const inlinee)
     {
-        return EnsureCodeGenRuntimeDataCommon(recycler, profiledCallSiteId, inlinee, AuxPointerType::CodeGenCallbackRuntimeData);
+        return EnsureCodeGenRuntimeDataCommon<AuxPointerType::CodeGenCallbackRuntimeData>(recycler, profiledCallSiteId, inlinee);
     }
 
     const FunctionCodeGenRuntimeData *FunctionBody::GetLdFldInlineeCodeGenRuntimeData(const InlineCacheIndex inlineCacheIndex) const
@@ -6740,12 +6740,12 @@ namespace Js
     }
     FunctionEntryPointInfo *FunctionBody::GetSimpleJitEntryPointInfo() const
     {
-        return static_cast<FunctionEntryPointInfo *>(this->GetAuxPtr(AuxPointerType::SimpleJitEntryPointInfo));
+        return this->GetAuxPtr<AuxPointerType::SimpleJitEntryPointInfo>();
     }
 
     void FunctionBody::SetSimpleJitEntryPointInfo(FunctionEntryPointInfo *const entryPointInfo)
     {
-        this->SetAuxPtr(AuxPointerType::SimpleJitEntryPointInfo, entryPointInfo);
+        this->SetAuxPtr<AuxPointerType::SimpleJitEntryPointInfo>(entryPointInfo);
     }
 
 

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -879,7 +879,9 @@ namespace Js
             CodeGenRuntimeData = 11,
             PolymorphicInlineCachesHead = 12,     // DList of all polymorphic inline caches that aren't finalized yet
             PropertyIdsForScopeSlotArray = 13,    // For SourceInfo
+#if ENABLE_PROFILE_INFO
             PolymorphicCallSiteInfoHead  = 14,
+#endif
             AuxBlock = 15,                        // Optional auxiliary information
             AuxContextBlock = 16,                 // Optional auxiliary context specific information
             ReferencedPropertyIdMap = 17,
@@ -890,7 +892,9 @@ namespace Js
             ForInCacheArray = 22,
             SlotIdInCachedScopeToNestedIndexArray = 23,
             CodeGenCallbackRuntimeData = 24,
+#if ENABLE_PROFILE_INFO
             CallbackArgOutInfoList = 25,
+#endif
 
             Max,
             Invalid = 0xff
@@ -920,7 +924,9 @@ namespace Js
         AuxPointerTypeEntry(AuxPointerType::CodeGenRuntimeData, Field(FunctionCodeGenRuntimeData*)*);
         AuxPointerTypeEntry(AuxPointerType::PolymorphicInlineCachesHead, FunctionBodyPolymorphicInlineCache*);
         AuxPointerTypeEntry(AuxPointerType::PropertyIdsForScopeSlotArray, Js::PropertyId*);
+#if ENABLE_PROFILE_INFO
         AuxPointerTypeEntry(AuxPointerType::PolymorphicCallSiteInfoHead , PolymorphicCallSiteInfo*);
+#endif
         AuxPointerTypeEntry(AuxPointerType::AuxBlock, ByteBlock*);
         AuxPointerTypeEntry(AuxPointerType::AuxContextBlock, ByteBlock*);
         AuxPointerTypeEntry(AuxPointerType::ReferencedPropertyIdMap, PropertyId*);
@@ -931,7 +937,9 @@ namespace Js
         AuxPointerTypeEntry(AuxPointerType::ForInCacheArray, EnumeratorCache*);
         AuxPointerTypeEntry(AuxPointerType::SlotIdInCachedScopeToNestedIndexArray, Js::AuxArray<uint32>*);
         AuxPointerTypeEntry(AuxPointerType::CodeGenCallbackRuntimeData, Field(FunctionCodeGenRuntimeData*)*);
+#if ENABLE_PROFILE_INFO
         AuxPointerTypeEntry(AuxPointerType::CallbackArgOutInfoList, CallbackInfoList*);
+#endif
 #undef AuxPointerTypeEntry
 
         typedef AuxPtrs<FunctionProxy, AuxPointerType> AuxPtrsT;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -896,9 +896,62 @@ namespace Js
             Invalid = 0xff
         };
 
+        template<AuxPointerType T>
+        struct AuxPointerTypeTable {
+            typedef void* type;
+        };
+        template<>
+        struct AuxPointerTypeTable<AuxPointerType::Max> {};
+        template<>
+        struct AuxPointerTypeTable<AuxPointerType::Invalid> {};
+
+#define AuxPointerTypeEntry(apt, T) template<> struct AuxPointerTypeTable<apt> { typedef T type; }
+        AuxPointerTypeEntry(AuxPointerType::DeferredStubs, DeferredFunctionStub*);
+        AuxPointerTypeEntry(AuxPointerType::CachedSourceString, RecyclerWeakReference<JavascriptString>*);
+        AuxPointerTypeEntry(AuxPointerType::AsmJsFunctionInfo, AsmJsFunctionInfo*);
+        AuxPointerTypeEntry(AuxPointerType::AsmJsModuleInfo, AsmJsModuleInfo*);
+        //AuxPointerTypeEntry(AuxPointerType::StatementMaps, StatementMapList*); // the type for this isn't declared yet
+        AuxPointerTypeEntry(AuxPointerType::StackNestedFuncParent, RecyclerWeakReference<FunctionInfo>*);
+        AuxPointerTypeEntry(AuxPointerType::SimpleJitEntryPointInfo, FunctionEntryPointInfo*);
+        AuxPointerTypeEntry(AuxPointerType::FunctionObjectTypeList, FunctionTypeWeakRefList*);
+        AuxPointerTypeEntry(AuxPointerType::CodeGenGetSetRuntimeData, Field(Js::FunctionCodeGenRuntimeData*)*);
+        AuxPointerTypeEntry(AuxPointerType::PropertyIdOnRegSlotsContainer, Js::PropertyIdOnRegSlotsContainer*);
+        AuxPointerTypeEntry(AuxPointerType::LoopHeaderArray, Js::LoopHeader*);
+        AuxPointerTypeEntry(AuxPointerType::CodeGenRuntimeData, Field(FunctionCodeGenRuntimeData*)*);
+        AuxPointerTypeEntry(AuxPointerType::PolymorphicInlineCachesHead, FunctionBodyPolymorphicInlineCache*);
+        AuxPointerTypeEntry(AuxPointerType::PropertyIdsForScopeSlotArray, Js::PropertyId*);
+        AuxPointerTypeEntry(AuxPointerType::PolymorphicCallSiteInfoHead , PolymorphicCallSiteInfo*);
+        AuxPointerTypeEntry(AuxPointerType::AuxBlock, ByteBlock*);
+        AuxPointerTypeEntry(AuxPointerType::AuxContextBlock, ByteBlock*);
+        AuxPointerTypeEntry(AuxPointerType::ReferencedPropertyIdMap, PropertyId*);
+        AuxPointerTypeEntry(AuxPointerType::LiteralRegexes, Field(UnifiedRegex::RegexPattern*)*);
+        AuxPointerTypeEntry(AuxPointerType::ObjLiteralTypes, Field(DynamicType*)*);
+        AuxPointerTypeEntry(AuxPointerType::ScopeInfo, ScopeInfo*);
+        AuxPointerTypeEntry(AuxPointerType::FormalsPropIdArray, PropertyIdArray*);
+        AuxPointerTypeEntry(AuxPointerType::ForInCacheArray, EnumeratorCache*);
+        AuxPointerTypeEntry(AuxPointerType::SlotIdInCachedScopeToNestedIndexArray, Js::AuxArray<uint32>*);
+        AuxPointerTypeEntry(AuxPointerType::CodeGenCallbackRuntimeData, Field(FunctionCodeGenRuntimeData*)*);
+        AuxPointerTypeEntry(AuxPointerType::CallbackArgOutInfoList, CallbackInfoList*);
+#undef AuxPointerTypeEntry
+
         typedef AuxPtrs<FunctionProxy, AuxPointerType> AuxPtrsT;
         friend AuxPtrsT;
         FieldWithBarrier(AuxPtrsT*) auxPtrs;
+        template<AuxPointerType T, typename MappedType = typename AuxPointerTypeTable<T>::type>
+        inline MappedType GetAuxPtr() const
+        {
+            return static_cast<MappedType>(GetAuxPtr(T));
+        }
+        template<AuxPointerType T, typename MappedType = typename AuxPointerTypeTable<T>::type>
+        inline MappedType GetAuxPtrWithLock() const
+        {
+            return static_cast<MappedType>(GetAuxPtrWithLock(T));
+        }
+        template<AuxPointerType T, typename MappedType = typename AuxPointerTypeTable<T>::type>
+        void SetAuxPtr(MappedType ptr)
+        {
+            SetAuxPtr(T, ptr);
+        }
         void* GetAuxPtr(AuxPointerType e) const;
         void* GetAuxPtrWithLock(AuxPointerType e) const;
         void SetAuxPtr(AuxPointerType e, void* ptr);
@@ -1508,8 +1561,8 @@ namespace Js
         ArgSlot GetReportedInParamsCount() const;
         void SetReportedInParamsCount(ArgSlot newReportedInParamCount);
         void ResetInParams();
-        ScopeInfo* GetScopeInfo() const { return static_cast<ScopeInfo*>(this->GetAuxPtr(AuxPointerType::ScopeInfo)); }
-        void SetScopeInfo(ScopeInfo* scopeInfo) {  this->SetAuxPtr(AuxPointerType::ScopeInfo, scopeInfo); }
+        ScopeInfo* GetScopeInfo() const { return this->GetAuxPtr<AuxPointerType::ScopeInfo>(); }
+        void SetScopeInfo(ScopeInfo* scopeInfo) {  this->SetAuxPtr<AuxPointerType::ScopeInfo>(scopeInfo); }
         PropertyId GetOrAddPropertyIdTracked(JsUtil::CharacterBuffer<WCHAR> const& propName);
 
         void SetScopeSlotArraySizes(uint scopeSlotCount, uint scopeSlotCountForParamScope)
@@ -1518,11 +1571,11 @@ namespace Js
             this->paramScopeSlotArraySize = scopeSlotCountForParamScope;
         }
 
-        PropertyId * GetPropertyIdsForScopeSlotArray() const { return static_cast<Js::PropertyId *>(this->GetAuxPtr(AuxPointerType::PropertyIdsForScopeSlotArray)); }
+        PropertyId * GetPropertyIdsForScopeSlotArray() const { return this->GetAuxPtr<AuxPointerType::PropertyIdsForScopeSlotArray>(); }
         void SetPropertyIdsForScopeSlotArray(Js::PropertyId * propertyIdsForScopeSlotArray, uint scopeSlotCount, uint scopeSlotCountForParamScope = 0)
         {
             SetScopeSlotArraySizes(scopeSlotCount, scopeSlotCountForParamScope);
-            this->SetAuxPtr(AuxPointerType::PropertyIdsForScopeSlotArray, propertyIdsForScopeSlotArray);
+            this->SetAuxPtr<AuxPointerType::PropertyIdsForScopeSlotArray>(propertyIdsForScopeSlotArray);
         }
 
         void SetInitialDefaultEntryPoint();
@@ -1648,8 +1701,8 @@ namespace Js
         ParseableFunctionInfo* GetNestedFunctionForExecution(uint index);
         void SetNestedFunc(FunctionInfo* nestedFunc, uint index, uint32 flags);
         void BuildDeferredStubs(ParseNodeFnc* pnodeFnc);
-        DeferredFunctionStub *GetDeferredStubs() const { return static_cast<DeferredFunctionStub *>(this->GetAuxPtr(AuxPointerType::DeferredStubs)); }
-        void SetDeferredStubs(DeferredFunctionStub *stub) { this->SetAuxPtr(AuxPointerType::DeferredStubs, stub); }
+        DeferredFunctionStub *GetDeferredStubs() const { return this->GetAuxPtr<AuxPointerType::DeferredStubs>(); }
+        void SetDeferredStubs(DeferredFunctionStub *stub) { this->SetAuxPtr<AuxPointerType::DeferredStubs>(stub); }
         void RegisterFuncToDiag(ScriptContext * scriptContext, char16 const * pszTitle);
         bool IsES6ModuleCode() const;
     private:
@@ -2185,12 +2238,12 @@ namespace Js
 
         Js::RootObjectBase * LoadRootObject() const;
         Js::RootObjectBase * GetRootObject() const;
-        ByteBlock* GetAuxiliaryData() const { return static_cast<ByteBlock*>(this->GetAuxPtr(AuxPointerType::AuxBlock)); }
-        ByteBlock* GetAuxiliaryDataWithLock() const { return static_cast<ByteBlock*>(this->GetAuxPtrWithLock(AuxPointerType::AuxBlock)); }
-        void SetAuxiliaryData(ByteBlock* auxBlock) { this->SetAuxPtr(AuxPointerType::AuxBlock, auxBlock); }
-        ByteBlock* GetAuxiliaryContextData()const { return static_cast<ByteBlock*>(this->GetAuxPtr(AuxPointerType::AuxContextBlock)); }
-        ByteBlock* GetAuxiliaryContextDataWithLock()const { return static_cast<ByteBlock*>(this->GetAuxPtrWithLock(AuxPointerType::AuxContextBlock)); }
-        void SetAuxiliaryContextData(ByteBlock* auxContextBlock) { this->SetAuxPtr(AuxPointerType::AuxContextBlock, auxContextBlock); }
+        ByteBlock* GetAuxiliaryData() const { return this->GetAuxPtr<AuxPointerType::AuxBlock>(); }
+        ByteBlock* GetAuxiliaryDataWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::AuxBlock>(); }
+        void SetAuxiliaryData(ByteBlock* auxBlock) { this->SetAuxPtr<AuxPointerType::AuxBlock>(auxBlock); }
+        ByteBlock* GetAuxiliaryContextData()const { return this->GetAuxPtr<AuxPointerType::AuxContextBlock>(); }
+        ByteBlock* GetAuxiliaryContextDataWithLock()const { return this->GetAuxPtrWithLock<AuxPointerType::AuxContextBlock>(); }
+        void SetAuxiliaryContextData(ByteBlock* auxContextBlock) { this->SetAuxPtr<AuxPointerType::AuxContextBlock>(auxContextBlock); }
         void SetFormalsPropIdArray(PropertyIdArray * propIdArray);
         PropertyIdArray* GetFormalsPropIdArray(bool checkForNull = true);
         Var GetFormalsPropIdArrayOrNullObj();
@@ -2465,20 +2518,20 @@ namespace Js
         DebuggerScope* AddScopeObject(DiagExtraScopesType scopeType, int start, RegSlot scopeLocation);
         bool TryGetDebuggerScopeAt(int index, DebuggerScope*& debuggerScope);
 
-        StatementMapList * GetStatementMaps() const { return static_cast<StatementMapList *>(this->GetAuxPtrWithLock(AuxPointerType::StatementMaps)); }
-        void SetStatementMaps(StatementMapList *pStatementMaps) { this->SetAuxPtr(AuxPointerType::StatementMaps, pStatementMaps); }
+        StatementMapList * GetStatementMaps() const { return static_cast<StatementMapList *>(this->GetAuxPtrWithLock<AuxPointerType::StatementMaps>()); }
+        void SetStatementMaps(StatementMapList *pStatementMaps) { this->SetAuxPtr<AuxPointerType::StatementMaps>(pStatementMaps); }
 
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenGetSetRuntimeData() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtr(AuxPointerType::CodeGenGetSetRuntimeData)); }
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenGetSetRuntimeDataWithLock() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtrWithLock(AuxPointerType::CodeGenGetSetRuntimeData)); }
-        void SetCodeGenGetSetRuntimeData(FunctionCodeGenRuntimeData** codeGenGetSetRuntimeData) { this->SetAuxPtr(AuxPointerType::CodeGenGetSetRuntimeData, codeGenGetSetRuntimeData); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenGetSetRuntimeData() const { return this->GetAuxPtr<AuxPointerType::CodeGenGetSetRuntimeData>(); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenGetSetRuntimeDataWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::CodeGenGetSetRuntimeData>(); }
+        void SetCodeGenGetSetRuntimeData(FunctionCodeGenRuntimeData** codeGenGetSetRuntimeData) { this->SetAuxPtr<AuxPointerType::CodeGenGetSetRuntimeData>(codeGenGetSetRuntimeData); }
 
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenRuntimeData() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtr(AuxPointerType::CodeGenRuntimeData)); }
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenRuntimeDataWithLock() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtrWithLock(AuxPointerType::CodeGenRuntimeData)); }
-        void SetCodeGenRuntimeData(FunctionCodeGenRuntimeData** codeGenRuntimeData) { this->SetAuxPtr(AuxPointerType::CodeGenRuntimeData, codeGenRuntimeData); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenRuntimeData() const { return this->GetAuxPtr<AuxPointerType::CodeGenRuntimeData>(); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenRuntimeDataWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::CodeGenRuntimeData>(); }
+        void SetCodeGenRuntimeData(FunctionCodeGenRuntimeData** codeGenRuntimeData) { this->SetAuxPtr<AuxPointerType::CodeGenRuntimeData>(codeGenRuntimeData); }
 
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenCallbackRuntimeData() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtr(AuxPointerType::CodeGenCallbackRuntimeData)); }
-        Field(FunctionCodeGenRuntimeData*)* GetCodeGenCallbackRuntimeDataWithLock() const { return static_cast<Field(FunctionCodeGenRuntimeData*)*>(this->GetAuxPtrWithLock(AuxPointerType::CodeGenCallbackRuntimeData)); }
-        void SetCodeGenCallbackRuntimeData(FunctionCodeGenRuntimeData** codeGenArgumentRuntimeData) { this->SetAuxPtr(AuxPointerType::CodeGenCallbackRuntimeData, codeGenArgumentRuntimeData); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenCallbackRuntimeData() const { return this->GetAuxPtr<AuxPointerType::CodeGenCallbackRuntimeData>(); }
+        Field(FunctionCodeGenRuntimeData*)* GetCodeGenCallbackRuntimeDataWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::CodeGenCallbackRuntimeData>(); }
+        void SetCodeGenCallbackRuntimeData(FunctionCodeGenRuntimeData** codeGenArgumentRuntimeData) { this->SetAuxPtr<AuxPointerType::CodeGenCallbackRuntimeData>(codeGenArgumentRuntimeData); }
 
         template <typename TStatementMapList>
         static StatementMap * GetNextNonSubexpressionStatementMap(TStatementMapList *statementMapList, int & startingAtIndex);
@@ -2552,9 +2605,9 @@ namespace Js
         uint GetLoopNumber(LoopHeader const * loopHeader) const;
         uint GetLoopNumberWithLock(LoopHeader const * loopHeader) const;
         bool GetHasAllocatedLoopHeaders() { return this->GetLoopHeaderArray() != nullptr; }
-        Js::LoopHeader* GetLoopHeaderArray() const { return static_cast<Js::LoopHeader*>(this->GetAuxPtr(AuxPointerType::LoopHeaderArray)); }
-        Js::LoopHeader* GetLoopHeaderArrayWithLock() const { return static_cast<Js::LoopHeader*>(this->GetAuxPtrWithLock(AuxPointerType::LoopHeaderArray)); }
-        void SetLoopHeaderArray(Js::LoopHeader* loopHeaderArray) { this->SetAuxPtr(AuxPointerType::LoopHeaderArray, loopHeaderArray); }
+        Js::LoopHeader* GetLoopHeaderArray() const { return this->GetAuxPtr<AuxPointerType::LoopHeaderArray>(); }
+        Js::LoopHeader* GetLoopHeaderArrayWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::LoopHeaderArray>(); }
+        void SetLoopHeaderArray(Js::LoopHeader* loopHeaderArray) { this->SetAuxPtr<AuxPointerType::LoopHeaderArray>(loopHeaderArray); }
 
 #if ENABLE_NATIVE_CODEGEN
         Js::JavascriptMethod GetLoopBodyEntryPoint(Js::LoopHeader * loopHeader, int entryPointIndex);
@@ -2691,16 +2744,16 @@ namespace Js
 #endif /* IR_VIEWER */
 
 #if ENABLE_NATIVE_CODEGEN
-        void SetPolymorphicCallSiteInfoHead(PolymorphicCallSiteInfo *polyCallSiteInfo) { this->SetAuxPtr(AuxPointerType::PolymorphicCallSiteInfoHead, polyCallSiteInfo); }
-        PolymorphicCallSiteInfo * GetPolymorphicCallSiteInfoHead() { return static_cast<PolymorphicCallSiteInfo *>(this->GetAuxPtr(AuxPointerType::PolymorphicCallSiteInfoHead)); }
+        void SetPolymorphicCallSiteInfoHead(PolymorphicCallSiteInfo *polyCallSiteInfo) { this->SetAuxPtr<AuxPointerType::PolymorphicCallSiteInfoHead>(polyCallSiteInfo); }
+        PolymorphicCallSiteInfo * GetPolymorphicCallSiteInfoHead() { return this->GetAuxPtr<AuxPointerType::PolymorphicCallSiteInfoHead>(); }
 
-        void SetCallbackInfoList(CallbackInfoList * callbackInfoList) { this->SetAuxPtr(AuxPointerType::CallbackArgOutInfoList, callbackInfoList); }
-        CallbackInfoList * GetCallbackInfoList() { return static_cast<CallbackInfoList *>(this->GetAuxPtr(AuxPointerType::CallbackArgOutInfoList)); }
-        CallbackInfoList * GetCallbackInfoListWithLock() { return static_cast<CallbackInfoList *>(this->GetAuxPtrWithLock(AuxPointerType::CallbackArgOutInfoList)); }
+        void SetCallbackInfoList(CallbackInfoList * callbackInfoList) { this->SetAuxPtr<AuxPointerType::CallbackArgOutInfoList>(callbackInfoList); }
+        CallbackInfoList * GetCallbackInfoList() { return this->GetAuxPtr<AuxPointerType::CallbackArgOutInfoList>(); }
+        CallbackInfoList * GetCallbackInfoListWithLock() { return this->GetAuxPtrWithLock<AuxPointerType::CallbackArgOutInfoList>(); }
 #endif
 
-        FunctionBodyPolymorphicInlineCache * GetPolymorphicInlineCachesHead() { return static_cast<FunctionBodyPolymorphicInlineCache *>(this->GetAuxPtr(AuxPointerType::PolymorphicInlineCachesHead)); }
-        void SetPolymorphicInlineCachesHead(FunctionBodyPolymorphicInlineCache * cache) { this->SetAuxPtr(AuxPointerType::PolymorphicInlineCachesHead, cache); }
+        FunctionBodyPolymorphicInlineCache * GetPolymorphicInlineCachesHead() { return this->GetAuxPtr<AuxPointerType::PolymorphicInlineCachesHead>(); }
+        void SetPolymorphicInlineCachesHead(FunctionBodyPolymorphicInlineCache * cache) { this->SetAuxPtr<AuxPointerType::PolymorphicInlineCachesHead>(cache); }
 
         bool PolyInliningUsingFixedMethodsAllowedByConfigFlags(FunctionBody* topFunctionBody)
         {
@@ -2712,15 +2765,15 @@ namespace Js
 
         Js::PropertyIdOnRegSlotsContainer * GetPropertyIdOnRegSlotsContainer() const
         {
-            return static_cast<Js::PropertyIdOnRegSlotsContainer *>(this->GetAuxPtr(AuxPointerType::PropertyIdOnRegSlotsContainer));
+            return this->GetAuxPtr<AuxPointerType::PropertyIdOnRegSlotsContainer>();
         }
         Js::PropertyIdOnRegSlotsContainer * GetPropertyIdOnRegSlotsContainerWithLock() const
         {
-            return static_cast<Js::PropertyIdOnRegSlotsContainer *>(this->GetAuxPtrWithLock(AuxPointerType::PropertyIdOnRegSlotsContainer));
+            return this->GetAuxPtrWithLock<AuxPointerType::PropertyIdOnRegSlotsContainer>();
         }
         void SetPropertyIdOnRegSlotsContainer(Js::PropertyIdOnRegSlotsContainer *propertyIdOnRegSlotsContainer)
         {
-            this->SetAuxPtr(AuxPointerType::PropertyIdOnRegSlotsContainer, propertyIdOnRegSlotsContainer);
+            this->SetAuxPtr<AuxPointerType::PropertyIdOnRegSlotsContainer>(propertyIdOnRegSlotsContainer);
         }
     private:
         void ResetProfileIds();
@@ -2955,9 +3008,9 @@ namespace Js
 #if DBG
         void VerifyCacheIdToPropertyIdMap();
 #endif
-        PropertyId* GetReferencedPropertyIdMap() const { return static_cast<PropertyId*>(this->GetAuxPtr(AuxPointerType::ReferencedPropertyIdMap)); }
-        PropertyId* GetReferencedPropertyIdMapWithLock() const { return static_cast<PropertyId*>(this->GetAuxPtrWithLock(AuxPointerType::ReferencedPropertyIdMap)); }
-        void SetReferencedPropertyIdMap(PropertyId* propIdMap) { this->SetAuxPtr(AuxPointerType::ReferencedPropertyIdMap, propIdMap); }
+        PropertyId* GetReferencedPropertyIdMap() const { return this->GetAuxPtr<AuxPointerType::ReferencedPropertyIdMap>(); }
+        PropertyId* GetReferencedPropertyIdMapWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::ReferencedPropertyIdMap>(); }
+        void SetReferencedPropertyIdMap(PropertyId* propIdMap) { this->SetAuxPtr<AuxPointerType::ReferencedPropertyIdMap>(propIdMap); }
         void CreateReferencedPropertyIdMap(uint referencedPropertyIdCount);
         void CreateReferencedPropertyIdMap();
         PropertyId GetReferencedPropertyIdWithMapIndex(uint mapIndex);
@@ -2981,38 +3034,38 @@ namespace Js
         Field(DynamicType*)* GetObjectLiteralTypeRefWithLock(uint index);
         uint NewLiteralRegex();
         void AllocateLiteralRegexArray();
-        Field(UnifiedRegex::RegexPattern*)* GetLiteralRegexes() const { return static_cast<Field(UnifiedRegex::RegexPattern*)*>(this->GetAuxPtr(AuxPointerType::LiteralRegexes)); }
-        Field(UnifiedRegex::RegexPattern*)* GetLiteralRegexesWithLock() const { return static_cast<Field(UnifiedRegex::RegexPattern*)*>(this->GetAuxPtrWithLock(AuxPointerType::LiteralRegexes)); }
-        void SetLiteralRegexs(UnifiedRegex::RegexPattern ** literalRegexes) { this->SetAuxPtr(AuxPointerType::LiteralRegexes, literalRegexes); }
+        Field(UnifiedRegex::RegexPattern*)* GetLiteralRegexes() const { return this->GetAuxPtr<AuxPointerType::LiteralRegexes>(); }
+        Field(UnifiedRegex::RegexPattern*)* GetLiteralRegexesWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::LiteralRegexes>(); }
+        void SetLiteralRegexs(UnifiedRegex::RegexPattern ** literalRegexes) { this->SetAuxPtr<AuxPointerType::LiteralRegexes>(literalRegexes); }
         UnifiedRegex::RegexPattern *GetLiteralRegex(const uint index);
         UnifiedRegex::RegexPattern *GetLiteralRegexWithLock(const uint index);
 #ifdef ASMJS_PLAT
-        AsmJsFunctionInfo* GetAsmJsFunctionInfo() const { return static_cast<AsmJsFunctionInfo*>(this->GetAuxPtr(AuxPointerType::AsmJsFunctionInfo)); }
-        AsmJsFunctionInfo* GetAsmJsFunctionInfoWithLock()const { return static_cast<AsmJsFunctionInfo*>(this->GetAuxPtrWithLock(AuxPointerType::AsmJsFunctionInfo)); }
+        AsmJsFunctionInfo* GetAsmJsFunctionInfo() const { return this->GetAuxPtr<AuxPointerType::AsmJsFunctionInfo>(); }
+        AsmJsFunctionInfo* GetAsmJsFunctionInfoWithLock()const { return this->GetAuxPtrWithLock<AuxPointerType::AsmJsFunctionInfo>(); }
         AsmJsFunctionInfo* AllocateAsmJsFunctionInfo();
-        AsmJsModuleInfo* GetAsmJsModuleInfo()const { return static_cast<AsmJsModuleInfo*>(this->GetAuxPtr(AuxPointerType::AsmJsModuleInfo)); }
-        AsmJsModuleInfo* GetAsmJsModuleInfoWithLock()const { return static_cast<AsmJsModuleInfo*>(this->GetAuxPtrWithLock(AuxPointerType::AsmJsModuleInfo)); }
+        AsmJsModuleInfo* GetAsmJsModuleInfo()const { return this->GetAuxPtr<AuxPointerType::AsmJsModuleInfo>(); }
+        AsmJsModuleInfo* GetAsmJsModuleInfoWithLock()const { return this->GetAuxPtrWithLock<AuxPointerType::AsmJsModuleInfo>(); }
         void ResetAsmJsInfo()
         {
-            SetAuxPtr(AuxPointerType::AsmJsFunctionInfo, nullptr);
-            SetAuxPtr(AuxPointerType::AsmJsModuleInfo, nullptr);
+            this->SetAuxPtr<AuxPointerType::AsmJsFunctionInfo>(nullptr);
+            this->SetAuxPtr<AuxPointerType::AsmJsModuleInfo>(nullptr);
         }
         bool IsAsmJSModule() const { return m_isAsmjsMode && !m_isAsmJsFunction; }
         AsmJsModuleInfo* AllocateAsmJsModuleInfo();
 #endif
         void SetLiteralRegex(const uint index, UnifiedRegex::RegexPattern *const pattern);
-        Field(DynamicType*)* GetObjectLiteralTypes() const { return static_cast<Field(DynamicType*)*>(this->GetAuxPtr(AuxPointerType::ObjLiteralTypes)); }
-        Field(DynamicType*)* GetObjectLiteralTypesWithLock() const { return static_cast<Field(DynamicType*)*>(this->GetAuxPtrWithLock(AuxPointerType::ObjLiteralTypes)); }
+        Field(DynamicType*)* GetObjectLiteralTypes() const { return this->GetAuxPtr<AuxPointerType::ObjLiteralTypes>(); }
+        Field(DynamicType*)* GetObjectLiteralTypesWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::ObjLiteralTypes>(); }
 
-        Js::AuxArray<uint32> * GetSlotIdInCachedScopeToNestedIndexArray() const { return static_cast<Js::AuxArray<uint32> *>(this->GetAuxPtr(AuxPointerType::SlotIdInCachedScopeToNestedIndexArray)); }
-        Js::AuxArray<uint32> * GetSlotIdInCachedScopeToNestedIndexArrayWithLock() const { return static_cast<Js::AuxArray<uint32> *>(this->GetAuxPtrWithLock(AuxPointerType::SlotIdInCachedScopeToNestedIndexArray)); }
+        Js::AuxArray<uint32> * GetSlotIdInCachedScopeToNestedIndexArray() const { return this->GetAuxPtr<AuxPointerType::SlotIdInCachedScopeToNestedIndexArray>(); }
+        Js::AuxArray<uint32> * GetSlotIdInCachedScopeToNestedIndexArrayWithLock() const { return this->GetAuxPtrWithLock<AuxPointerType::SlotIdInCachedScopeToNestedIndexArray>(); }
         Js::AuxArray<uint32> * AllocateSlotIdInCachedScopeToNestedIndexArray(uint32 slotCount);
 
     private:
         void ResetLiteralRegexes();
         void ResetObjectLiteralTypes();
-        void SetObjectLiteralTypes(DynamicType** objLiteralTypes) { this->SetAuxPtr(AuxPointerType::ObjLiteralTypes, objLiteralTypes); };
-        void SetSlotIdInCachedScopeToNestedIndexArray(Js::AuxArray<uint32> * slotIdInCachedScopeToNestedIndexArray) { this->SetAuxPtr(AuxPointerType::SlotIdInCachedScopeToNestedIndexArray, slotIdInCachedScopeToNestedIndexArray); }
+        void SetObjectLiteralTypes(DynamicType** objLiteralTypes) { this->SetAuxPtr<AuxPointerType::ObjLiteralTypes>(objLiteralTypes); };
+        void SetSlotIdInCachedScopeToNestedIndexArray(Js::AuxArray<uint32> * slotIdInCachedScopeToNestedIndexArray) { this->SetAuxPtr<AuxPointerType::SlotIdInCachedScopeToNestedIndexArray>(slotIdInCachedScopeToNestedIndexArray); }
         void ResetSlotIdInCachedScopeToNestedIndexArray() { SetSlotIdInCachedScopeToNestedIndexArray(nullptr); }
     public:
 
@@ -3021,11 +3074,11 @@ namespace Js
 
         void FindClosestStatements(int32 characterOffset, StatementLocation *firstStatementLocation, StatementLocation *secondStatementLocation);
 #if ENABLE_NATIVE_CODEGEN
+        template<AuxPointerType T>
         FunctionCodeGenRuntimeData *EnsureCodeGenRuntimeDataCommon(
             Recycler *const recycler,
             __in_range(0, profiledCallSiteCount - 1) const ProfileId profiledCallSiteId,
-            FunctionBody *const inlinee,
-            AuxPointerType auxType);
+            FunctionBody *const inlinee);
 
         const FunctionCodeGenRuntimeData *GetInlineeCodeGenRuntimeData(const ProfileId profiledCallSiteId) const;
         const FunctionCodeGenRuntimeData *GetInlineeCodeGenRuntimeDataForTargetInlinee(const ProfileId profiledCallSiteId, FunctionBody *inlineeFuncBody) const;


### PR DESCRIPTION
Add a type table for function auxptr types instead of having casts everywhere.
