### PR TITLE
Mark ExtendArg parameters as live on back edge in JIT loops

### DIFF
--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -231,6 +231,13 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
             regArg->Free(this->m_func);
             instrArg->Remove();
         }
+        else if (instrArg->m_opcode == Js::OpCode::ExtendArg_A)
+        {
+            if (instrArg->GetSrc1()->IsRegOpnd())
+            {
+                m_lowerer->addToLiveOnBackEdgeSyms->Set(instrArg->GetSrc1()->AsRegOpnd()->GetStackSym()->m_id);
+            }
+        }
     }
 
     switch (helperMethod)

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -227,6 +227,13 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
             regArg->Free(this->m_func);
             instrArg->Remove();
         }
+        else if (instrArg->m_opcode == Js::OpCode::ExtendArg_A)
+        {
+            if (instrArg->GetSrc1()->IsRegOpnd())
+            {
+                m_lowerer->addToLiveOnBackEdgeSyms->Set(instrArg->GetSrc1()->AsRegOpnd()->GetStackSym()->m_id);
+            }
+        }
     }
 
     switch (helperMethod)

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -241,6 +241,13 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
             regArg->Free(this->m_func);
             instrArg->Remove();
         }
+        else if (instrArg->m_opcode == Js::OpCode::ExtendArg_A)
+        {
+            if (instrArg->GetSrc1()->IsRegOpnd())
+            {
+                m_lowerer->addToLiveOnBackEdgeSyms->Set(instrArg->GetSrc1()->AsRegOpnd()->GetStackSym()->m_id);
+            }
+        }
     }
 
     switch (helperMethod)

--- a/test/Bugs/HomeObjInLoop.js
+++ b/test/Bugs/HomeObjInLoop.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0(){
+  var arrObj0 = {};
+  arrObj0[0] = 1;
+
+  function v0(o)
+  {
+    for (var v1 = 0 ; v1 < 8 ; v1++)
+    {
+      class class7 {
+        func56 (){
+        }
+      }
+      o[v1] = v1;
+    }
+  }
+  
+  v0(arrObj0);
+
+  
+};
+
+test0();
+test0();
+test0();
+print("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -477,5 +477,11 @@
       <files>bug_OS17417473.js</files> 
       <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
     </default> 
+  </test>
+  <test> 
+    <default> 
+      <files>HomeObjInLoop.js</files> 
+      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags> 
+    </default> 
   </test> 
 </regress-exe>


### PR DESCRIPTION
For HomeObj opcodes the helper call is done using ExtendArgs. When the ExtendArgs are hoisted outside the loop marking them as live on back edge to avoid being reused.
