### PR TITLE
OS#17830745 - ASSERT:  childModuleRecord->WasParsed() (chakra!<lambda_dd028cf82b8b597299372d12cc6b9c81>::operator()+84

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -367,7 +367,7 @@ namespace Js
     {
         OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("OnChildModuleReady(%s)\n"), this->GetSpecifierSz(), childModule->GetSpecifierSz());
         HRESULT hr = NOERROR;
-        if (childException != nullptr)
+        if (childException != nullptr || this->errorObject != nullptr)
         {
             // propagate the error up as needed.
             if (this->errorObject == nullptr)

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -367,7 +367,7 @@ namespace Js
     {
         OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("OnChildModuleReady(%s)\n"), this->GetSpecifierSz(), childModule->GetSpecifierSz());
         HRESULT hr = NOERROR;
-        if (childException != nullptr || this->errorObject != nullptr)
+        if (childException != nullptr)
         {
             // propagate the error up as needed.
             if (this->errorObject == nullptr)
@@ -836,7 +836,7 @@ namespace Js
         OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("ModuleDeclarationInstantiation(%s)\n"), this->GetSpecifierSz());
         ScriptContext* scriptContext = GetScriptContext();
 
-        if (this->WasDeclarationInitialized())
+        if (this->WasDeclarationInitialized() || this->errorObject != nullptr)
         {
             return false;
         }

--- a/test/es6module/bug_OS17830745.js
+++ b/test/es6module/bug_OS17830745.js
@@ -11,13 +11,16 @@
 // not parsed. That put module3 into error state, we should skip instantiating
 // module3.
 
-WScript.RegisterModuleSource('module0_e0565b64-3435-42c1-ad1f-6376fb7af915.js', `
-console.log('fail');`);
-WScript.RegisterModuleSource('module3_65eb7cb0-2a92-4a34-a368-2cfc1d6a3768.js', `import {
-  default as module3_localbinding_0,
-  default as module3_localbinding_1
-} from 'module0_e0565b64-3435-42c1-ad1f-6376fb7af915.js';
-export { } from 'module2_894411c7-94ec-4069-b8e1-10ab0d881f6e.js';
-console.log('fail');`);
-WScript.LoadScriptFile('module3_65eb7cb0-2a92-4a34-a368-2cfc1d6a3768.js', 'module');
+WScript.RegisterModuleSource('module0.js', `
+console.log('fail');
+`);
+
+WScript.RegisterModuleSource('module3.js', `
+import { default as _default } from 'module0.js';
+export { } from 'module2.js';
+console.log('fail');
+`);
+
+WScript.LoadScriptFile('module3.js', 'module');
+
 console.log('pass');

--- a/test/es6module/bug_OS17830745.js
+++ b/test/es6module/bug_OS17830745.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Resolving module2 will result in error (can't find the module file).
+// This causes us to mark module3 as having an error.
+// Later we resolve module0 which parses correctly.
+// This causes us to notify parents which will try to instantiate module3 because
+// module0 did not have an error. However, module3 has children modules which were 
+// not parsed. That put module3 into error state, we should skip instantiating
+// module3.
+
+WScript.RegisterModuleSource('module0_e0565b64-3435-42c1-ad1f-6376fb7af915.js', `
+console.log('fail');`);
+WScript.RegisterModuleSource('module3_65eb7cb0-2a92-4a34-a368-2cfc1d6a3768.js', `import {
+  default as module3_localbinding_0,
+  default as module3_localbinding_1
+} from 'module0_e0565b64-3435-42c1-ad1f-6376fb7af915.js';
+export { } from 'module2_894411c7-94ec-4069-b8e1-10ab0d881f6e.js';
+console.log('fail');`);
+WScript.LoadScriptFile('module3_65eb7cb0-2a92-4a34-a368-2cfc1d6a3768.js', 'module');
+console.log('pass');

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -161,4 +161,11 @@
       <tags>exclude_jshost</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS17830745.js</files>
+      <compile-flags>-MuteHostErrorMsg</compile-flags>
+      <tags>exclude_sanitize_address</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
If a parent module has multiple children and one child fails to load (results in error) but children which resolve later succeed, we will attempt to instantiate the parent module anyway because we forget that a previous child failed.

```javascript
import { default as d0 } from 'module0.js';
import { default as d1 } from 'module1.js'; // module1.js doesn't exist or otherwise results in error
```

In above, we resolve children modules from bottom-up so module1.js is resolved first. Since it results in an error we'll save the error in our parent module. Next we'll continue to resolve module0.js which parses successfully. Since the child didn't result in an error, we'll attempt to instantiate the parent module but not all children were parsed so we'll hit an assert.

Attempt to fix this by checking to see if parent module already has an error before calling to instantiate the parent module.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/17830745
