### PR TITLE
don't cache writes to default setter

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2303,7 +2303,7 @@ CommonNumber:
                     }
                     if (setterValueOrProxy)
                     {
-                        if (!WithScopeObject::Is(receiver) && info->GetPropertyRecordUsageCache())
+                        if (!WithScopeObject::Is(receiver) && info->GetPropertyRecordUsageCache() && !JavascriptOperators::IsUndefinedAccessor(setterValueOrProxy, requestContext))
                         {
                             CacheOperators::CachePropertyWrite(RecyclableObject::FromVar(receiver), false, object->GetType(), info->GetPropertyRecordUsageCache()->GetPropertyRecord()->GetPropertyId(), info, requestContext);
                         }
@@ -2525,7 +2525,7 @@ CommonNumber:
                     {
                         receiver = (RecyclableObject::FromVar(receiver))->GetThisObjectOrUnWrap();
                     }
-                    else
+                    else if (!JavascriptOperators::IsUndefinedAccessor(setterValueOrProxy, requestContext))
                     {
                         CacheOperators::CachePropertyWrite(RecyclableObject::FromVar(receiver), isRoot, object->GetType(), propertyId, info, requestContext);
                     }

--- a/test/InlineCaches/defaultsetterbug.js
+++ b/test/InlineCaches/defaultsetterbug.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let threw = false
+try
+{
+    var obj1 = {};
+    var func0 = function () {
+    for (var _strvar2 in Object) {
+        Object.prototype[_strvar2] = {};
+    }
+    };
+    let cnt = 0;
+
+    Object.defineProperty(obj1, 'prop0', {
+    get: function () {
+        print("BAD!");
+    },
+    configurable: true
+    });
+
+    Object.prototype.prop0 = func0();
+    Object.prototype.prop2 = func0();
+
+    Object.prop2 = Object.defineProperty(Object.prototype, 'prop2', {
+    get: function () {
+    }});
+    (function () {
+    'use strict';
+    for (var _strvar0 in Object) {
+        Object.prototype[_strvar0] = func0();
+    }
+    }());
+}
+catch(e)
+{
+    threw = true;
+}
+
+print(threw ? "Pass" : "Fail")

--- a/test/InlineCaches/rlexe.xml
+++ b/test/InlineCaches/rlexe.xml
@@ -83,6 +83,11 @@
   </test>
   <test>
     <default>
+      <files>defaultsetterbug.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>BigDictionaryTypeHandler.js</files>
     </default>
   </test>


### PR DESCRIPTION
We can't cache writes to the default setter in sloppy mode, because we may then get a cache hit in strict mode and call it, when we should throw an exception instead

OS: 17124936