### PR TITLE
Fix assertion when dumping encoder with foreground JIT

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -797,8 +797,6 @@ Encoder::Encode()
 
     if (PHASE_DUMP(Js::EncoderPhase, m_func) && Js::Configuration::Global.flags.Verbose && !m_func->IsOOPJIT())
     {
-        m_func->GetInProcJITEntryPointInfo()->DumpNativeOffsetMaps();
-        m_func->GetInProcJITEntryPointInfo()->DumpNativeThrowSpanSequence();
         this->DumpInlineeFrameMap(m_func->GetJITOutput()->GetCodeAddress());
         Output::Flush();
     }

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1192,6 +1192,13 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 
     workItem->GetEntryPoint()->SetCodeGenRecorded((Js::JavascriptMethod)jitWriteData.thunkAddress, (Js::JavascriptMethod)jitWriteData.codeAddress, jitWriteData.codeSize, (void *)this);
 
+    if (PHASE_DUMP(Js::EncoderPhase, workItem->GetFunctionBody()) && Js::Configuration::Global.flags.Verbose && !JITManager::GetJITManager()->IsOOPJITEnabled())
+    {
+        workItem->GetEntryPoint()->DumpNativeOffsetMaps();
+        workItem->GetEntryPoint()->DumpNativeThrowSpanSequence();
+        Output::Flush();
+    }
+
     if (jitWriteData.hasBailoutInstr != FALSE)
     {
         body->SetHasBailoutInstrInJittedCode(true);

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1192,12 +1192,14 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 
     workItem->GetEntryPoint()->SetCodeGenRecorded((Js::JavascriptMethod)jitWriteData.thunkAddress, (Js::JavascriptMethod)jitWriteData.codeAddress, jitWriteData.codeSize, (void *)this);
 
+#if DBG_DUMP
     if (PHASE_DUMP(Js::EncoderPhase, workItem->GetFunctionBody()) && Js::Configuration::Global.flags.Verbose && !JITManager::GetJITManager()->IsOOPJITEnabled())
     {
         workItem->GetEntryPoint()->DumpNativeOffsetMaps();
         workItem->GetEntryPoint()->DumpNativeThrowSpanSequence();
         Output::Flush();
     }
+#endif
 
     if (jitWriteData.hasBailoutInstr != FALSE)
     {


### PR DESCRIPTION
While outputting offsets in the EncoderPhase, several asserts can be hit because the state of the EntryPointInfo is Queued, where it is expected to be Recorded or Done. The effect is that there is no base address available for the right output.
The fix is to move the calls with that dependency to after the state transitions to Recorded.
