### PR TITLE
OS#16649604: Do not type specialize integer computed properties in getters/setters 

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -10972,9 +10972,15 @@ GlobOpt::ToTypeSpecIndex(IR::Instr * instr, IR::RegOpnd * indexOpnd, IR::IndirOp
 {
     Assert(indirOpnd != nullptr || indexOpnd == instr->GetSrc1());
 
+    bool isGetterOrSetter = instr->m_opcode == Js::OpCode::InitGetElemI ||
+        instr->m_opcode == Js::OpCode::InitSetElemI ||
+        instr->m_opcode == Js::OpCode::InitClassMemberGetComputedName ||
+        instr->m_opcode == Js::OpCode::InitClassMemberSetComputedName;
+
     if ((indexOpnd->GetValueType().IsInt()
         ? !IsTypeSpecPhaseOff(func)
-        : indexOpnd->GetValueType().IsLikelyInt() && DoAggressiveIntTypeSpec()) && !GetIsAsmJSFunc()) // typespec is disabled for asmjs
+        : indexOpnd->GetValueType().IsLikelyInt() && DoAggressiveIntTypeSpec() && !isGetterOrSetter) // typespec is disabled for getters, setters
+        && !GetIsAsmJSFunc()) // typespec is disabled for asmjs
     {
         StackSym *const indexVarSym = indexOpnd->m_sym;
         Value *const indexValue = CurrentBlockData()->FindValue(indexVarSym);

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -9011,8 +9011,6 @@ Lowerer::LowerStElemI(IR::Instr * instr, Js::PropertyOperationFlags flags, bool 
     instr->UnlinkDst();
     instr->UnlinkSrc1();
 
-    IR::Opnd *indexOpnd = dst->AsIndirOpnd()->UnlinkIndexOpnd();
-
     Assert(
         helperMethod == IR::HelperOP_InitElemGetter ||
         helperMethod == IR::HelperOP_InitElemSetter ||
@@ -9023,8 +9021,19 @@ Lowerer::LowerStElemI(IR::Instr * instr, Js::PropertyOperationFlags flags, bool 
         helperMethod == IR::HelperOp_InitClassMemberSetComputedName
         );
 
+    IR::IndirOpnd* dstIndirOpnd = dst->AsIndirOpnd();
+
+    IR::Opnd *indexOpnd = dstIndirOpnd->UnlinkIndexOpnd();
+
     if (indexOpnd && indexOpnd->GetType() != TyVar)
     {
+        Assert(
+            helperMethod != IR::HelperOP_InitElemGetter &&
+            helperMethod != IR::HelperOP_InitElemSetter &&
+            helperMethod != IR::HelperOp_InitClassMemberGetComputedName &&
+            helperMethod != IR::HelperOp_InitClassMemberSetComputedName
+        );
+
         if (indexOpnd->GetType() == TyInt32)
         {
             helperMethod =

--- a/test/es6/bug_OS16649604.js
+++ b/test/es6/bug_OS16649604.js
@@ -1,0 +1,49 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Computed get-set property names",
+        body: function () {
+            const n = 1;
+            const m = 2;
+            const r = 0.5;
+            const s = 'prop';
+            function test2() {
+                c = class {
+                    get [n]() { return 42; }
+                    set [m](val) { }
+                    get [r]() { return 'a'; }
+                    set [s](val) { }
+                }
+
+                d = {
+                    get [n]() { return 42; },
+                    set [m](val) {},
+                    get [r]() { return 'a'; },
+                    set [s](val) {}
+                };
+            }
+            for (let i = 0; i < 100; ++i) {
+                test2();
+            }
+
+            assert.areEqual('number', typeof ((new c())[1]), "Integer as class member getter property name");
+            assert.areEqual('undefined', typeof ((new c())[2]), "Integer as class member setter property name");
+            assert.areEqual('string', typeof ((new c())[0.5]), "Float as class member getter property name");
+            assert.areEqual('undefined', typeof ((new c())['prop']), "String as class member setter property name");
+
+            assert.areEqual('number', typeof (d[1]), "Integer as getter property name");
+            assert.areEqual('undefined', typeof (d[2]), "Integer as setter property name");
+            assert.areEqual('string', typeof (d[0.5]), "Float as getter property name");
+            assert.areEqual('undefined', typeof (d['prop']), "String as setter property name");
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });
+    

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1480,4 +1480,10 @@
     <baseline>supersetter.baseline</baseline>
   </default>
 </test>
+<test>
+  <default>
+    <files>bug_OS16649604.js</files>
+    <compile-flags>-args summary -endargs</compile-flags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
GlobOpt::ToTypeSpecIndex() generates the wrong code for a getter (or setter) like:
```
const n = 1;
function test2() {
  d = {
    get [n]() { return 42; },
  };
}
```
where y can be type specialized to an integer:

```
s18(s6).i32 =  FromVar s6[LikelyCanBeTaggedValue_Int].var!
[s5[UninitializedObject].var+s18(s6).i32!].var = InitGetElemI  s7.var!
```

while, for non-integer computed properties:

```
[s5[UninitializedObject].var+s6[LikelyCanBeTaggedValue_String].var!].var = InitGetElemI  s7.var!
```

where s5: object, s6: computed property, s7: getter function.

Then, in Lowerer::LowerStElemI(), if the helper method is a getter or a setter, the generated code calls Op_SetElementI_Int32() and as result:

```
var v = d[1];
```
typeof(v) is 'function' and not 'number'.

To fix this there are two possibilities:
1. In GlobOpt::ToTypeSpecIndex() we can skip type spec for the index operand if the instruction is a getter or setter.
2. In Lowerer::LowerStElemI() we should replace the integer index with its equivalent var symbol. 

This PR implements the first fix.