### PR TITLE
OS#17729736: Don't cache missing properties for objects with DictionaryTypeHandler's

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1806,10 +1806,12 @@ CommonNumber:
 
         DynamicTypeHandler* handler = DynamicObject::UnsafeFromVar(instance)->GetDynamicType()->GetTypeHandler();
 
-        // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers and DictionaryTypeHandlers, because only these types have the right behavior
-        // when the missing property is later added: path types guarantee a type change, and DictionaryTypeHandlerBase::AddProperty explicitly invalidates all prototype caches for the
-        // property.  (We don't support other types only because we haven't needed to yet; we do not anticipate any difficulties in adding the cache-invalidation logic there if that changes.)
-        if (!handler->IsPathTypeHandler() && !handler->IsDictionaryTypeHandler())
+        // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers, because only these types have the right behavior
+        // when the missing property is later added. DictionaryTypeHandler's introduce the possibility that a stale TypePropertyCache entry with isMissing==true can
+        // be left in the cache after the property has been installed in the object's prototype chain. Other changes to optimize accesses to objects that don't
+        // override special symbols make it unnecessary to introduce an invalidation scheme to deal with DictionaryTypeHandler's.
+
+        if (!handler->IsPathTypeHandler())
         {
             return;
         }

--- a/test/es6/ES6Proto.js
+++ b/test/es6/ES6Proto.js
@@ -99,6 +99,35 @@ var tests = [
             assert.areEqual(p, Object.getPrototypeOf(o), "[[Prototype]] slot of o was changed to p");
         }
     },
+    {
+        name: "__proto__ plus missing property",
+        body: function () {
+            function main() {
+                var l0 = {
+                    a: -1,
+                    b: 0x414141,
+                };
+                l0.a = (l0.a) + (l0.a);
+
+                l0.y = {};
+                l0.__defineGetter__('z', function () {
+                    delete l0.a;
+                    return 5;
+                });
+                l0.a = (l0.a) - (l0.z);
+
+                l0.__proto__ = l0.y;
+                l0.z = (l0.z) / (l0.a);
+                var o = {};
+                o.a = 42;
+                l0.y.__proto__ = o;
+                return l0.a;
+            }
+            for (var i = 0; i < 20; i++) {
+                assert.areEqual(42, main(), "Missing property on local instance should be found in prototype chain");
+            }
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
This may leave stale isMissing elements in the TypePropertyCache after the property has been added to the prototype chain.