### PR TITLE
OS#17857906 - Fix assertion in Lower.cpp helperMethod != IR::HelperOP_InitElemGetter...

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -10977,9 +10977,10 @@ GlobOpt::ToTypeSpecIndex(IR::Instr * instr, IR::RegOpnd * indexOpnd, IR::IndirOp
         instr->m_opcode == Js::OpCode::InitClassMemberGetComputedName ||
         instr->m_opcode == Js::OpCode::InitClassMemberSetComputedName;
 
-    if ((indexOpnd->GetValueType().IsInt()
-        ? !IsTypeSpecPhaseOff(func)
-        : indexOpnd->GetValueType().IsLikelyInt() && DoAggressiveIntTypeSpec() && !isGetterOrSetter) // typespec is disabled for getters, setters
+    if (!isGetterOrSetter // typespec is disabled for getters, setters
+        && (indexOpnd->GetValueType().IsInt()
+            ? !IsTypeSpecPhaseOff(func)
+            : indexOpnd->GetValueType().IsLikelyInt() && DoAggressiveIntTypeSpec())
         && !GetIsAsmJSFunc()) // typespec is disabled for asmjs
     {
         StackSym *const indexVarSym = indexOpnd->m_sym;

--- a/test/es6/bug_OS16649604.js
+++ b/test/es6/bug_OS16649604.js
@@ -19,6 +19,7 @@ var tests = [
                     set [m](val) { }
                     get [r]() { return 'a'; }
                     set [s](val) { }
+                    get [1 & Math]() { return 42; }
                 }
 
                 d = {
@@ -36,6 +37,7 @@ var tests = [
             assert.areEqual('undefined', typeof ((new c())[2]), "Integer as class member setter property name");
             assert.areEqual('string', typeof ((new c())[0.5]), "Float as class member getter property name");
             assert.areEqual('undefined', typeof ((new c())['prop']), "String as class member setter property name");
+            assert.areEqual('number', typeof ((new c())[1 & Math]), "Expression as class member setter property name");
 
             assert.areEqual('number', typeof (d[1]), "Integer as getter property name");
             assert.areEqual('undefined', typeof (d[2]), "Integer as setter property name");


### PR DESCRIPTION
A previous fix for OS#16649604 was not complete and caused an assertion in \lib\Backend\Lower.cpp  line 9035) helperMethod != IR::HelperOP_InitElemGetter && helperMethod != IR::HelperOP_InitElemSetter && ...

The original fix skipped type spec for computed properties in getters/setters (GlobOpt::ToTypeSpecIndex()), but the fix did not cover all code path and asserted with code like:

```
function test3() {
    return class blnnsx {
        get [1 & Math]() {
            return 42;
        }
    }
}
test3();
test3();
```
