### PR TITLE
Modernize CI configuration: Modern = RS4 + Dev 15.7; Legacy = (2008 R2 & 2012 R2) + Dev14

### DIFF
--- a/Build/scripts/add_msbuild_path.cmd
+++ b/Build/scripts/add_msbuild_path.cmd
@@ -6,11 +6,11 @@
 :: add_msbuild_path.cmd
 ::
 :: Locate msbuild.exe and add it to the PATH
-set USE_MSBUILD_12=%1
+set FORCE_MSBUILD_VERSION=%1
 
-if "%USE_MSBUILD_12%" == "True" (
-    echo Skipping Dev15 and trying Dev12...
-    goto :LABEL_USE_MSBUILD_12
+if "%FORCE_MSBUILD_VERSION%" == "msbuild14" (
+    echo Skipping Dev15 and trying Dev14...
+    goto :LABEL_USE_MSBUILD_14
 )
 
 where /q msbuild.exe
@@ -20,8 +20,10 @@ if "%ERRORLEVEL%" == "0" (
 
 REM Try Dev15 first
 
-set MSBUILD_VERSION=15.0
+echo Trying to locate Dev15...
 
+:LABEL_USE_MSBUILD_15
+set MSBUILD_VERSION=15.0
 set "MSBUILD_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Preview\Enterprise\MSBuild\15.0\Bin"
 
 if not exist "%MSBUILD_PATH%\msbuild.exe" (
@@ -40,8 +42,9 @@ if exist "%MSBUILD_PATH%\msbuild.exe" (
     goto :MSBuildFound
 )
 
-echo Dev15 not found, trying Dev14...
+echo Dev15 not found, trying to locate Dev14...
 
+:LABEL_USE_MSBUILD_14
 set MSBUILD_VERSION=14.0
 set "MSBUILD_PATH=%ProgramFiles%\msbuild\%MSBUILD_VERSION%\Bin\x86"
 
@@ -57,7 +60,7 @@ if exist "%MSBUILD_PATH%\msbuild.exe" (
     goto :MSBuildFound
 )
 
-echo Dev14 not found, trying Dev12...
+echo Dev14 not found, trying to locate Dev12...
 
 :LABEL_USE_MSBUILD_12
 set MSBUILD_VERSION=12.0

--- a/netci.groovy
+++ b/netci.groovy
@@ -18,10 +18,20 @@ def msbuildTypeMap = [
 
 // convert `machine` parameter to OS component of PR task name
 def machineTypeToOSTagMap = [
-    'Windows_NT': 'Windows',        // Windows Server 2012 R2, equivalent to Windows 8.1 (aka Blue)
+    'Windows 7': 'Windows 7',       // Windows Server 2008 R2                     ~= Windows 7
+    'Windows_NT': 'Windows',        // 'latest-or-auto' -> Windows Server 2012 R2 ~= Windows 8.1 aka Blue
+    'windows.10.amd64.clientrs4.devex.open': 'Windows',                         // = Windows 10 RS4 with Dev 15.7
     'Ubuntu16.04': 'Ubuntu',
     'OSX10.12': 'OSX'
 ]
+
+def defaultMachineTag = 'latest-or-auto'
+
+def legacyWindowsMachine = 'Windows 7'
+def legacyWindowsMachineTag = defaultMachineTag
+
+def latestWindowsMachine = 'windows.10.amd64.clientrs4.devex.open' // Windows 10 RS4 with Dev 15.7
+def latestWindowsMachineTag = null // all information is included in the machine name above
 
 def dailyRegex = 'dailies'
 
@@ -29,7 +39,7 @@ def dailyRegex = 'dailies'
 // HELPER CLOSURES
 // ---------------
 
-def CreateBuildTask = { isPR, buildArch, buildType, machine, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup ->
+def CreateBuildTask = { isPR, buildArch, buildType, machine, machineTag, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup ->
     if (excludeConfigIf && excludeConfigIf(isPR, buildArch, buildType)) {
         return // early exit: we don't want to create a job for this configuration
     }
@@ -75,7 +85,13 @@ def CreateBuildTask = { isPR, buildArch, buildType, machine, configTag, buildExt
         false, // doNotFailIfNothingArchived=false ~= failIfNothingArchived
         false) // archiveOnlyIfSuccessful=false ~= archiveAlways
 
-    Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
+    if (machineTag == null) {
+        // note: this is a different overload and not equivalent to calling setMachineAffinity(_,_,null)
+        Utilities.setMachineAffinity(newJob, machine)
+    } else {
+        Utilities.setMachineAffinity(newJob, machine, machineTag)
+    }
+
     Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
     if (nonDefaultTaskSetup == null) {
@@ -95,11 +111,11 @@ def CreateBuildTask = { isPR, buildArch, buildType, machine, configTag, buildExt
     }
 }
 
-def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup ->
+def CreateBuildTasks = { machine, machineTag, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup ->
     [true, false].each { isPR ->
         ['x86', 'x64', 'arm'].each { buildArch ->
             ['debug', 'test', 'release'].each { buildType ->
-                CreateBuildTask(isPR, buildArch, buildType, machine, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup)
+                CreateBuildTask(isPR, buildArch, buildType, machine, machineTag, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup)
             }
         }
     }
@@ -142,7 +158,7 @@ def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, co
         true, // doNotFailIfNothingArchived=false ~= failIfNothingArchived (true ~= doNotFail)
         false) // archiveOnlyIfSuccessful=false ~= archiveAlways
 
-    Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
+    Utilities.setMachineAffinity(newJob, machine, defaultMachineTag)
     Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
 
     if (nonDefaultTaskSetup == null) {
@@ -213,7 +229,7 @@ def CreateStyleCheckTasks = { taskString, taskName, checkName ->
             Utilities.addGithubPushTrigger(newJob)
         }
 
-        Utilities.setMachineAffinity(newJob, 'Ubuntu16.04', 'latest-or-auto')
+        Utilities.setMachineAffinity(newJob, 'Ubuntu16.04', defaultMachineTag)
     }
 }
 
@@ -221,34 +237,45 @@ def CreateStyleCheckTasks = { taskString, taskName, checkName ->
 // INNER LOOP TASKS
 // ----------------
 
-CreateBuildTasks('Windows_NT', null, null, "-winBlue", true, null, null)
+CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, null, null, "-winBlue", true, null, null)
 
 // Add some additional daily configs to trigger per-PR as a quality gate:
 // x64_debug Slow Tests
 CreateBuildTask(true, 'x64', 'debug',
-    'Windows_NT', 'ci_slow', null, '-winBlue -includeSlow', false, null, null)
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_slow', null, '-winBlue -includeSlow', false, null, null)
 // x64_debug DisableJIT
 CreateBuildTask(true, 'x64', 'debug',
-    'Windows_NT', 'ci_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', false, null, null)
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', false, null, null)
 // x64_debug Lite
 CreateBuildTask(true, 'x64', 'debug',
-    'Windows_NT', 'ci_lite', '"/p:BuildLite=true"', '-winBlue -lite', false, null, null)
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_lite', '"/p:BuildLite=true"', '-winBlue -lite', false, null, null)
+// x64_debug Legacy
+CreateBuildTask(true, 'x64', 'debug',
+    legacyWindowsMachine, legacyWindowsMachineTag, 'ci_legacy', 'msbuild14', '-win7 -includeSlow', false, null, null)
 
 // -----------------
 // DAILY BUILD TASKS
 // -----------------
 
 if (!branch.endsWith('-ci')) {
-    // build and test on the usual configuration (VS 2015) with -includeSlow
-    CreateBuildTasks('Windows_NT', 'daily_slow', null, '-winBlue -includeSlow', false,
+    // build and test on the legacy configuration (Windows 7 + VS 2015 (Dev14))
+    CreateBuildTasks(legacyWindowsMachine, legacyWindowsMachineTag, 'daily_legacy', 'msbuild14', '-win7 -includeSlow', false,
+        /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
+        /* nonDefaultTaskSetup */ { newJob, isPR, config ->
+            DailyBuildTaskSetup(newJob, isPR,
+                "Windows 7 ${config}",
+                'legacy\\s+tests')})
+
+    // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with -includeSlow
+    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_slow', null, '-winBlue -includeSlow', false,
         /* excludeConfigIf */ null,
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
                 "Windows ${config}",
                 'slow\\s+tests')})
 
-    // build and test on the usual configuration (VS 2015) with JIT disabled
-    CreateBuildTasks('Windows_NT', 'daily_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', true,
+    // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with JIT disabled
+    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', true,
         /* excludeConfigIf */ null,
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
@@ -292,7 +319,7 @@ if (isXPlatCompatibleBranch) {
     CreateXPlatBuildTasks(osString, "linux", "ubuntu", branch, null, "")
 
     // Create a PR/continuous task to check ubuntu/static/debug/no-icu
-    [true, false].each { isPR -> 
+    [true, false].each { isPR ->
         CreateXPlatBuildTask(isPR, "debug", true, osString, "linux",
             "ubuntu", branch, null, "--no-icu", "--not-tag exclude_noicu", "")
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -27,8 +27,11 @@ def machineTypeToOSTagMap = [
 
 def defaultMachineTag = 'latest-or-auto'
 
-def legacyWindowsMachine = 'Windows 7'
-def legacyWindowsMachineTag = defaultMachineTag
+def legacyWindows7Machine = 'Windows 7'
+def legacyWindows7MachineTag = defaultMachineTag
+
+def legacyWindows8Machine = 'Windows_NT'
+def legacyWindows8MachineTag = defaultMachineTag
 
 def latestWindowsMachine = 'windows.10.amd64.clientrs4.devex.open' // Windows 10 RS4 with Dev 15.7
 def latestWindowsMachineTag = null // all information is included in the machine name above
@@ -237,21 +240,24 @@ def CreateStyleCheckTasks = { taskString, taskName, checkName ->
 // INNER LOOP TASKS
 // ----------------
 
-CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, null, null, "-winBlue", true, null, null)
+CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, null, null, "-win10", true, null, null)
 
 // Add some additional daily configs to trigger per-PR as a quality gate:
 // x64_debug Slow Tests
 CreateBuildTask(true, 'x64', 'debug',
-    latestWindowsMachine, latestWindowsMachineTag, 'ci_slow', null, '-winBlue -includeSlow', false, null, null)
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_slow', null, '-win10 -includeSlow', false, null, null)
 // x64_debug DisableJIT
 CreateBuildTask(true, 'x64', 'debug',
-    latestWindowsMachine, latestWindowsMachineTag, 'ci_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', false, null, null)
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_disablejit', '"/p:BuildJIT=false"', '-win10 -disablejit', false, null, null)
 // x64_debug Lite
 CreateBuildTask(true, 'x64', 'debug',
-    latestWindowsMachine, latestWindowsMachineTag, 'ci_lite', '"/p:BuildLite=true"', '-winBlue -lite', false, null, null)
-// x64_debug Legacy
+    latestWindowsMachine, latestWindowsMachineTag, 'ci_lite', '"/p:BuildLite=true"', '-win10 -lite', false, null, null)
+// x64_debug Legacy (Windows 7)
 CreateBuildTask(true, 'x64', 'debug',
-    legacyWindowsMachine, legacyWindowsMachineTag, 'ci_legacy', 'msbuild14', '-win7 -includeSlow', false, null, null)
+    legacyWindows7Machine, legacyWindows7MachineTag, 'ci_legacy7', 'msbuild14', '-win7 -includeSlow', false, null, null)
+// x64_debug Legacy (Windows 8.1 (Blue))
+CreateBuildTask(true, 'x64', 'debug',
+    legacyWindows8Machine, legacyWindows8MachineTag, 'ci_legacy8', 'msbuild14', '-winBlue -includeSlow', false, null, null)
 
 // -----------------
 // DAILY BUILD TASKS
@@ -259,15 +265,23 @@ CreateBuildTask(true, 'x64', 'debug',
 
 if (!branch.endsWith('-ci')) {
     // build and test on the legacy configuration (Windows 7 + VS 2015 (Dev14))
-    CreateBuildTasks(legacyWindowsMachine, legacyWindowsMachineTag, 'daily_legacy', 'msbuild14', '-win7 -includeSlow', false,
+    CreateBuildTasks(legacyWindows7Machine, legacyWindows7MachineTag, 'daily_legacy7', 'msbuild14', '-win7 -includeSlow', false,
         /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
                 "Windows 7 ${config}",
                 'legacy\\s+tests')})
 
+    // build and test on the legacy configuration (Windows 8.1 (Blue) + VS 2015 (Dev14))
+    CreateBuildTasks(legacyWindows8Machine, legacyWindows8MachineTag, 'daily_legacy8', 'msbuild14', '-winBlue -includeSlow', false,
+        /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
+        /* nonDefaultTaskSetup */ { newJob, isPR, config ->
+            DailyBuildTaskSetup(newJob, isPR,
+                "Windows 8 ${config}",
+                'legacy\\s+tests')})
+
     // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with -includeSlow
-    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_slow', null, '-winBlue -includeSlow', false,
+    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_slow', null, '-win10 -includeSlow', false,
         /* excludeConfigIf */ null,
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
@@ -275,7 +289,7 @@ if (!branch.endsWith('-ci')) {
                 'slow\\s+tests')})
 
     // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with JIT disabled
-    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_disablejit', '"/p:BuildJIT=false"', '-winBlue -disablejit', true,
+    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_disablejit', '"/p:BuildJIT=false"', '-win10 -disablejit', true,
         /* excludeConfigIf */ null,
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,

--- a/netci.groovy
+++ b/netci.groovy
@@ -276,7 +276,7 @@ if (!branch.endsWith('-ci')) {
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
                 "Windows 7 ${config}",
-                'legacy\\s+tests')})
+                'legacy7?\\s+tests)')})
 
     // build and test on the legacy configuration (Windows 8.1 (Blue) + VS 2015 (Dev14))
     CreateBuildTasks(legacyWindows8Machine, legacyWindows8MachineTag, 'daily_legacy8', 'msbuild14', '-winBlue -includeSlow', false,
@@ -284,7 +284,7 @@ if (!branch.endsWith('-ci')) {
         /* nonDefaultTaskSetup */ { newJob, isPR, config ->
             DailyBuildTaskSetup(newJob, isPR,
                 "Windows 8 ${config}",
-                'legacy\\s+tests')})
+                'legacy8?\\s+tests')})
 
     // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with -includeSlow
     CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_slow', null, '-win10 -includeSlow', false,
@@ -301,6 +301,14 @@ if (!branch.endsWith('-ci')) {
             DailyBuildTaskSetup(newJob, isPR,
                 "Windows ${config}",
                 '(disablejit|nojit)\\s+tests')})
+
+    // build and test on the latest configuration (RS4 + VS 2017 Dev 15.7) with Lite build
+    CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, 'daily_lite', '"/p:BuildLite=true"', '-win10 -lite', true,
+        /* excludeConfigIf */ null,
+        /* nonDefaultTaskSetup */ { newJob, isPR, config ->
+            DailyBuildTaskSetup(newJob, isPR,
+                "Windows ${config}",
+                'lite\\s+tests')})
 }
 
 // ----------------

--- a/netci.groovy
+++ b/netci.groovy
@@ -18,9 +18,9 @@ def msbuildTypeMap = [
 
 // convert `machine` parameter to OS component of PR task name
 def machineTypeToOSTagMap = [
-    'Windows 7': 'Windows 7',       // Windows Server 2008 R2                     ~= Windows 7
-    'Windows_NT': 'Windows',        // 'latest-or-auto' -> Windows Server 2012 R2 ~= Windows 8.1 aka Blue
-    'windows.10.amd64.clientrs4.devex.open': 'Windows',                         // = Windows 10 RS4 with Dev 15.7
+    'Windows 7': 'Windows 7',           // 'latest-or-auto' -> Windows Server 2008 R2 ~= Windows 7
+    'Windows_NT': 'Windows 8.1',        // 'latest-or-auto' -> Windows Server 2012 R2 ~= Windows 8.1 aka Blue
+    'windows.10.amd64.clientrs4.devex.open': 'Windows 10',                          // = Windows 10 RS4 with Dev 15.7
     'Ubuntu16.04': 'Ubuntu',
     'OSX10.12': 'OSX'
 ]

--- a/netci.groovy
+++ b/netci.groovy
@@ -240,7 +240,13 @@ def CreateStyleCheckTasks = { taskString, taskName, checkName ->
 // INNER LOOP TASKS
 // ----------------
 
-CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, null, null, "-win10", true, null, null)
+// The latest machine seems to have a configuration problem preventing us from building ARM.
+// For now, build ARM on the LKG config, Legacy Windows 8.1 (Blue) config.
+// TODO When the configuration is updated, unify this config split.
+CreateBuildTasks(latestWindowsMachine, latestWindowsMachineTag, null, null, "-win10", true,
+    /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') }, null)
+CreateBuildTasks(legacyWindows8Machine, legacyWindows8MachineTag, null, null, "-winBlue", true,
+    /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch != 'arm') }, null)
 
 // Add some additional daily configs to trigger per-PR as a quality gate:
 // x64_debug Slow Tests

--- a/test/jenkins.build.init.cmd
+++ b/test/jenkins.build.init.cmd
@@ -13,11 +13,11 @@ if not "%JENKINS_BUILD%" == "True" (
 set REPO_ROOT=%~dp0\..
 
 set JENKINS_BUILD_ARGS=
-set JENKINS_USE_MSBUILD_12=
+set JENKINS_FORCE_MSBUILD_VERSION=
 :ContinueArgParse
 if not [%1]==[] (
-    if [%1]==[msbuild12] (
-        set JENKINS_USE_MSBUILD_12=True
+    if [%1]==[msbuild14] (
+        set JENKINS_FORCE_MSBUILD_VERSION=%1
         goto :ContinueArgParseEnd
     )
 
@@ -36,4 +36,4 @@ if not [%1]==[] (
 :: Set up msbuild.exe
 :: ========================================
 
-call %REPO_ROOT%\Build\scripts\add_msbuild_path.cmd %JENKINS_USE_MSBUILD_12%
+call %REPO_ROOT%\Build\scripts\add_msbuild_path.cmd %JENKINS_FORCE_MSBUILD_VERSION%


### PR DESCRIPTION
* Update Windows build matrix to use a modernized CI configuration: Modern = RS4 + Dev 15.7 and Legacy7 = Server 2008 R2 + Dev14 and Legacy8 = Server 2012 R2 + Dev14
* Update script logic for forcing detection of a specific msbuild version

Note that the legacy OS is the same as before (2008 R2 ~= Windows 7 SP1) which is the lowest Windows OS version ChakraCore supports, and the legacy version of VS has been updated to VS 2015 / Dev14, which is now the lowest Visual Studio version ChakraCore supports (since Dev12 support was dropped).

This change also adds a second legacy configuration for 2012 R2 ~= Windows 8.1 Blue.