### PR TITLE
OS#10368428: Failfast if IsExternalUnicodeLibraryAvailable would return false.

### DIFF
--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -77,6 +77,13 @@ namespace Js {
         ReportFatalException(NULL, E_FAIL, Fatal_Internal_Error, scenario);
     }
 
+    void Throw::FatalInternalGlobalizationError()
+    {
+        AssertMsg(false, "Failure in initializing Globalization library");
+        int scenario = 2;
+        ReportFatalException(NULL, E_FAIL, Fatal_Internal_Error, scenario);
+    }
+
     void Throw::FatalProjectionError()
     {
         RaiseException((DWORD)DBG_TERMINATE_PROCESS, EXCEPTION_NONCONTINUABLE, 0, NULL);

--- a/lib/Common/Exceptions/Throw.h
+++ b/lib/Common/Exceptions/Throw.h
@@ -21,6 +21,8 @@ namespace Js {
         static void __declspec(noreturn) InternalError();
         static void __declspec(noreturn) FatalInternalError();
         static void __declspec(noreturn) FatalInternalErrorEx(int scenario);
+        static void __declspec(noreturn) FatalInternalGlobalizationError();
+
         static void __declspec(noreturn) FatalProjectionError();
 #if ENABLE_JS_REENTRANCY_CHECK
         static void __declspec(noreturn) FatalJsReentrancyError();

--- a/lib/Parser/CharClassifier.cpp
+++ b/lib/Parser/CharClassifier.cpp
@@ -411,13 +411,11 @@ Js::CharClassifier::CharClassifier(void)
     bool isES6UnicodeModeEnabled = CONFIG_FLAG(ES6Unicode);
     bool isFullUnicodeSupportAvailable = PlatformAgnostic::UnicodeText::IsExternalUnicodeLibraryAvailable();
 
-#ifdef NTBUILD
     AssertMsg(isFullUnicodeSupportAvailable, "Windows.Globalization needs to present with IUnicodeCharacterStatics support for Chakra.dll to work");
     if (!isFullUnicodeSupportAvailable)
     {
-        Js::Throw::FatalInternalError();
+        Js::Throw::FatalInternalGlobalizationError();
     }
-#endif
 
     // If we're in ES6 mode, and we have full support for Unicode character classification
     // from an external library, then use the ES6/Surrogate pair supported versions of the functions
@@ -450,7 +448,6 @@ Js::CharClassifier::CharClassifier(void)
         getBigCharFlagsFunc = &CharClassifier::GetBigCharFlagsES5;
     }
 #endif
-
 }
 
 const OLECHAR* Js::CharClassifier::SkipWhiteSpaceNonSurrogate(LPCOLESTR psz, const CharClassifier *instance)

--- a/lib/Parser/CharClassifier.cpp
+++ b/lib/Parser/CharClassifier.cpp
@@ -411,11 +411,13 @@ Js::CharClassifier::CharClassifier(void)
     bool isES6UnicodeModeEnabled = CONFIG_FLAG(ES6Unicode);
     bool isFullUnicodeSupportAvailable = PlatformAgnostic::UnicodeText::IsExternalUnicodeLibraryAvailable();
 
+#if INTL_ICU || INTL_WINGLOB // don't assert in _no_icu builds (where there is no i18n library, by design)
     AssertMsg(isFullUnicodeSupportAvailable, "Windows.Globalization needs to present with IUnicodeCharacterStatics support for Chakra.dll to work");
     if (!isFullUnicodeSupportAvailable)
     {
         Js::Throw::FatalInternalGlobalizationError();
     }
+#endif
 
     // If we're in ES6 mode, and we have full support for Unicode character classification
     // from an external library, then use the ES6/Surrogate pair supported versions of the functions

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
@@ -408,18 +408,16 @@ namespace PlatformAgnostic
                     {
                         return true;
                     }
-#ifdef NTBUILD
                     else
                     {
                         // did not find winGlobCharApi
-                        Js::Throw::FatalInternalError();
+                        Js::Throw::FatalInternalGlobalizationError();
                     }
                 }
                 else
                 {
                     // failed to initialize Windows Globalization
-                    Js::Throw::FatalInternalError();
-#endif
+                    Js::Throw::FatalInternalGlobalizationError();
                 }
 
                 return false;

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
@@ -399,8 +399,7 @@ namespace PlatformAgnostic
                 Js::WindowsGlobalizationAdapter* globalizationAdapter = threadContext->GetWindowsGlobalizationAdapter();
                 Js::DelayLoadWindowsGlobalization* globLibrary = threadContext->GetWindowsGlobalizationLibrary();
                 HRESULT hr = globalizationAdapter->EnsureDataTextObjectsInitialized(globLibrary);
-                // Failed to load windows.globalization.dll or jsintl.dll. No unicodeStatics support
-                // in that case.
+                // Failed to load windows.globalization.dll or jsintl.dll. No unicodeStatics support in that case.
                 if (SUCCEEDED(hr))
                 {
                     auto winGlobCharApi = globalizationAdapter->GetUnicodeStatics();
@@ -420,7 +419,9 @@ namespace PlatformAgnostic
                     Js::Throw::FatalInternalGlobalizationError();
                 }
 
-                return false;
+#ifndef DBG
+                return false; // in debug builds, this is unreachable code
+#endif
             }, false);
         }
 

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
@@ -407,6 +407,7 @@ namespace PlatformAgnostic
                     {
                         return true;
                     }
+#if INTL_ICU || INTL_WINGLOB // don't assert in _no_icu builds (where there is no i18n library, by design)
                     else
                     {
                         // did not find winGlobCharApi
@@ -417,9 +418,10 @@ namespace PlatformAgnostic
                 {
                     // failed to initialize Windows Globalization
                     Js::Throw::FatalInternalGlobalizationError();
+#endif
                 }
 
-#ifndef DBG
+#if (INTL_ICU || INTL_WINGLOB) && !defined(DBG)
                 return false; // in debug builds, this is unreachable code
 #endif
             }, false);

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
@@ -408,6 +408,18 @@ namespace PlatformAgnostic
                     {
                         return true;
                     }
+#ifdef NTBUILD
+                    else
+                    {
+                        // did not find winGlobCharApi
+                        Js::Throw::FatalInternalError();
+                    }
+                }
+                else
+                {
+                    // failed to initialize Windows Globalization
+                    Js::Throw::FatalInternalError();
+#endif
                 }
 
                 return false;


### PR DESCRIPTION
The only caller of IsExternalUnicodeLibraryAvailable  (Js::CharClassifier::CharClassifier) will failfast when this method returns false, so move the failfast closer the cause of the problem to improve diagnosis and attribution by stack. Also create a specific failfast type for this failure mode to improve attribution.