### PR TITLE
Improving memory usage of promises

### DIFF
--- a/lib/Runtime/Debug/TTSnapObjects.h
+++ b/lib/Runtime/Debug/TTSnapObjects.h
@@ -371,6 +371,7 @@ namespace TTD
         struct SnapPromiseInfo
         {
             uint32 Status;
+            bool isHandled;
             TTDVar Result;
 
             //

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -4993,9 +4993,9 @@ namespace Js
         return JavascriptPromiseReaction::New(capabilities, handler, this->scriptContext);
     }
 
-    Js::RecyclableObject* JavascriptLibrary::CreatePromise_TTD(uint32 status, Var result, JsUtil::List<Js::JavascriptPromiseReaction*, HeapAllocator>& resolveReactions, JsUtil::List<Js::JavascriptPromiseReaction*, HeapAllocator>& rejectReactions)
+    Js::RecyclableObject* JavascriptLibrary::CreatePromise_TTD(uint32 status, bool isHandled, Var result, SList<Js::JavascriptPromiseReaction*, HeapAllocator>& resolveReactions, SList<Js::JavascriptPromiseReaction*, HeapAllocator>& rejectReactions)
     {
-        return JavascriptPromise::InitializePromise_TTD(this->scriptContext, status, result, resolveReactions, rejectReactions);
+        return JavascriptPromise::InitializePromise_TTD(this->scriptContext, status, isHandled, result, resolveReactions, rejectReactions);
     }
 
     JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper* JavascriptLibrary::CreateAlreadyDefinedWrapper_TTD(bool alreadyDefined)

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -643,7 +643,7 @@ namespace Js
         Js::JavascriptPromiseCapability* CreatePromiseCapability_TTD(Var promise, Var resolve, Var reject);
         Js::JavascriptPromiseReaction* CreatePromiseReaction_TTD(RecyclableObject* handler, JavascriptPromiseCapability* capabilities);
 
-        Js::RecyclableObject* CreatePromise_TTD(uint32 status, Var result, JsUtil::List<Js::JavascriptPromiseReaction*, HeapAllocator>& resolveReactions, JsUtil::List<Js::JavascriptPromiseReaction*, HeapAllocator>& rejectReactions);
+        Js::RecyclableObject* CreatePromise_TTD(uint32 status, bool isHandled, Var result, SList<Js::JavascriptPromiseReaction*, HeapAllocator>& resolveReactions, SList<Js::JavascriptPromiseReaction*, HeapAllocator>& rejectReactions);
         JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper* CreateAlreadyDefinedWrapper_TTD(bool alreadyDefined);
         Js::RecyclableObject* CreatePromiseResolveOrRejectFunction_TTD(RecyclableObject* promise, bool isReject, JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper* alreadyResolved);
         Js::RecyclableObject* CreatePromiseReactionTaskFunction_TTD(JavascriptPromiseReaction* reaction, Var argument);

--- a/test/es6/ES6PromiseAsync.baseline
+++ b/test/es6/ES6PromiseAsync.baseline
@@ -61,6 +61,7 @@ Executing test #58 - Promise.prototype.finally passes through result for Reject 
 Executing test #59 - Promise.prototype.finally passes through result for Resolve with not callable argument
 Executing test #60 - Promise.prototype.finally throws own rejection after a resolved promise
 Executing test #61 - Promise.prototype.finally throws own rejection after a rejected promise
+Executing test #62 - Ensure Multiple then handlers on a single promise are executed in correct order
 
 Completion Results:
 Test #1 - Success handler called with result = basic:success
@@ -105,6 +106,7 @@ Test #52 - Error handler #1 called with err = 'success'
 Test #53 - Success handler #1 called with res = 'success'
 Test #54 - Success finally handler called for resolved promise without value
 Test #55 - Success finally handler called for rejected promise without value
+Test #62 - val is 0(Expect 0)
 Test #6 - Error handler #2 called with err = thenable.get:error!
 Test #8 - Error handler #2 called with err = success.throw:error
 Test #9 - Error handler #2 called with err = error.throw:error

--- a/test/es6/ES6PromiseAsync.js
+++ b/test/es6/ES6PromiseAsync.js
@@ -1167,7 +1167,27 @@ var tests = [
                         (e) => { if(e == "own rejection") { echo(`Test #${index} - Success - own rejection passed through finally`); }
                             else {echo(`Test #${index} - Failed - wrong result ${e} passed through finally`); } } );
         }
-    }
+    },
+    {
+        name: "Ensure Multiple then handlers on a single promise are executed in correct order",
+        body: function (index) {
+            let val = -7
+            let resolveFunc;
+            const p = new Promise((resolve, reject) => {
+                resolveFunc = resolve;
+            });
+            p.then(() => {
+                val = val * 3;
+            });
+            p.then(() => {
+                val = val + 21
+            });
+            p.then(() => {
+                echo('Test #' + index + ' - val is ' + val + '(Expect 0)');
+            });
+            resolveFunc();
+        }
+    },
 ];
 
 var index = 1;


### PR DESCRIPTION
This change improve memory usage of JavascriptPromises.  On a 64-bit build, we should go from 224 bytes for a promise with one reaction to 116 bytes.

Most of the gains here are by using a single SList for both reject & resolve reactions, instead of using two JsUtil::List instances.  This optimization assumes that the common case is having one or two "then" calls per promise.