### PR TITLE
OS#17885560 - Fix perf regression introduced with a bad fix for OS#17417473

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -14274,7 +14274,7 @@ GlobOpt::OptIsInvariant(Sym *sym, BasicBlock *block, Loop *loop, Value *srcVal, 
     }
     else if (sym->IsPropertySym())
     {
-        if (!loop->landingPad->globOptData.liveFields->Test(sym->AsPropertySym()->m_stackSym->m_id))
+        if (!loop->landingPad->globOptData.liveVarSyms->Test(sym->AsPropertySym()->m_stackSym->m_id))
         {
             return false;
         }


### PR DESCRIPTION
The fix for bug 17417473 was incorrect: in GlobOpt::OptIsInvariant() we should use loop->landingPad->globOptData.liveVarSyms, not loop->landingPad->globOptData.liveFields to make sure a symbol is not hoisted if not alive in landingPad.
This also introduced a perf regression; in test mandreel.js a large number of "CheckFixedFld" instructions were not hoisted outside loops.