### PR TITLE
Fix #5182: Clamp range quantifier to MaxCharCount instead of throwing SyntaxError

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -1120,16 +1120,40 @@ namespace UnifiedRegex
             if (!standardEncodedChars->IsDigit(ec))
             {
                 if (digits == 0)
+                {
                     Fail(JSERR_RegExpSyntax);
+                }
+
                 return n;
             }
+
             if (n > MaxCharCount / 10)
-                Fail(JSERR_RegExpSyntax);
+            {
+                break;
+            }
+
             n *= 10;
             if (n > MaxCharCount - standardEncodedChars->DigitValue(ec))
-                Fail(JSERR_RegExpSyntax);
+            {
+                break;
+            }
+
             n += standardEncodedChars->DigitValue(ec);
             digits++;
+            ECConsume();
+        }
+
+        Assert(digits != 0); // shouldn't be able to reach here with (digits == 0)
+
+        // The token had a value larger than MaxCharCount so we didn't return the value and reached here instead.
+        // Consume the rest of the token and return MaxCharCount.
+        while (true)
+        {
+            EncodedChar ec = ECLookahead();
+            if (!standardEncodedChars->IsDigit(ec))
+            {
+                return MaxCharCount;
+            }
             ECConsume();
         }
     }

--- a/test/Regex/clampNumericQuantifier.js
+++ b/test/Regex/clampNumericQuantifier.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function assert(b) {
+    if (!b) {
+        print('fail');
+    }
+}
+
+let p1 = new RegExp('^[a-z]{2,2147483648}$');
+assert(!p1.test('a'));
+
+let p2 = /^[a-z]{2,2147483648}$/;
+assert(p2.test('aaaaa'));
+
+print('PASS');

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -39,6 +39,11 @@
   </test>
   <test>
     <default>
+      <files>clampNumericQuantifier.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>rx1.js</files>
       <baseline>rx1.baseline</baseline>
     </default>


### PR DESCRIPTION
Fix #5182 