### PR TITLE
Add exception handling to LEAVE_SCRIPT_IF

### DIFF
--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -107,16 +107,19 @@ protected:
                 }\
         }
 
-#define LEAVE_SCRIPT_IF(scriptContext, condition, block) \
-        if (condition) \
+#define LEAVE_SCRIPT_IF_ACTIVE(scriptContext, externalCall) \
+        if (scriptContext->GetThreadContext()->IsScriptActive()) \
         { \
             BEGIN_LEAVE_SCRIPT(scriptContext); \
-            block \
+            externalCall \
             END_LEAVE_SCRIPT(scriptContext); \
         } \
         else \
         { \
-            block \
+            DECLARE_EXCEPTION_CHECK_DATA \
+            SAVE_EXCEPTION_CHECK \
+            externalCall \
+            RESTORE_EXCEPTION_CHECK \
         }
 
 #define ENTER_SCRIPT_IF(scriptContext, doCleanup, isCallRoot, hasCaller, condition, block) \

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -203,11 +203,10 @@ namespace Js
             }
 
             // Notify host if current module is dynamically-loaded module, or is root module and the host hasn't been notified
-            bool isScriptActive = scriptContext->GetThreadContext()->IsScriptActive();
             if (this->promise != nullptr || (isRootModule && !hadNotifyHostReady))
             {
                 OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyHostAboutModuleReady %s (ParseSource error)\n"), this->GetSpecifierSz());
-                LEAVE_SCRIPT_IF(scriptContext, isScriptActive,
+                LEAVE_SCRIPT_IF_ACTIVE(scriptContext,
                 {
                     scriptContext->GetHostScriptContext()->NotifyHostAboutModuleReady(this, this->errorObject);
                 });
@@ -295,10 +294,8 @@ namespace Js
                 {
                     if (!hadNotifyHostReady && !WasEvaluated())
                     {
-                        bool isScriptActive = scriptContext->GetThreadContext()->IsScriptActive();
-
                         OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyHostAboutModuleReady %s (PostProcessDynamicModuleImport)\n"), this->GetSpecifierSz());
-                        LEAVE_SCRIPT_IF(scriptContext, isScriptActive,
+                        LEAVE_SCRIPT_IF_ACTIVE(scriptContext,
                         {
                             hr = scriptContext->GetHostScriptContext()->NotifyHostAboutModuleReady(this, this->errorObject);
                         });
@@ -341,8 +338,7 @@ namespace Js
                 // TODO: move this as a promise call? if parser is called from a different thread
                 // We'll need to call the bytecode gen in the main thread as we are accessing GC.
                 ScriptContext* scriptContext = GetScriptContext();
-                bool isScriptActive = scriptContext->GetThreadContext()->IsScriptActive();
-                Assert(!isScriptActive || this->promise != nullptr);
+                Assert(!scriptContext->GetThreadContext()->IsScriptActive() || this->promise != nullptr);
 
                 if (ModuleDeclarationInstantiation())
                 {
@@ -351,7 +347,7 @@ namespace Js
                 if (!hadNotifyHostReady && !WasEvaluated())
                 {
                     OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyHostAboutModuleReady %s (PrepareForModuleDeclarationInitialization)\n"), this->GetSpecifierSz());
-                    LEAVE_SCRIPT_IF(scriptContext, isScriptActive,
+                    LEAVE_SCRIPT_IF_ACTIVE(scriptContext,
                     {
                         hr = scriptContext->GetHostScriptContext()->NotifyHostAboutModuleReady(this, this->errorObject);
                     });
@@ -378,8 +374,6 @@ namespace Js
             OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentAsNeeded (childException)\n"), this->GetSpecifierSz());
             NotifyParentsAsNeeded();
 
-            bool isScriptActive = scriptContext->GetThreadContext()->IsScriptActive();
-
             if (this->promise != nullptr)
             {
                 SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this);
@@ -388,7 +382,7 @@ namespace Js
             if (this->promise != nullptr || (isRootModule && !hadNotifyHostReady))
             {
                 OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyHostAboutModuleReady %s (OnChildModuleReady)\n"), this->GetSpecifierSz());
-                LEAVE_SCRIPT_IF(scriptContext, isScriptActive,
+                LEAVE_SCRIPT_IF_ACTIVE(scriptContext,
                 {
                     hr = scriptContext->GetHostScriptContext()->NotifyHostAboutModuleReady(this, this->errorObject);
                 });


### PR DESCRIPTION
External calls create exception boundaries which we handle in LEAVE_SCRIPT_START_EX but don't handle in LEAVE_SCRIPT_IF if not currently in script.
