### PR TITLE
MSFT:18075741 Fail fast if the concurrent threads are not shutdown when Recycler is deleted.

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -31,9 +31,7 @@ class JavascriptThreadService;
 struct RecyclerMemoryData;
 #endif
 
-#if DBG
 class ThreadContext;
-#endif
 
 namespace Memory
 {
@@ -535,9 +533,7 @@ struct CollectionParam
 #if ENABLE_CONCURRENT_GC
 class RecyclerParallelThread
 {
-#if DBG
     friend class ThreadContext;
-#endif
 
 public:
     typedef void (Recycler::* WorkFunc)();
@@ -1805,9 +1801,8 @@ private:
     friend class HeapInfo;
     friend class HeapInfoManager;
     friend class LargeHeapBucket;
-#if DBG
     friend class ThreadContext;
-#endif
+
     template <typename TBlockType>
     friend class HeapBucketT;
     template <typename TBlockType>

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -527,9 +527,9 @@ ThreadContext::~ThreadContext()
         Assert(this->debugManager == nullptr);
 #endif
 
-#if DBG && ENABLE_CONCURRENT_GC && defined(_WIN32)
-        AssertMsg(recycler->concurrentThread == NULL, "Recycler background thread should have been shutdown before destroying Recycler.");
-        AssertMsg((recycler->parallelThread1.concurrentThread == NULL) && (recycler->parallelThread2.concurrentThread == NULL), "Recycler parallelThread(s) should have been shutdown before destroying Recycler.");
+#if ENABLE_CONCURRENT_GC && defined(_WIN32)
+        AssertOrFailFastMsg(recycler->concurrentThread == NULL, "Recycler background thread should have been shutdown before destroying Recycler.");
+        AssertOrFailFastMsg((recycler->parallelThread1.concurrentThread == NULL) && (recycler->parallelThread2.concurrentThread == NULL), "Recycler parallelThread(s) should have been shutdown before destroying Recycler.");
 #endif
 
         HeapDelete(recycler);


### PR DESCRIPTION
We haven't seen this happen in the wild. But JSHost Fuzzing tools are hitting this pretty often. It seems the fuzzer is using test flavor. Converting these asserts to fail fast to help with the investigation.