### PR TITLE
OS#17895855 - Concise-body lambda function followed by in keyword is not handled correctly

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -801,18 +801,18 @@ private:
 
     template<bool buildAST> void ParseComputedName(ParseNodePtr* ppnodeName, LPCOLESTR* ppNameHint, LPCOLESTR* ppFullNameHint = nullptr, uint32 *pNameLength = nullptr, uint32 *pShortNameOffset = nullptr);
     template<bool buildAST> ParseNodeBin * ParseMemberGetSet(OpCode nop, LPCOLESTR* ppNameHint);
-    template<bool buildAST> ParseNode * ParseFncDeclCheckScope(ushort flags, bool resetParsingSuperRestrictionState = true);
-    template<bool buildAST> ParseNodeFnc * ParseFncDeclNoCheckScope(ushort flags, LPCOLESTR pNameHint = nullptr, const bool needsPIDOnRCurlyScan = false, bool resetParsingSuperRestrictionState = true, bool fUnaryOrParen = false);
-    template<bool buildAST> ParseNodeFnc * ParseFncDeclInternal(ushort flags, LPCOLESTR pNameHint, const bool needsPIDOnRCurlyScan, bool resetParsingSuperRestrictionState, bool fUnaryOrParen, bool noStmtContext);
+    template<bool buildAST> ParseNode * ParseFncDeclCheckScope(ushort flags, bool resetParsingSuperRestrictionState = true, bool fAllowIn = true);
+    template<bool buildAST> ParseNodeFnc * ParseFncDeclNoCheckScope(ushort flags, LPCOLESTR pNameHint = nullptr, const bool needsPIDOnRCurlyScan = false, bool resetParsingSuperRestrictionState = true, bool fUnaryOrParen = false, bool fAllowIn = true);
+    template<bool buildAST> ParseNodeFnc * ParseFncDeclInternal(ushort flags, LPCOLESTR pNameHint, const bool needsPIDOnRCurlyScan, bool resetParsingSuperRestrictionState, bool fUnaryOrParen, bool noStmtContext, bool fAllowIn = true);
     template<bool buildAST> void ParseFncName(ParseNodeFnc * pnodeFnc, ushort flags, IdentPtr* pFncNamePid = nullptr);
     template<bool buildAST> void ParseFncFormals(ParseNodeFnc * pnodeFnc, ParseNodeFnc * pnodeParentFnc, ushort flags, bool isTopLevelDeferredFunc = false);
-    template<bool buildAST> void ParseFncDeclHelper(ParseNodeFnc * pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly, bool skipFormals = false, IdentPtr* pFncNamePid = nullptr);
-    template<bool buildAST> void ParseExpressionLambdaBody(ParseNodeFnc * pnodeFnc);
+    template<bool buildAST> void ParseFncDeclHelper(ParseNodeFnc * pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly, bool skipFormals = false, IdentPtr* pFncNamePid = nullptr, bool fAllowIn = true);
+    template<bool buildAST> void ParseExpressionLambdaBody(ParseNodeFnc * pnodeFnc, bool fAllowIn = true);
     template<bool buildAST> void UpdateCurrentNodeFunc(ParseNodeFnc * pnodeFnc, bool fLambda);
     bool FncDeclAllowedWithoutContext(ushort flags);
-    void FinishFncDecl(ParseNodeFnc * pnodeFnc, LPCOLESTR pNameHint, bool fLambda, bool skipCurlyBraces = false);
-    void ParseTopLevelDeferredFunc(ParseNodeFnc * pnodeFnc, ParseNodeFnc * pnodeFncParent, LPCOLESTR pNameHint, bool fLambda, bool *pNeedScanRCurly = nullptr);
-    void ParseNestedDeferredFunc(ParseNodeFnc * pnodeFnc, bool fLambda, bool *pNeedScanRCurly, bool *pStrictModeTurnedOn);
+    void FinishFncDecl(ParseNodeFnc * pnodeFnc, LPCOLESTR pNameHint, bool fLambda, bool skipCurlyBraces = false, bool fAllowIn = true);
+    void ParseTopLevelDeferredFunc(ParseNodeFnc * pnodeFnc, ParseNodeFnc * pnodeFncParent, LPCOLESTR pNameHint, bool fLambda, bool *pNeedScanRCurly = nullptr, bool fAllowIn = true);
+    void ParseNestedDeferredFunc(ParseNodeFnc * pnodeFnc, bool fLambda, bool *pNeedScanRCurly, bool *pStrictModeTurnedOn, bool fAllowIn = true);
     void CheckStrictFormalParameters();
     ParseNodeVar * AddArgumentsNodeToVars(ParseNodeFnc * pnodeFnc);
     ParseNodeVar * InsertVarAtBeginning(ParseNodeFnc * pnodeFnc, IdentPtr pid);
@@ -845,7 +845,7 @@ private:
     LPCOLESTR AppendNameHints(LPCOLESTR leftStr, uint32 leftLen, LPCOLESTR rightStr, uint32 rightLen, uint32 *pNameLength, uint32 *pShortNameOffset, bool ignoreAddDotWithSpace = false, bool wrapInBrackets = false);
     WCHAR * AllocateStringOfLength(ULONG length);
 
-    void FinishFncNode(ParseNodeFnc * pnodeFnc);
+    void FinishFncNode(ParseNodeFnc * pnodeFnc, bool fAllowIn = true);
 
     template<bool buildAST> bool ParseOptionalExpr(
         ParseNodePtr* pnode,

--- a/test/es6/bug_OS17895855.js
+++ b/test/es6/bug_OS17895855.js
@@ -1,0 +1,47 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Concise-body lambda function containing in expression",
+        body: function () {
+            var l = a => '0' in [123]
+            assert.areEqual("a => '0' in [123]", l.toString(), "consise-body lambda containing in expression");
+            assert.isTrue(l(), "in expression can be the concise-body lambda body");
+        }
+    },
+    {
+        name: "Concise-body lambda function as var decl initializer in a for..in loop",
+        body: function () {
+            for (var a = () => 'pass' in []) {
+                assert.fail("Should not enter for loop since [] has no properties");
+            }
+            assert.areEqual('pass', a(), "var decl from for loop should have initialized a");
+
+            for (var a2 = () => 'pass' in [123]) {
+                assert.areEqual('0', a2, "Should enter the for loop with property '0'");
+            }
+            assert.areEqual('0', a2, "var decl from for loop should have been assigned to during iteration");
+        }
+    },
+    {
+        name: "Concise-body lambda function as var decl initializer in a for..in..in loop",
+        body: function () {
+            for (var b = () => 'pass' in [] in []) {
+              assert.fail("Should not enter for loop");
+            }
+            assert.areEqual('pass', b(), "var decl from for loop should still have initial value");
+
+            for (var b2 = () => 'pass' in '0' in [123]) {
+              assert.fail("var decl initialization turns into var b2 = () => 'pass' in true which should not enter this loop");
+            }
+            assert.areEqual('pass', b2(), "var decl was not overriden inside the for loop");
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1486,4 +1486,10 @@
     <compile-flags>-args summary -endargs</compile-flags>
   </default>
 </test>
+<test>
+  <default>
+    <files>bug_OS17895855.js</files>
+    <compile-flags>-args summary -endargs</compile-flags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
At the moment we parse this as a postfix operator, it should be part of the lambda body except for when we're parsing a for..in loop header.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/17895855
