### PR TITLE
OS#17417473 - SCCLiveness::ProcessStackSymUse lifetime nullptr deref

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -14242,7 +14242,7 @@ GlobOpt::OptIsInvariant(Sym *sym, BasicBlock *block, Loop *loop, Value *srcVal, 
     }
     else if (sym->IsPropertySym())
     {
-        if (!loop->landingPad->globOptData.liveFields->Test(sym->m_id))
+        if (!loop->landingPad->globOptData.liveFields->Test(sym->AsPropertySym()->m_stackSym->m_id))
         {
             return false;
         }

--- a/test/Bugs/bug_OS17417473.js
+++ b/test/Bugs/bug_OS17417473.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "OS17417473: hoisting a constant propertySymbol should not trigger assertion",
+        body: function () {
+            function opt() {
+                let _1337;
+                s = "";
+                s = "" & s.hasOwnProperty("");
+                var s = 0x1337;
+                for (i =0; i < 1; i++) {
+                    _1337 = s.hasOwnProperty("x");
+                }
+            }
+            
+            // trigger the full jit
+            for (let i = 0; i < 100; i++) {
+                opt();
+            }
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -472,4 +472,10 @@
       <files>symcmpbug.js</files>
     </default>
   </test>
+  <test> 
+    <default> 
+      <files>bug_OS17417473.js</files> 
+      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
+    </default> 
+  </test> 
 </regress-exe>


### PR DESCRIPTION
Modify GlobOpt::OptIsInvariant() to make sure a const symbol is not hoisted if not alive in landingPad.