### PR TITLE
Fix potential buffer overread in CountNewlines in Scan.cpp

### DIFF
--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -10,19 +10,18 @@
 *  a given character can be part of an identifier, and so on.
 */
 
-int CountNewlines(LPCOLESTR psz, int cch)
+int CountNewlines(LPCOLESTR psz)
 {
     int cln = 0;
 
-    while (0 != *psz && 0 != cch--)
+    while (0 != *psz)
     {
         switch (*psz++)
         {
         case _u('\xD'):
-            if (cch != 0 && *psz == _u('\xA'))
+            if (*psz == _u('\xA'))
             {
                 ++psz;
-                --cch;
             }
             // fall-through
         case _u('\xA'):

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -19,11 +19,10 @@ int CountNewlines(LPCOLESTR psz, int cch)
         switch (*psz++)
         {
         case _u('\xD'):
-            if (*psz == _u('\xA'))
+            if (cch != 0 && *psz == _u('\xA'))
             {
                 ++psz;
-                if (0 == cch--)
-                    break;
+                --cch;
             }
             // fall-through
         case _u('\xA'):

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -12,7 +12,7 @@ namespace Js
 #include "Windows.Globalization.h"
 #endif
 
-int CountNewlines(LPCOLESTR psz, int cch = -1);
+int CountNewlines(LPCOLESTR psz);
 
 class Parser;
 struct ParseContext;


### PR DESCRIPTION
`cch` parameter is ignored if `psz` is not null-terminated and `psz[cch-1] == '\r'` and `psz[cch] == '\n'`. For example, `CountNewlines(_u("ab\r\na\n\n"), 3)` should return 1 (only count the first \r), but it now returns 2 (the first \r\n is skipped but the trailing \n\n are counted). The problem is that the `break` at line 26 breaks the switch, and `cch` becomes -1.

Also it seems this function is not used in ChakraCore. Is it used in ChakraFull? If not, can we just remove it?