### PR TITLE
don't create background allocators for OOP JIT

### DIFF
--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -138,6 +138,7 @@ private:
 
     InProcCodeGenAllocators *EnsureForegroundAllocators(PageAllocator * pageAllocator)
     {
+        Assert(!JITManager::GetJITManager()->IsOOPJITEnabled());
         if (this->foregroundAllocators == nullptr)
         {
             this->foregroundAllocators = CreateAllocators(pageAllocator);
@@ -178,7 +179,10 @@ private:
 
     virtual void ProcessorThreadSpecificCallBack(PageAllocator * pageAllocator) override
     {
-        AllocateBackgroundAllocators(pageAllocator);
+        if (!JITManager::GetJITManager()->IsOOPJITEnabled())
+        {
+            AllocateBackgroundAllocators(pageAllocator);
+        }
     }
 
     static ExecutionMode PrejitJitMode(Js::FunctionBody *const functionBody);


### PR DESCRIPTION
Aside from being useless, this can cause slowdown during NativeCodeGenerator::Close, since we call `DelayDeletingFunctionTable::Clear` when cleaning up the allocator, which is an expensive process that would otherwise be called from a background thread.

OS: 17334521