### PR TITLE
MSFT:17672777 Fix two pass concurrent sweep states.

### DIFF
--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -85,9 +85,9 @@ enum CollectionState
     CollectionStateConcurrentSweep        = Collection_ConcurrentSweep | Collection_ExecutingConcurrent,      // concurrent sweep
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     CollectionStateConcurrentSweepPass1 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 1
-    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait,                                   // concurrent sweep wait state after Pass 1 has finished
+    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait | Collection_FinishConcurrent,      // concurrent sweep wait state after Pass 1 has finished
     CollectionStateConcurrentSweepPass2 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 2
-    CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait,                                   // concurrent sweep wait state after Pass 2 has finished
+    CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait | Collection_FinishConcurrent,     // concurrent sweep wait state after Pass 2 has finished
 #endif
     CollectionStateTransferSweptWait      = Collection_ConcurrentSweep | Collection_FinishConcurrent,         // transfer swept objects (after concurrent sweep)
 #endif


### PR DESCRIPTION
It is possible that AbortConcurrent gets called while we are in the concurrent sweep pass1 wait state. We handle this case correctly, just need to indicate that these can also be finished states for concurrent GC.