### PR TITLE
OS#17529874 - Skipping a nested deferred function containing a with statement can trigger load from invalid scope slot

### DIFF
--- a/test/Bugs/bug_OS17529874.js
+++ b/test/Bugs/bug_OS17529874.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function w_n() {
+    function foo() {
+        console.log("pass");
+    }
+
+    function bar() {
+        with ({}) {
+            foo();
+        }
+    }
+    bar();
+};
+w_n()
+console.log('pass');

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -472,18 +472,25 @@
       <files>symcmpbug.js</files>
     </default>
   </test>
-  <test> 
-    <default> 
-      <files>bug_OS17417473.js</files> 
-      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
-    </default> 
+  <test>
+    <default>
+      <files>bug_OS17417473.js</files>
+      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags>
+    </default>
   </test>
-  <test> 
-    <default> 
-      <files>HomeObjInLoop.js</files> 
-      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags> 
-    </default> 
-  </test> 
+  <test>
+    <default>
+      <files>bug_OS17529874.js</files>
+      <compile-flags>-force:deferparse -useparserstatecache -parserstatecache</compile-flags>
+      <tags>exclude_jshost</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>HomeObjInLoop.js</files>
+      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>bug17785360.js</files>


### PR DESCRIPTION
When we use deferred stubs in the parser to skip past nested deferred functions, we need to be careful about nested functions containing with statements. Names referenced inside the with can't be pushed as ordinary references - we need to know that the symbols are referenced inside the with statement or not. This isn't possible with stubs currently so, instead, avoid skipping such nested functions.

Fixes:
https://microsoft.visualstudio.com/_workitems/edit/17529874
