### PR TITLE
Enable deadstore for jit loop bodies when there is try

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -107,9 +107,7 @@ BackwardPass::DoMarkTempObjectVerify() const
 bool
 BackwardPass::DoDeadStore(Func* func)
 {
-    return
-        !PHASE_OFF(Js::DeadStorePhase, func) &&
-        (!func->HasTry() || func->DoOptimizeTry());
+    return !PHASE_OFF(Js::DeadStorePhase, func);
 }
 
 bool
@@ -124,8 +122,7 @@ bool
 BackwardPass::DoDeadStoreSlots() const
 {
     // only dead store fields if glob opt is on to generate the trackable fields bitvector
-    return (tag == Js::DeadStorePhase && this->func->DoGlobOpt()
-        && (!this->func->HasTry()));
+    return (tag == Js::DeadStorePhase && this->func->DoGlobOpt());
 }
 
 // Whether dead store is enabled for given func and sym.

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -204,4 +204,11 @@
        <files>tfjitloopbug.js</files>
   </default>
   </test>
+  <test>
+    <default>
+      <files>tcdeadstorebug.js</files>
+      <compile-flags> -maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport  -bgjit- -loopinterpretcount:1</compile-flags>
+      <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/EH/tcdeadstorebug.js
+++ b/test/EH/tcdeadstorebug.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function test0() {
+  var i32 = new Int32Array(1);
+  {
+    class class0 {
+    }
+    class class8 {
+    }
+    class class17 {
+      static func91(argMath135) {
+        if (new class0() * h) {
+        } 
+      }
+      static func94() {
+        return class8.func78;
+      }
+    }
+    for (var _strvar2 in i32) {
+      continue;	    
+      try {
+      } catch (ex) {
+        class8;
+      }
+    }
+  }
+}
+test0();
+test0();
+print("Passed");


### PR DESCRIPTION
We insert LdSlots at the top of the function in jitloopbody for all syms that are coming in live to the loop. These LdSlots should be restored correctly on BailOutFromSimpleJitToJitLoopBody.
However we do unreachable code elimination in flowgraph in simplejit, which can dead code the uses of these syms, and so they will not be restored on bailout.
This works if we run deadstore pass which will cleanup all the LdSlots inserted at the top of the function, after we run unreachable block elimination phase.
But since we turn off deadstore for functions with try/catch, we end up having a nullptr AV.

Fixes OS#17447405
