### PR TITLE
Fix typo in cleanup for poisoning code

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -16266,7 +16266,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             if (baseValueType.IsLikelyTypedArray())
             {
                 int lengthOffset;
-                lengthOffset = GetArrayOffsetOfHeadSegment(baseValueType);
+                lengthOffset = GetArrayOffsetOfLength(baseValueType);
                 headSegmentLengthOpnd = IR::IndirOpnd::New(arrayOpnd, lengthOffset, TyUint32, m_func);
                 autoReuseHeadSegmentLengthOpnd.Initialize(headSegmentLengthOpnd, m_func);
             }


### PR DESCRIPTION
Backporting this fix to release/1.8 due to special request.