### PR TITLE
Fixing obj-ptr copy-prop in prepass. OS 17555305

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -565,6 +565,7 @@ private:
     bool                    IsPrepassSrcValueInfoPrecise(IR::Opnd *const src, Value *const srcValue, bool * canTransferValueNumberToDst = nullptr) const;
     bool                    IsPrepassSrcValueInfoPrecise(IR::Instr *const instr, Value *const src1Value, Value *const src2Value, bool * canTransferValueNumberToDst = nullptr) const;
     bool                    IsSafeToTransferInPrepass(StackSym * const sym, ValueInfo *const srcValueInfo) const;
+    bool                    SafeToCopyPropInPrepass(StackSym * const originalSym, StackSym * const copySym, Value *const value) const;
     Value *                 CreateDstUntransferredIntValue(const int32 min, const int32 max, IR::Instr *const instr, Value *const src1Value, Value *const src2Value);
     Value *                 CreateDstUntransferredValue(const ValueType desiredValueType, IR::Instr *const instr, Value *const src1Value, Value *const src2Value);
     Value *                 ValueNumberTransferDst(IR::Instr *const instr, Value *src1Val);

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1710,8 +1710,7 @@ GlobOpt::CopyPropPropertySymObj(IR::SymOpnd *symOpnd, IR::Instr *instr)
             PropertySym *newProp = PropertySym::FindOrCreate(
                 copySym->m_id, propertySym->m_propertyId, propertySym->GetPropertyIdIndex(), propertySym->GetInlineCacheIndex(), propertySym->m_fieldKind, this->func);
 
-            if (!this->IsLoopPrePass() || 
-                 (IsSafeToTransferInPrepass(objSym, val->GetValueInfo()) && IsSafeToTransferInPrepass(copySym, val->GetValueInfo())))
+            if (!this->IsLoopPrePass() || SafeToCopyPropInPrepass(objSym, copySym, val))
             {
 #if DBG_DUMP
                 if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::GlobOptPhase, this->func->GetSourceContextId(), this->func->GetLocalFunctionId()))

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1490,6 +1490,12 @@
   </test>
   <test>
     <default>
+      <files>test151.js</files>
+      <compile-flags>-off:usefixeddataprops -off:objtypespec</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>IsIn_ArrayNoMissingValues.js</files>
       <baseline>IsIn_ArrayNoMissingValues.baseline</baseline>
       <compile-flags>-testtrace:BoundCheckElimination</compile-flags>

--- a/test/Optimizer/test151.js
+++ b/test/Optimizer/test151.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo(n, a, o, i) {
+    
+    var g;
+    var k = n || i.tmpl;
+    for(var j = 0; j<a.length; j++)
+    {
+        g = o[j];
+        k.tmpls && g.tmpls;
+        k.tmpls[0];
+        n = g.props.tmpl;
+    }
+
+}
+
+n = {tmpls: [1,2,3,4,5]};
+a = [1,2];
+o = {};
+
+o[0] = {props: {tmpl: 10}, tmpls: [1,2,3,4,5]};
+o[1] = {props: {tmpl: 20}, tmpls: [1,2,3,4,5]};
+
+foo(n, a, o);
+foo(n, a, o);
+foo(n, a, o);
+print("passed");


### PR DESCRIPTION
For copy-propping in prepass, it is not sufficient that the two syms are safe to tranfer values.  For instance, the copy sym may not be live on back-edge but, may become live on back edge after the copy-prop. 

In addition to the safe-to-transfer checks, the copy-sym shouldn't be written to if the original sym is live on back edge. If, however, the original sym is not live on back edge, then we can do the copy prop, provided both symbols satisfied the safe-to-transfer checks.

Example:
    
    s1 = s2
    $Loop:
        s3 = s1  <-- can't copy-prop s2 here even though both s1 and s2 are safe to transfer
        s2 = s4
        Br $Loop
