### PR TITLE
OS#17666127: (ARM64) fix bailout problem from indir offset legalization

### DIFF
--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -333,7 +333,9 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
                 Assert(IRType_IsSignedInt(largerType) || IRType_IsUnsignedInt(largerType));
                 IRType sourceType = baseOpnd->GetType();
                 IRType targetType = IRType_IsSignedInt(sourceType) ? IRType_EnsureSigned(largerType) : IRType_EnsureUnsigned(largerType);
-                IR::Instr* movInstr = Lowerer::InsertMove(baseOpnd->UseWithNewType(targetType, instr->m_func), baseOpnd, instr, false);
+                IR::RegOpnd * tmpOpnd = IR::RegOpnd::New(sourceType, instr->m_func);
+                Lowerer::InsertMove(tmpOpnd, baseOpnd, instr, false);
+                IR::Instr* movInstr = Lowerer::InsertMove(tmpOpnd->UseWithNewType(targetType, instr->m_func), tmpOpnd, instr, false);
                 indirOpnd->SetBaseOpnd(movInstr->GetDst()->AsRegOpnd());
             }
             else
@@ -343,7 +345,9 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
                 Assert(IRType_IsSignedInt(largerType) || IRType_IsUnsignedInt(largerType));
                 IRType sourceType = indexOpnd->GetType();
                 IRType targetType = IRType_IsSignedInt(sourceType) ? IRType_EnsureSigned(largerType) : IRType_EnsureUnsigned(largerType);
-                IR::Instr* movInstr = Lowerer::InsertMove(indexOpnd->UseWithNewType(targetType, instr->m_func), indexOpnd, instr, false);
+                IR::RegOpnd * tmpOpnd = IR::RegOpnd::New(sourceType, instr->m_func);
+                Lowerer::InsertMove(tmpOpnd, indexOpnd, instr, false);
+                IR::Instr* movInstr = Lowerer::InsertMove(tmpOpnd->UseWithNewType(targetType, instr->m_func), tmpOpnd, instr, false);
                 indirOpnd->SetIndexOpnd(movInstr->GetDst()->AsRegOpnd());
             }
         }


### PR DESCRIPTION
In ARM64 LEA is canonicalized into an ADD, and both operands of ADDs must be the same size, either 64 or 32. For LEAs with 64 bit bases and 32 bit offsets, this means converting the 32 bit offset to a 64 bit value with sign extention as needed. Calling UseWithNewType on an operand with the original 32 bit symbol resulted in the symbol's type changing as well, so the register allocator would not know that the symbol was supposed to be a tagged int, and it would not be retagged on bailout.
