### PR TITLE
Implement -module flag in ch for running a script as a module

### DIFF
--- a/bin/ch/HostConfigFlagsList.h
+++ b/bin/ch/HostConfigFlagsList.h
@@ -17,6 +17,7 @@ FLAG(bool, IgnoreScriptErrorCode,           "Don't return error code on script e
 FLAG(bool, MuteHostErrorMsg,                "Mute host error output, e.g. module load failures", false)
 FLAG(bool, TraceHostCallback,               "Output traces for host callbacks", false)
 FLAG(bool, Test262,                         "load Test262 harness", false)
+FLAG(bool, Module,                          "load the script as a module", false)
 FLAG(bool, TrackRejectedPromises,           "Enable tracking of unhandled promise rejections", false)
 FLAG(BSTR, CustomConfigFile,                "Custom config file to be used to pass in additional flags to Chakra", NULL)
 FLAG(bool, ExecuteWithBgParse,              "[No-op] Load script with bgparse (note: requires bgparse to be on as well)", false)

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -435,6 +435,11 @@ void WScriptJsrt::GetDir(LPCSTR fullPathNarrow, std::string *fullDirNarrow)
     *fullDirNarrow = result;
 }
 
+JsErrorCode WScriptJsrt::ModuleEntryPoint(LPCSTR fileName, LPCSTR fileContent, LPCSTR fullName)
+{
+    return LoadModuleFromString(fileName, fileContent, fullName, true);
+}
+
 JsErrorCode WScriptJsrt::LoadModuleFromString(LPCSTR fileName, LPCSTR fileContent, LPCSTR fullName, bool isFile)
 {
     DWORD_PTR dwSourceCookie = WScriptJsrt::GetNextSourceContext();

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -10,6 +10,7 @@ class WScriptJsrt
 public:
     static bool Initialize();
     static bool Uninitialize();
+    static JsErrorCode ModuleEntryPoint(LPCSTR fileName, LPCSTR fileContent, LPCSTR fullName);
 
     class CallbackMessage : public MessageBase
     {

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -452,6 +452,10 @@ HRESULT RunScript(const char* fileName, LPCSTR fileContents, size_t fileLength, 
                 parserStateCache,
                 nullptr);
         }
+        else if (HostConfigFlags::flags.Module)
+        {
+            runScript = WScriptJsrt::ModuleEntryPoint(fileName, fileContents, fullPath);
+        }
         else // bufferValue == nullptr && parserStateCache == nullptr
         {
             JsValueRef scriptSource;

--- a/test/es6module/multiple-roots-circular.js
+++ b/test/es6module/multiple-roots-circular.js
@@ -5,8 +5,6 @@
 
 // Tests that circular overlapping module dependencies are all loaded before execution
 
-WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
-
 WScript.RegisterModuleSource("mod0.js", "print('pass')");
 WScript.RegisterModuleSource("mod1.js", "import 'mod2.js';");
 WScript.RegisterModuleSource("mod2.js", "import 'mod0.js';");

--- a/test/es6module/otherModule.js
+++ b/test/es6module/otherModule.js
@@ -4,5 +4,5 @@
 //-------------------------------------------------------------------------------------------------------
 
 //test that dynamic import works from module
-//this file is imported only once - dynamicly from another module to check that the host is notified for that
+//this file is imported only once - dynamically from another module to check that the host is notified for that
 export const success = true;

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -161,4 +161,12 @@
       <tags>exclude_jshost</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>passmodule.js</files>
+      <!-- This test is designed for ch only - to test the -module flag. -->
+      <compile-flags>-module</compile-flags>
+      <tags>exclude_jshost</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes: #5274 

This PR adds a command line flag "-module" to ch which can be used to run a script as a module to avoid the need for wrapping module tests in an extra file of: WScript.LoadScriptfile(nameOfRealTest, "module");

I've added a simple test which runs an existing test file without it's wrapper to show that this works.

CC: @rwaldron