### PR TITLE
Don't reset hasBailedOutBitPtr, instead use ctor/dtor

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1044,10 +1044,12 @@ BailOutRecord::BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, Bail
     Js::ScriptFunction * innerMostInlinee = nullptr;
     BailOutInlinedHelper(layout, currentBailOutRecord, bailOutOffset, returnAddress, bailOutKind, registerSaves, &bailOutReturnValue, &innerMostInlinee, false, branchValue);
 
-    bool * hasBailOutBit = layout->functionObject->GetScriptContext()->GetThreadContext()->GetHasBailedOutBitPtr();
-    if (hasBailOutBit != nullptr && bailOutRecord->ehBailoutData)
+    bool * hasBailedOutBitPtr = layout->functionObject->GetScriptContext()->GetThreadContext()->GetHasBailedOutBitPtr();
+    Assert(!bailOutRecord->ehBailoutData || hasBailedOutBitPtr ||
+        bailOutRecord->ehBailoutData->ht == Js::HandlerType::HT_Finally /* When we bailout from inlinee in non exception finally, we maynot see hasBailedOutBitPtr*/);
+    if (hasBailedOutBitPtr && bailOutRecord->ehBailoutData)
     {
-        *hasBailOutBit = true;
+        *hasBailedOutBitPtr = true;
     }
     Js::Var result = BailOutCommonNoCodeGen(layout, currentBailOutRecord, currentBailOutRecord->bailOutOffset, returnAddress, bailOutKind, branchValue,
         registerSaves, &bailOutReturnValue);
@@ -1087,11 +1089,14 @@ BailOutRecord::BailOutFromLoopBodyInlinedCommon(Js::JavascriptCallStackLayout * 
     BailOutReturnValue bailOutReturnValue;
     Js::ScriptFunction * innerMostInlinee = nullptr;
     BailOutInlinedHelper(layout, currentBailOutRecord, bailOutOffset, returnAddress, bailOutKind, registerSaves, &bailOutReturnValue, &innerMostInlinee, true, branchValue);
-    bool * hasBailOutBit = layout->functionObject->GetScriptContext()->GetThreadContext()->GetHasBailedOutBitPtr();
-    if (hasBailOutBit != nullptr && bailOutRecord->ehBailoutData)
+    bool * hasBailedOutBitPtr = layout->functionObject->GetScriptContext()->GetThreadContext()->GetHasBailedOutBitPtr();
+    Assert(!bailOutRecord->ehBailoutData || hasBailedOutBitPtr ||
+        bailOutRecord->ehBailoutData->ht == Js::HandlerType::HT_Finally /* When we bailout from inlinee in non exception finally, we maynot see hasBailedOutBitPtr*/);
+    if (hasBailedOutBitPtr && bailOutRecord->ehBailoutData)
     {
-        *hasBailOutBit = true;
+        *hasBailedOutBitPtr = true;
     }
+
     uint32 result = BailOutFromLoopBodyHelper(layout, currentBailOutRecord, currentBailOutRecord->bailOutOffset,
         bailOutKind, nullptr, registerSaves, &bailOutReturnValue);
     ScheduleLoopBodyCodeGen(Js::ScriptFunction::FromVar(layout->functionObject), innerMostInlinee, currentBailOutRecord, bailOutKind);

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -72,6 +72,18 @@ namespace Js
         m_threadContext->SetTryCatchFrameAddr(m_prevTryCatchFrameAddr);
     }
 
+    JavascriptExceptionOperators::HasBailedOutPtrStack::HasBailedOutPtrStack(ScriptContext* scriptContext, bool *hasBailedOutPtr)
+    {
+        m_threadContext = scriptContext->GetThreadContext();
+        m_prevHasBailedOutPtr = m_threadContext->GetHasBailedOutBitPtr();
+        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(hasBailedOutPtr);
+    }
+
+    JavascriptExceptionOperators::HasBailedOutPtrStack::~HasBailedOutPtrStack()
+    {
+        m_threadContext->SetHasBailedOutBitPtr(m_prevHasBailedOutPtr);
+    }
+
     JavascriptExceptionOperators::PendingFinallyExceptionStack::PendingFinallyExceptionStack(ScriptContext* scriptContext, Js::JavascriptExceptionObject *exceptionObj)
     {
         m_threadContext = scriptContext->GetThreadContext();
@@ -105,7 +117,8 @@ namespace Js
         void *continuation = nullptr;
         JavascriptExceptionObject *exception = nullptr;
         void *tryCatchFrameAddr = nullptr;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)frame + hasBailedOutOffset));
+
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)frame + hasBailedOutOffset));
 
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + spillSize + argsSize);
         {
@@ -148,7 +161,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }  
 
@@ -156,7 +168,6 @@ namespace Js
             AssertMsg(exceptionObject, "Caught object is null.");
             continuation = amd64_CallWithFakeFrame(catchAddr, frame, spillSize, argsSize, exceptionObject);
         }
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return continuation;
     }
 
@@ -170,8 +181,8 @@ namespace Js
     {
         void                      *tryContinuation     = nullptr;
         JavascriptExceptionObject *exception           = nullptr;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)frame + hasBailedOutOffset));
 
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)frame + hasBailedOutOffset));
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + spillSize + argsSize);
 
         try
@@ -213,7 +224,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }
 
@@ -224,7 +234,6 @@ namespace Js
             }
         }
 
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return tryContinuation;
     }
 
@@ -278,7 +287,7 @@ namespace Js
         void *continuation = nullptr;
         JavascriptExceptionObject *exception = nullptr;
         void * tryCatchFrameAddr = nullptr;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)localsPtr + hasBailedOutOffset));
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)framePtr + hasBailedOutOffset));
 
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + argsSize);
         {
@@ -324,7 +333,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }
 
@@ -337,7 +345,6 @@ namespace Js
 #endif
         }
 
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return continuation;
     }
 
@@ -352,7 +359,7 @@ namespace Js
     {
         void                      *tryContinuation     = nullptr;
         JavascriptExceptionObject *exception           = nullptr;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)localsPtr + hasBailedOutOffset));
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)framePtr + hasBailedOutOffset));
 
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout + argsSize);
         try
@@ -394,7 +401,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(exception, scriptContext);
             }
 
@@ -409,7 +415,6 @@ namespace Js
             }
         }
 
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return tryContinuation;
     }
 
@@ -473,7 +478,8 @@ namespace Js
         void* continuationAddr = NULL;
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
         void *tryCatchFrameAddr = nullptr;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)framePtr + hasBailedOutOffset));
+
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)framePtr + hasBailedOutOffset));
 
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout);
         {
@@ -571,7 +577,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(pExceptionObject, scriptContext);
             }
 
@@ -628,7 +633,6 @@ namespace Js
 #endif
         }
 
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return continuationAddr;
     }
 
@@ -636,7 +640,8 @@ namespace Js
     {
         Js::JavascriptExceptionObject* pExceptionObject = NULL;
         void* continuationAddr = NULL;
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr((bool*)((char*)framePtr + hasBailedOutOffset));
+
+        Js::JavascriptExceptionOperators::HasBailedOutPtrStack hasBailedOutPtrStack(scriptContext, (bool*)((char*)framePtr + hasBailedOutOffset));
         PROBE_STACK(scriptContext, Constants::MinStackJitEHBailout);
 
         try
@@ -731,7 +736,6 @@ namespace Js
                 // If we have bailed out, this exception is coming from the interpreter. It should not have been caught;
                 // it so happens that this catch was on the stack and caught the exception.
                 // Re-throw!
-                scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
                 JavascriptExceptionOperators::DoThrow(pExceptionObject, scriptContext);
             }
 
@@ -799,7 +803,6 @@ namespace Js
             }
         }
 
-        scriptContext->GetThreadContext()->SetHasBailedOutBitPtr(nullptr);
         return continuationAddr;
     }
 

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -54,6 +54,17 @@ namespace Js
             ~TryCatchFrameAddrStack();
         };
 
+        class HasBailedOutPtrStack
+        {
+        private:
+            bool * m_prevHasBailedOutPtr;
+            ThreadContext* m_threadContext;
+
+        public:
+            HasBailedOutPtrStack(ScriptContext* scriptContext, bool *hasBailedOutPtr);
+            ~HasBailedOutPtrStack();
+        };
+
         class PendingFinallyExceptionStack
         {
         private:

--- a/test/EH/hasBailedOutBug2.js
+++ b/test/EH/hasBailedOutBug2.js
@@ -1,0 +1,86 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  function func80() {
+  }
+  var uniqobj22 = new func80();
+  try {
+    (function () {
+      try {
+        try {
+        } catch (ex) {
+        }
+        function func104() {
+          uniqobj22 >>>= 1;
+        }
+        func104();
+      } catch (ex) {
+        WScript.Echo("FAILED");
+      } finally {
+        protoObj0();
+      }
+    }());
+  } catch (ex) {
+  }
+}
+test0();
+test0();
+
+function test1() {
+  var obj1 = {};
+  var func2 = function () {
+    try {
+    } catch (ex) {
+    }
+  };
+  obj1.method1 = func2;
+  var IntArr0 = new Array();
+  function v0() {
+    function v2() {
+      try {
+        obj1.method1();
+        function func7() {
+          IntArr0[1];
+        }
+        func7();
+      } catch (ex) {
+        WScript.Echo("FAILED");
+      }
+      var v3 = runtime_error;
+    }
+    try {
+      v2();
+    } catch (ex) {
+    }
+  }
+  v0();
+}
+test1();
+test1();
+test1();
+
+function test2() {
+  function makeArrayLength(x) {
+    if (x < 1) {
+    }
+  }
+  var func2 = function () {
+    try {
+    } finally {
+      makeArrayLength(393266900 * 1957286472);
+    }
+  };
+  func2();
+  try {
+    func2();
+  } finally {
+  }
+}
+test2();
+test2();
+test2();
+
+WScript.Echo("Passed");

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -185,6 +185,12 @@
   </test>
   <test>
     <default>
+       <files>hasBailedOutBug2.js</files>
+       <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
+  <test>
+    <default>
        <files>StackOverflow.js</files>
     </default>
   </test>


### PR DESCRIPTION
We can loose hasBailedOut information due to the reset in nested try catches and this can result in incorrectly executing catch blocks that happen to be on the callstack
try {
// Set hasbailoutptr
try {} catch{} // reset hasbailoutbitptr
// inlinee code
// bailout
// exception
} catch(){ // hasbailedout info lost}

Fixes OS#17791189
