### PR TITLE
Use large count in the boundFunction call

### DIFF
--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -177,12 +177,13 @@ namespace Js
             // OACR thinks that this can change between here and the check in the for loop below
             const unsigned int argCount = args.Info.Count;
 
-            if ((boundFunction->count + args.GetArgCountWithExtraArgs()) > CallInfo::kMaxCountArgs)
+            uint32 newArgCount = UInt32Math::Add(boundFunction->count, args.GetLargeArgCountWithExtraArgs());
+            if (newArgCount > CallInfo::kMaxCountArgs)
             {
                 JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgListTooLarge);
             }
 
-            Field(Var) *newValues = RecyclerNewArray(scriptContext->GetRecycler(), Field(Var), boundFunction->count + args.GetArgCountWithExtraArgs());
+            Field(Var) *newValues = RecyclerNewArray(scriptContext->GetRecycler(), Field(Var), newArgCount);
 
             uint index = 0;
 
@@ -218,7 +219,7 @@ namespace Js
             actualArgs = Arguments(args.Info, unsafe_write_barrier_cast<Var*>(newValues));
             actualArgs.Info.Count = boundFunction->count + argCount;
 
-            Assert(index == actualArgs.GetArgCountWithExtraArgs());
+            Assert(index == actualArgs.GetLargeArgCountWithExtraArgs());
         }
         else
         {

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -130,6 +130,12 @@ var tests = [
         function foo() {}
         Reflect.construct(foo, new Array(2**16-2));
       } catch(e) { }
+
+      try {
+        function foo() {}
+        var bar = foo.bind({}, 1);
+        new bar(...(new Array(2**16+1)))
+      } catch(e) { }
     }
   }
   


### PR DESCRIPTION
We can get large count in the boundfunction new instance. We should be using the large count variant API to get the count (OS#17406027)
