### PR TITLE
Post-Op bailout with unconditional branches

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -317,7 +317,9 @@ FlowGraph::Build(void)
 
             Assert(leaveTarget->labelRefs.HasOne());
             IR::BranchInstr * brOnException = IR::BranchInstr::New(Js::OpCode::BrOnException, finallyLabel, instr->m_func);
-            leaveTarget->labelRefs.Head()->InsertBefore(brOnException);
+            IR::BranchInstr * leaveInstr = leaveTarget->labelRefs.Head();
+            brOnException->SetByteCodeOffset(leaveInstr);
+            leaveInstr->InsertBefore(brOnException);
 
             instrPrev = instr->m_prev;
         }

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -1372,24 +1372,10 @@ GlobOpt::MayNeedBailOnImplicitCall(IR::Instr const * instr, Value const * src1Va
 void
 GlobOpt::GenerateBailAfterOperation(IR::Instr * *const pInstr, IR::BailOutKind kind)
 {
-    Assert(pInstr);
+    Assert(pInstr && *pInstr);
 
     IR::Instr* instr = *pInstr;
-    Assert(instr);
-
-    IR::Instr * nextInstr = instr->GetNextRealInstrOrLabel();
-    uint32 currentOffset = instr->GetByteCodeOffset();
-    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
-        nextInstr->GetByteCodeOffset() == currentOffset)
-    {
-        nextInstr = nextInstr->GetNextRealInstrOrLabel();
-    }
-    // This can happen due to break block removal
-    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
-        nextInstr->GetByteCodeOffset() < currentOffset)
-    {
-        nextInstr = nextInstr->GetNextRealInstrOrLabel();
-    }
+    IR::Instr * nextInstr = instr->GetNextByteCodeInstr();
     IR::Instr * bailOutInstr = instr->ConvertToBailOutInstr(nextInstr, kind);
     if (this->currentBlock->GetLastInstr() == instr)
     {

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2704,6 +2704,35 @@ Instr::GetNextBranchOrLabel() const
     return instr;
 }
 
+IR::Instr *
+Instr::GetNextByteCodeInstr() const
+{
+    IR::Instr * nextInstr = GetNextRealInstrOrLabel();
+    uint32 currentOffset = GetByteCodeOffset();
+    const auto getNext = [](IR::Instr* nextInstr) -> IR::Instr*
+    {
+        if (nextInstr->IsBranchInstr())
+        {
+            IR::BranchInstr* branchInstr = nextInstr->AsBranchInstr();
+            AssertMsg(branchInstr->IsUnconditional(), "We can't know which branch to take on a conditionnal branch");
+            return branchInstr->GetTarget();
+        }
+        return nextInstr->GetNextRealInstrOrLabel();
+    };
+    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
+        nextInstr->GetByteCodeOffset() == currentOffset)
+    {
+        nextInstr = getNext(nextInstr);
+    }
+    // This can happen due to break block removal
+    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
+        nextInstr->GetByteCodeOffset() < currentOffset)
+    {
+        nextInstr = getNext(nextInstr);
+    }
+    return nextInstr;
+}
+
 ///----------------------------------------------------------------------------
 ///
 /// Instr::GetPrevRealInstr

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2715,7 +2715,10 @@ Instr::GetNextByteCodeInstr() const
         {
             IR::BranchInstr* branchInstr = nextInstr->AsBranchInstr();
             AssertMsg(branchInstr->IsUnconditional(), "We can't know which branch to take on a conditionnal branch");
-            return branchInstr->GetTarget();
+            if (branchInstr->IsUnconditional())
+            {
+                return branchInstr->GetTarget();
+            }
         }
         return nextInstr->GetNextRealInstrOrLabel();
     };

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -288,6 +288,7 @@ public:
     IR::Instr *     GetNextRealInstr() const;
     IR::Instr *     GetNextRealInstrOrLabel() const;
     IR::Instr *     GetNextBranchOrLabel() const;
+    IR::Instr *     GetNextByteCodeInstr() const;
     IR::Instr *     GetPrevRealInstr() const;
     IR::Instr *     GetPrevRealInstrOrLabel() const;
     IR::LabelInstr *GetPrevLabelInstr() const;

--- a/test/bailout/bug17449647.js
+++ b/test/bailout/bug17449647.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var strvar1 = "";
+function foo() {
+  switch (strvar1) {
+  case 1:
+    this();
+  case "":
+  }
+}
+for (let i = 0; i < 1000; ++i) {
+  foo();
+}
+console.log("pass");

--- a/test/bailout/rlexe.xml
+++ b/test/bailout/rlexe.xml
@@ -269,4 +269,9 @@
       <files>bug13674598.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug17449647.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When searching for new bytecode instr for a post-op bailout, follow unconditional branches.

OS#17449647

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5250)
<!-- Reviewable:end -->
