### PR TITLE
Make the engine respect -off:typepropertycache

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -336,8 +336,8 @@ PHASE(All)
             PHASE(ObjectHeaderInliningForObjectLiterals)
             PHASE(ObjectHeaderInliningForEmptyObjects)
         PHASE(OptUnknownElementName)
-#if DBG_DUMP
         PHASE(TypePropertyCache)
+#if DBG_DUMP
         PHASE(InlineSlots)
 #endif
         PHASE(DynamicProfile)

--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -367,7 +367,13 @@ namespace Js
                 JavascriptFunction::IsBuiltinProperty(objectWithProperty, propertyId));
         }
 
-        const bool includeTypePropertyCache = IncludeTypePropertyCache && !isRoot;
+        const bool includeTypePropertyCache = 
+            IncludeTypePropertyCache && 
+            !isRoot && 
+            (info->GetFunctionBody()
+                 ? !PHASE_OFF(Js::TypePropertyCachePhase, info->GetFunctionBody())
+                 : !PHASE_OFF1(Js::TypePropertyCachePhase)
+            );
         bool createTypePropertyCache = false;
         PolymorphicInlineCache *polymorphicInlineCache = info->GetPolymorphicInlineCache();
         if(!polymorphicInlineCache && info->GetFunctionBody())


### PR DESCRIPTION
The phase switch was only being used to enable tracing, not to disable the feature.