### PR TITLE
toFixed : should return toString from numbers >=abs(10^21)

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -673,7 +673,7 @@ namespace Js
         {
             return ToStringNan(scriptContext);
         }
-        if(value >= 1e21)
+        if(value >= 1e21 || value <= -1e21)
         {
             return ToStringRadix10(value, scriptContext);
         }

--- a/test/Number/toString.js
+++ b/test/Number/toString.js
@@ -11,6 +11,7 @@ runTest('new Number(0)');
 runTest('0.9999999999999999e21');
 runTest('1e21');
 runTest('1.0000000000000001e21');
+runTest('-1.0000000000000001e21');
 
 function runTest(numberToTestAsString)
 {

--- a/test/Number/toString_3.baseline
+++ b/test/Number/toString_3.baseline
@@ -182,3 +182,26 @@ n.toPrecision(2):  1.0e+21
 n.toPrecision(5):  1.0000e+21
 n.toPrecision(20):  1.0000000000000001000e+21
 
+Test: -1.0000000000000001e21
+n.toString():  -1.0000000000000001e+21
+n.toString(10):  -1.0000000000000001e+21
+n.toString(8):  -154327115334273650400000
+n.toString(2):  -1101100011010111001001101011011100010111011110101000100000000000000000
+n.toString(16):  -3635c9adc5dea20000
+n.toString(25):  -11l25a0000007fbb
+n.toFixed():  -1.0000000000000001e+21
+n.toFixed(0):  -1.0000000000000001e+21
+n.toFixed(2):  -1.0000000000000001e+21
+n.toFixed(5):  -1.0000000000000001e+21
+n.toFixed(20):  -1.0000000000000001e+21
+RangeError: The number of fractional digits is out of range
+RangeError: The number of fractional digits is out of range
+n.toExponential():  -1.0000000000000001e+21
+n.toExponential(undefined):  -1.0000000000000001e+21
+n.toExponential(2):  -1.00e+21
+n.toExponential(5):  -1.00000e+21
+n.toPrecision():  -1.0000000000000001e+21
+n.toPrecision(2):  -1.0e+21
+n.toPrecision(5):  -1.0000e+21
+n.toPrecision(20):  -1.0000000000000001000e+21
+


### PR DESCRIPTION
We were doing that for positive value but missed that for negative value - fixed it.
