### PR TITLE
Built-in properties (like Array.length) should not be enumerated even when they are defined in Object.prototype

### DIFF
--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -210,6 +210,18 @@ namespace Js
                     return nullptr;
                 }
 
+                // Ignore special properties (ex: Array.length)
+                uint specialPropertyCount = this->shadowData->currentObject->GetSpecialPropertyCount();
+                if (specialPropertyCount > 0)
+                {
+                    PropertyId const* specialPropertyIds = this->shadowData->currentObject->GetSpecialPropertyIds();
+                    Assert(specialPropertyIds != nullptr);
+                    for (uint i = 0; i < specialPropertyCount; i++)
+                    {
+                        TestAndSetEnumerated(specialPropertyIds[i]);
+                    }
+                }
+
                 RecyclableObject * object;
                 if (!this->enumeratingPrototype)
                 {

--- a/test/Bugs/bug_OS17614914.js
+++ b/test/Bugs/bug_OS17614914.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+Object.prototype.length = undefined;
+var ary = Array();
+ary.prop1 = 1;
+Object.defineProperty(ary, "prop2", {
+    value: 1,
+    enumerable: false
+});
+for (var prop in ary) {
+    if (prop !== "prop1") {
+        console.log(`Fail: ${prop} property should not show in for-in`);
+    }
+}
+console.log("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -501,4 +501,9 @@
       <files>withSplitScope.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS17614914.js</files>
+    </default>
+  </test>  
 </regress-exe>


### PR DESCRIPTION
In bug 17614914 JIT is causing a bad code gen, but the root problem is that with a script like:

```
Object.prototype.length = undefined;
var ary = new Array();
var func0 = function() {
    for (var _strvar2 in ary) {
        console.log(_strvar2);
    }
};
func0();
```

a built-in property like Array.length should not be enumerated even if it is defined in Object.prototype.
This PR fixes this problem by ignoring the builtin properties in ForInObjectEnumerator::MoveAndGetNext().