### PR TITLE
Use more efficient call to load module

### DIFF
--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -1299,7 +1299,7 @@ namespace JsUtil
 
 #if !defined(_UCRT)
         HMODULE dllHandle = NULL;
-        if (!GetModuleHandleEx(0, AutoSystemInfo::GetJscriptDllFileName(), &dllHandle))
+        if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)&BackgroundJobProcessor::StaticThreadProc, &dllHandle))
         {
             dllHandle = NULL;
         }


### PR DESCRIPTION
The ThreadProc for BackgroundJobProcessor calls GetModuleHandleEx to ensure that Chakra.dll isn't unloaded while code is still executing on this thread. However, using the full path to the DLL is an expensive kernal call.
Instead, follow the convention of other threads in Chakra and use GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS.
