### PR TITLE
Generalize WeakReferenceDictionary to support weak keys or weak values

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -141,6 +141,8 @@ public:
         heapBlock = nullptr;
         return ptr = newPtr;
     };
+
+    void Clear() { heapBlock = nullptr; ptr = nullptr; };
 private:
     RecyclerWeakReferenceRegionItem(RecyclerWeakReferenceRegionItem<T>&) = delete;
 

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -321,7 +321,7 @@ namespace Js
 
     void JavascriptWeakMap::Clear()
     {
-        keySet.Map([&](RecyclableObject* key, bool value, const RecyclerWeakReference<RecyclableObject>* weakRef) {
+        keySet.Map([&](RecyclableObject* key, bool value, WeakType weakRef) {
             WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
             // It may be the case that a CEO has been reset and the keyMap is now null.

--- a/lib/Runtime/Library/JavascriptWeakMap.h
+++ b/lib/Runtime/Library/JavascriptWeakMap.h
@@ -42,7 +42,14 @@ namespace Js
         // its type and therefore without invalidating cache and JIT assumptions.
         //
         typedef JsUtil::BaseDictionary<WeakMapId, Var, Recycler, PowerOf2SizePolicy, RecyclerPointerComparer> WeakMapKeyMap;
+
+#if ENABLE_WEAK_REFERENCE_REGIONS
+        typedef JsUtil::WeakReferenceRegionKeyDictionary<RecyclableObject*, bool, RecyclerPointerComparer> KeySet;
+        typedef const RecyclerWeakReferenceRegionItem<RecyclableObject*>& WeakType;
+#else
         typedef JsUtil::WeaklyReferencedKeyDictionary<RecyclableObject, bool, RecyclerPointerComparer<const RecyclableObject*>> KeySet;
+        typedef const RecyclerWeakReference<RecyclableObject>* WeakType;
+#endif
 
         Field(KeySet) keySet;
 
@@ -97,7 +104,7 @@ namespace Js
         template <typename Fn>
         void Map(Fn fn)
         {
-            return keySet.Map([&](RecyclableObject* key, bool, const RecyclerWeakReference<RecyclableObject>*)
+            return keySet.Map([&](RecyclableObject* key, bool, WeakType)
             {
                 Var value = nullptr;
                 WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);

--- a/lib/Runtime/Library/JavascriptWeakSet.h
+++ b/lib/Runtime/Library/JavascriptWeakSet.h
@@ -9,7 +9,13 @@ namespace Js
     class JavascriptWeakSet : public DynamicObject
     {
     private:
+#if ENABLE_WEAK_REFERENCE_REGIONS
+        typedef JsUtil::WeakReferenceRegionKeyDictionary<RecyclableObject*, bool, RecyclerPointerComparer> KeySet;
+        typedef const RecyclerWeakReferenceRegionItem<RecyclableObject*>& WeakType;
+#else
         typedef JsUtil::WeaklyReferencedKeyDictionary<RecyclableObject, bool, RecyclerPointerComparer<const RecyclableObject*>> KeySet;
+        typedef const RecyclerWeakReference<RecyclableObject>* WeakType;
+#endif
 
         Field(KeySet) keySet;
 
@@ -49,7 +55,7 @@ namespace Js
         template <typename Fn>
         void Map(Fn fn)
         {
-            return keySet.Map([&](RecyclableObject* key, bool, const RecyclerWeakReference<RecyclableObject>*)
+            return keySet.Map([&](RecyclableObject* key, bool, WeakType)
             {
                 fn(key);
             });


### PR DESCRIPTION
The `WeakReferenceRegionDictionary` type only supports storing values weakly, while we also have some cases that want to strongly reference values, but weakly reference the keys.

This change generalizes the underlying dictionary to support having either weak keys or weak values, and then uses the weakly-keyed dictionary for `WeakSet`s and `WeakMap`s.