### PR TITLE
Fixing null ScriptContext issue in JavascriptWeakMap

### DIFF
--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -42,7 +42,7 @@ namespace Js
             return nullptr;
         }
 
-        if (key->GetScriptContext()->GetLibrary()->GetUndefined() == weakMapKeyData)
+        if (key->GetLibrary()->GetUndefined() == weakMapKeyData)
         {
             return nullptr;
         }


### PR DESCRIPTION
Fixes OS: 18010051 
Fixing issue where ScriptContext can be null if closed before JavascriptWeakMap gets finalized