### PR TITLE
MSFT:17677205 IdleDecommit hang. Back-off from decommit if UI thread wants to enter IdleDecommit again.

### DIFF
--- a/lib/Common/Memory/AllocatorTelemetryStats.h
+++ b/lib/Common/Memory/AllocatorTelemetryStats.h
@@ -11,6 +11,14 @@ struct AllocatorDecommitStats
 {
     Js::Tick lastLeaveDecommitRegion;
     Js::TickDelta maxDeltaBetweenDecommitRegionLeaveAndDecommit;
+
+    // The following values correspond to when we last entered the critical section for Enter/Leave IdleDecommit and
+    // how long we waited to enter the critical section if we had to wait.
+    Js::Tick lastEnterLeaveIdleDecommitTick;
+    Js::TickDelta lastEnterLeaveIdleDecommitCSWaitTime;
+    Js::TickDelta maxEnterLeaveIdleDecommitCSWaitTime;
+    Js::TickDelta totalEnterLeaveIdleDecommitCSWaitTime;
+
     int64 numDecommitCalls;
     int64 numPagesDecommitted;
     int64 numFreePageCount;
@@ -18,11 +26,14 @@ struct AllocatorDecommitStats
     AllocatorDecommitStats() :
         lastLeaveDecommitRegion(),
         maxDeltaBetweenDecommitRegionLeaveAndDecommit(0),
+        lastEnterLeaveIdleDecommitTick(),
+        lastEnterLeaveIdleDecommitCSWaitTime(0),
+        maxEnterLeaveIdleDecommitCSWaitTime(0),
+        totalEnterLeaveIdleDecommitCSWaitTime(0),
         numDecommitCalls(0),
         numPagesDecommitted(0),
         numFreePageCount(0)
     {}
-
 };
 
 struct AllocatorSizes

--- a/lib/Common/Memory/IdleDecommitPageAllocator.h
+++ b/lib/Common/Memory/IdleDecommitPageAllocator.h
@@ -41,6 +41,23 @@ public:
 #endif
 
 private:
+    class AutoResetWaitingToEnterIdleDecommitFlag
+    {
+    public:
+        AutoResetWaitingToEnterIdleDecommitFlag(IdleDecommitPageAllocator * pageAllocator)
+        {
+            this->pageAllocator = pageAllocator;
+            pageAllocator->waitingToEnterIdleDecommit = true;
+        }
+
+        ~AutoResetWaitingToEnterIdleDecommitFlag()
+        {
+            pageAllocator->waitingToEnterIdleDecommit = false;
+        }
+
+    private:
+        IdleDecommitPageAllocator * pageAllocator;
+    };
 
 #ifdef IDLE_DECOMMIT_ENABLED
 #if DBG_DUMP
@@ -83,5 +100,4 @@ public:
     }
 #endif
 };
-
 }

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -858,6 +858,15 @@ protected:
 
     // Idle Decommit
     bool isUsed;
+    // A flag to indicate we are trying to enter IdleDecommit again and back-off from decommit in DecommitNow. This is to prevent
+    // blocking UI thread for too long. We have seen hangs under AppVerifier and believe this may be due to the decommit being slower
+    // under AppVerifier. This shouldn't be a problem otherwise.
+    bool waitingToEnterIdleDecommit;
+
+#if DBG
+    uint idleDecommitBackOffCount;
+#endif
+
     size_t minFreePageCount;
     uint idleDecommitEnterCount;
 


### PR DESCRIPTION
We suspect that this may be a problem only under AppVerifier where decommit maybe running slower than usual. The fix should have no impact under normal conditions.