### PR TITLE
OS#16526223: Keep writes to 'prototype' from going through inline cache so that we get the necessary runtime behavior

### DIFF
--- a/lib/Runtime/Base/PropertyRecord.cpp
+++ b/lib/Runtime/Base/PropertyRecord.cpp
@@ -68,6 +68,13 @@ namespace Js
         }
     }
 
+    bool PropertyRecord::ShouldDisableWriteCache() const
+    {
+        // We can't cache stores to the 'prototype' property of function objects. We must go through the runtime and clear the constructor cache.
+        // We could consider treating 'prototype' as an accessor on JavascriptFunction and friends, though this seems like it will grow the object.
+        return pid == PropertyIds::prototype;
+    }
+
 #ifdef DEBUG
     // This is only used to assert that integer property names are not passed into
     // the GetSetter, GetProperty, SetProperty etc methods that take JavascriptString

--- a/lib/Runtime/Base/PropertyRecord.h
+++ b/lib/Runtime/Base/PropertyRecord.h
@@ -77,6 +77,8 @@ namespace Js
         bool IsBound() const { return isBound; }
         bool IsSymbol() const { return isSymbol; }
 
+        bool ShouldDisableWriteCache() const;
+
         void SetHash(uint hash) const
         {
             this->hash = hash;

--- a/lib/Runtime/Library/PropertyRecordUsageCache.h
+++ b/lib/Runtime/Library/PropertyRecordUsageCache.h
@@ -30,6 +30,8 @@ namespace Js
         void RegisterCacheHit() { ++this->hitRate; };
         bool ShouldUseCache() const;
 
+        bool ShouldDisableWriteCache() const { return propertyRecord && propertyRecord->ShouldDisableWriteCache(); }
+
         static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyRecordUsageCache, ldElemInlineCache); }
         static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyRecordUsageCache, stElemInlineCache); }
         static uint32 GetOffsetOfHitRate() { return offsetof(PropertyRecordUsageCache, hitRate); }

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -39,6 +39,10 @@ namespace Js
         info->prop = prop;
         info->propertyRecordUsageCache = propertyRecordUsageCache;
         SetCacheInfo(info, polymorphicInlineCache, allowResizing);
+        if (propertyRecordUsageCache && propertyRecordUsageCache->ShouldDisableWriteCache())
+        {
+            info->ClearInfoFlag(CacheInfoFlag::enableStoreFieldCacheFlag);
+        }
     }
 
     void PropertyValueInfo::SetCacheInfo(_Out_ PropertyValueInfo* info, _In_ PolymorphicInlineCache *const polymorphicInlineCache, bool allowResizing)

--- a/test/Function/prototype_set.js
+++ b/test/Function/prototype_set.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function f() {
+    function inner() { }
+    inner.__proto__ = {b:'b'};  // Put enumerable property into prototype chain
+    new inner();                // Populate ctor cache
+    for (var s in inner) {      // Cache 'prototype' in TypePropertyCache while enumerating
+        inner[s];
+    }
+    inner.prototype = {sox:'red'}; // Set new prototype, using inline cache on 2nd invocation
+    return new inner();            // On 2nd invocation, try to construct using stale ctor cache
+}
+
+f();
+var Boston = f();
+if (Boston.sox === 'red')
+    WScript.Echo('pass');
+

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -228,6 +228,11 @@
   </test>
   <test>
     <default>
+      <files>prototype_set.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>TApply1.js</files>
       <baseline>TApply1.baseline</baseline>
     </default>


### PR DESCRIPTION
Writes to the prototype property of JavascriptFunction must go through the runtime so that the constructor cache, etc., can be invalidated. Enumeration provided a way to record a write to 'prototype' in an inline cache so that the runtime could be skipped. One solution would be to make 'prototype' an accessor property on JavascriptFunction, but this would probably grow function objects and slow down loads of the property. Instead, let PropertyRecord indicate that we should disable caching of writes to the property and disable store field cache in PropertyValueInfo.