### PR TITLE
Memop fix related to scanning for missing values

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -892,7 +892,7 @@ SECOND_PASS:
                         else if (!HasNoMissingValues())
                         {
                             // Have we overwritten all the missing values?
-                            if (!ScanForMissingValues<T>(0, startOffset))
+                            if (!ScanForMissingValues<T>(0, startOffset) && !ScanForMissingValues<T>(startOffset + length, current->length))
                             {
                                 SetHasNoMissingValues();
                             }

--- a/test/Array/memop_missingValues.js
+++ b/test/Array/memop_missingValues.js
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0()
+{
+  var GiantPrintArray = [];
+  var IntArr0 = new Array(1, 1);
+  var FloatArr0 = [];
+  FloatArr0[1] = 1;
+  FloatArr0[0] = 1;
+  FloatArr0[12] = 1;
+  var v5;
+  v5 = IntArr0.length;
+  for (var i = 0; i < v5; i++) {
+    FloatArr0[i] = IntArr0[i];
+  }
+  GiantPrintArray.push(FloatArr0);
+  for (var v2 = 0; 0 < GiantPrintArray; 0) {
+  }
+}
+test0();
+test0();
+test0();
+print("passed");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -716,6 +716,12 @@
   </test>
   <test>
     <default>
+      <files>memop_missingValues.js</files>
+      <compile-flags>-mmoc:0</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug4587739.js</files>
       <compile-flags>-mic:1 -off:simplejit</compile-flags>
     </default>


### PR DESCRIPTION
If the entire range of a memop operation fits in the head segment, properly check if there were any missing items in the head outside of that range, before setting HasNoMissingValues to true on the dst array.

This is needed only after #5110.