### PR TITLE
Proxy : getPrototype trap should not be called.

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -194,7 +194,7 @@ using namespace Js;
         //      ii. Let nextp be the result of calling the [[GetInheritance]] internal method of p with no arguments.
         //      iii.    ReturnIfAbrupt(nextp).
         //      iv. Let  p be nextp.
-        if (IsPrototypeOf(object, newPrototype, scriptContext)) // Reject cycle
+        if (IsPrototypeOfStopAtProxy(object, newPrototype, scriptContext)) // Reject cycle
         {
             if (shouldThrow)
             {

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -137,6 +137,23 @@ var tests = [
         new bar(...(new Array(2**16+1)))
       } catch(e) { }
     }
+  },
+  {
+    name: "getPrototypeOf Should not be called when set as prototype",
+    body: function () {
+      var p = new Proxy({}, { getPrototypeOf: function() {
+          assert.fail("this should not be called")
+          return {};
+        }});
+
+        var obj = {};
+        obj.__proto__ = p; // This should not call the getPrototypeOf
+
+        var obj1 = {};
+        Object.setPrototypeOf(obj1, p); // This should not call the getPrototypeOf
+
+        var obj2 = {__proto__ : p}; // This should not call the getPrototypeOf
+    }
   }
   
 ];


### PR DESCRIPTION
when setting proxy as a prototype of  another object - it should not inoke the trap.
(If I read correctly, step 8.c.i: https://tc39.github.io/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v ).
