### PR TITLE
Fix redeferral for deserialized DeferDeserializeFunctionInfo functions

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1433,6 +1433,11 @@ namespace Js
         {
             other->SetIsJsBuiltInCode();
         }
+
+#define CopyDeferParseField(field) other->field = this->field;
+        CopyDeferParseField(deferredPrototypeType);
+        CopyDeferParseField(undeferredFunctionType);
+#undef CopyDeferParseField
     }
 
     void ParseableFunctionInfo::Copy(ParseableFunctionInfo * other)
@@ -1466,8 +1471,6 @@ namespace Js
         other->SetCachedSourceStringWeakRef(this->GetCachedSourceStringWeakRef());
         CopyDeferParseField(m_isAsmjsMode);
         CopyDeferParseField(m_isAsmJsFunction);
-        CopyDeferParseField(deferredPrototypeType);
-        CopyDeferParseField(undeferredFunctionType);
 
         other->SetFunctionObjectTypeList(this->GetFunctionObjectTypeList());
 

--- a/test/Function/bug_os17698041.js
+++ b/test/Function/bug_os17698041.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Should not crash with switches:
+// -off:deferparse -force:redeferral -collectgarbage -parserstatecache -useparserstatecache
+
+function test() { }
+
+test();
+CollectGarbage();
+test();
+
+console.log('pass'); 

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -449,4 +449,10 @@
       <compile-flags>-force:deferparse -force:redeferral</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_os17698041.js</files>
+      <compile-flags>-off:deferparse -force:redeferral -collectgarbage -parserstatecache -useparserstatecache</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When DeferDeserializeFunctionInfo transitions into a FunctionBody during Deserialize, the deferredPrototypeType and undeferredFunctionType from FunctionProxy are not copied into the FunctionBody because copying them is only done in ParseableFunctionInfo::Copy (DeferDeserializeFunctionInfo does not call this). If the FunctionBody is then redeferred, we'll fail to reset the type since it wasn't saved.

Fix is to copy these two fields in FunctionProxy::Copy which is called by DeferDeserializeFunctionInfo::Deserialize.
