### PR TITLE
Re-enable PRE test

### DIFF
--- a/test/PRE/pre1.baseline
+++ b/test/PRE/pre1.baseline
@@ -22,7 +22,6 @@ TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
-TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
 undefined
@@ -33,7 +32,6 @@ TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
-TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
 2001

--- a/test/PRE/rlexe.xml
+++ b/test/PRE/rlexe.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <regress-exe>
-  <!-- OS bug 17559989 -->
-  <!-- <test>
+   <test>
     <default>
       <files>pre1.js</files>
       <baseline>pre1.baseline</baseline>
       <tags>exclude_forceserialized,exclude_dynapogo</tags>
       <compile-flags>-testtrace:fieldcopyprop -oopjit-</compile-flags>
     </default>
-  </test> -->
+  </test> 
 </regress-exe>


### PR DESCRIPTION
There were some differences in RS4 and master that meant the baseline for this test was different in the two versions of the code. Reenabling the test with updated baseline now.