### PR TITLE
When deserializing the parser state cache, verify the script code matches the script used to create the cache

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -997,34 +997,6 @@ void Encoder::EnsureRelocEntryIntegrity(size_t newBufferStartAddress, size_t cod
     }
 }
 
-uint Encoder::CalculateCRC(uint bufferCRC, size_t data)
-{
-#if defined(_WIN32) || defined(__SSE4_2__)
-#if defined(_M_IX86)
-    if (AutoSystemInfo::Data.SSE4_2Available())
-    {
-        return _mm_crc32_u32(bufferCRC, data);
-    }
-#elif defined(_M_X64)
-    if (AutoSystemInfo::Data.SSE4_2Available())
-    {
-        //CRC32 always returns a 32-bit result
-        return (uint)_mm_crc32_u64(bufferCRC, data);
-    }
-#endif
-#endif
-    return CalculateCRC32(bufferCRC, data);
-}
-
-uint Encoder::CalculateCRC(uint bufferCRC, size_t count, _In_reads_bytes_(count) void * buffer)
-{
-    for (uint index = 0; index < count; index++)
-    {
-        bufferCRC = CalculateCRC(bufferCRC, *((BYTE*)buffer + index));
-    }
-    return bufferCRC;
-}
-
 void Encoder::ValidateCRC(uint bufferCRC, uint initialCRCSeed, _In_reads_bytes_(count) void* buffer, size_t count)
 {
     uint validationCRC = initialCRCSeed;

--- a/lib/Backend/Encoder.h
+++ b/lib/Backend/Encoder.h
@@ -63,8 +63,6 @@ private:
     void            TryCopyAndAddRelocRecordsForSwitchJumpTableEntries(BYTE *codeStart, size_t codeSize, JmpTableList * jumpTableListForSwitchStatement, size_t totalJmpTableSizeInBytes);
 
     void            ValidateCRC(uint bufferCRC, uint initialCRCSeed, _In_reads_bytes_(count) void* buffer, size_t count);
-    static uint     CalculateCRC(uint bufferCRC, size_t count, _In_reads_bytes_(count) void * buffer);
-    static uint     CalculateCRC(uint bufferCRC, size_t data);
     static void     EnsureRelocEntryIntegrity(size_t newBufferStartAddress, size_t codeSize, size_t oldBufferAddress, size_t relocAddress, uint offsetBytes, ptrdiff_t opndData, bool isRelativeAddr = true);
 #if defined(_M_IX86) || defined(_M_X64)
     void            ValidateCRCOnFinalBuffer(_In_reads_bytes_(finalCodeSize) BYTE * finalCodeBufferStart, size_t finalCodeSize, size_t jumpTableSize, _In_reads_bytes_(finalCodeSize) BYTE * oldCodeBufferStart, uint initialCrcSeed, uint bufferCrcToValidate, BOOL isSuccessBrShortAndLoopAlign);

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 #include "Backend.h"
+#include "Core/CRC.h"
 
 #include "X64Encode.h"
 
@@ -1637,7 +1638,7 @@ EncoderMD::ApplyRelocs(size_t codeBufferAddress_, size_t codeSize, uint * buffer
                     }
                 }
 
-                *bufferCRC = Encoder::CalculateCRC(*bufferCRC, pcrel);
+                *bufferCRC = CalculateCRC(*bufferCRC, pcrel);
 
                 break;
             }
@@ -1658,7 +1659,7 @@ EncoderMD::ApplyRelocs(size_t codeBufferAddress_, size_t codeSize, uint * buffer
                 {
                     Encoder::EnsureRelocEntryIntegrity(codeBufferAddress_, codeSize, (size_t)m_encoder->m_encodeBuffer, (size_t)relocAddress, sizeof(size_t), targetAddress, false);
                 }
-                *bufferCRC = Encoder::CalculateCRC(*bufferCRC, offset);
+                *bufferCRC = CalculateCRC(*bufferCRC, offset);
                 break;
             }
         case RelocTypeLabel:

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 #include "Backend.h"
+#include "Core/CRC.h"
 
 #include "X86Encode.h"
 
@@ -1431,7 +1432,7 @@ EncoderMD::ApplyRelocs(uint32 codeBufferAddress, size_t codeSize, uint * bufferC
                     Assert(*(uint32 *)relocAddress == 0);
                     *(uint32 *)relocAddress = offset;
                 }
-                *bufferCRC = Encoder::CalculateCRC(*bufferCRC, offset);
+                *bufferCRC = CalculateCRC(*bufferCRC, offset);
                 break;
             }
         case RelocTypeBranch:
@@ -1466,7 +1467,7 @@ EncoderMD::ApplyRelocs(uint32 codeBufferAddress, size_t codeSize, uint * bufferC
                         Encoder::EnsureRelocEntryIntegrity(codeBufferAddress, codeSize, (size_t)m_encoder->m_encodeBuffer, (size_t)relocAddress, sizeof(uint32), (ptrdiff_t)labelInstr->GetPC() - ((ptrdiff_t)reloc->m_ptr + 4));
                     }
                 }
-                *bufferCRC = Encoder::CalculateCRC(*bufferCRC, pcrel);
+                *bufferCRC = CalculateCRC(*bufferCRC, pcrel);
                 break;
             }
         case RelocTypeLabelUse:
@@ -1484,7 +1485,7 @@ EncoderMD::ApplyRelocs(uint32 codeBufferAddress, size_t codeSize, uint * bufferC
                 {
                     Encoder::EnsureRelocEntryIntegrity(codeBufferAddress, codeSize, (size_t)m_encoder->m_encodeBuffer, (size_t)relocAddress, sizeof(size_t), targetAddress, false);
                 }
-                *bufferCRC = Encoder::CalculateCRC(*bufferCRC, offset);
+                *bufferCRC = CalculateCRC(*bufferCRC, offset);
                 break;
             }
         case RelocTypeLabel:

--- a/lib/Common/Core/CRC.cpp
+++ b/lib/Common/Core/CRC.cpp
@@ -25,3 +25,31 @@ unsigned int CalculateCRC32(const char* in)
     }
     return crc ^ (unsigned int)-1;
 }
+
+uint CalculateCRC(uint bufferCRC, size_t data)
+{
+#if defined(_WIN32) || defined(__SSE4_2__)
+#if defined(_M_IX86)
+    if (AutoSystemInfo::Data.SSE4_2Available())
+    {
+        return _mm_crc32_u32(bufferCRC, data);
+    }
+#elif defined(_M_X64)
+    if (AutoSystemInfo::Data.SSE4_2Available())
+    {
+        //CRC32 always returns a 32-bit result
+        return (uint)_mm_crc32_u64(bufferCRC, data);
+    }
+#endif
+#endif
+    return CalculateCRC32(bufferCRC, data);
+}
+
+uint CalculateCRC(uint bufferCRC, size_t count, _In_reads_bytes_(count) void * buffer)
+{
+    for (uint index = 0; index < count; index++)
+    {
+        bufferCRC = CalculateCRC(bufferCRC, *((BYTE*)buffer + index));
+    }
+    return bufferCRC;
+}

--- a/lib/Common/Core/CRC.h
+++ b/lib/Common/Core/CRC.h
@@ -51,3 +51,7 @@ static const unsigned int crc_32_tab[] =
 unsigned int CalculateCRC32(unsigned int bufferCRC, size_t data);
 
 unsigned int CalculateCRC32(const char* in);
+
+uint CalculateCRC(uint bufferCRC, size_t data);
+
+uint CalculateCRC(uint bufferCRC, size_t count, _In_reads_bytes_(count) void * buffer);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1291,6 +1291,7 @@ private:
 
         HRESULT TryDeserializeParserState(
             _In_ ULONG grfscr,
+            _In_ uint sourceCRC,
             _In_ charcount_t cchLength,
             _In_ SRCINFO *srcInfo,
             _In_ Js::Utf8SourceInfo* utf8SourceInfo,
@@ -1303,6 +1304,7 @@ private:
             _In_ Js::SimpleDataCacheWrapper* pDataCache);
 
         HRESULT TrySerializeParserState(
+            _In_ uint sourceCRC,
             _In_ LPCUTF8 pszSrc,
             _In_ size_t cbLength,
             _In_ SRCINFO *srcInfo,


### PR DESCRIPTION
Calculate a checksum of the script code and store it in the stream along with the parser state cache. When we try and use this parser state cache later, make sure the script we are given back matches the script we used to create the cache. If it doesn't for some reason, discard the parser state cache as it may not match the script code exactly.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/17542547
https://microsoft.visualstudio.com/OS/_workitems/edit/17713429
