### PR TITLE
Scan interior pointers from GC stack roots when hosted by a native GC host

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -938,6 +938,18 @@ Recycler::SetIsInScript(bool isInScript)
 }
 
 bool
+Recycler::HasNativeGCHost() const
+{
+    return this->hasNativeGCHost;
+}
+
+void
+Recycler::SetHasNativeGCHost()
+{
+    this->hasNativeGCHost = true;
+}
+
+bool
 Recycler::NeedOOMRescan() const
 {
     return this->needOOMRescan;
@@ -1680,7 +1692,7 @@ Recycler::ScanStack()
 
     BEGIN_DUMP_OBJECT(this, _u("Registers"));
     // We will not scan interior pointers on stack if we are not in script or we are in mem-protect mode.
-    if (!this->isInScript || this->IsMemProtectMode())
+    if (!this->HasNativeGCHost() && (!this->isInScript || this->IsMemProtectMode()))
     {
         if (doSpecialMark)
         {
@@ -1699,7 +1711,7 @@ Recycler::ScanStack()
     {
         // We may have interior pointers on the stack such as pointers in the middle of the character buffers backing a JavascriptString or SubString object.
         // To prevent UAFs of these buffers after the GC we will always do MarkInterior for the pointers on stack. This is necessary only when we are doing a
-        // GC while running a script as that is when the possiblity of a UAF after GC exists.
+        // GC while running a script or when we have a host who allocates objects on the Chakra heap.
         if (doSpecialMark)
         {
             ScanMemoryInline<true, true /* forceInterior */>(this->savedThreadContext.GetRegisters(), sizeof(void*) * SavedRegisterState::NumRegistersToSave
@@ -1715,7 +1727,7 @@ Recycler::ScanStack()
 
     BEGIN_DUMP_OBJECT(this, _u("Stack"));
     // We will not scan interior pointers on stack if we are not in script or we are in mem-protect mode.
-    if (!this->isInScript || this->IsMemProtectMode())
+    if (!this->HasNativeGCHost() && (!this->isInScript || this->IsMemProtectMode()))
     {
         if (doSpecialMark)
         {
@@ -1732,7 +1744,7 @@ Recycler::ScanStack()
     {
         // We may have interior pointers on the stack such as pointers in the middle of the character buffers backing a JavascriptString or SubString object.
         // To prevent UAFs of these buffers after the GC we will always do MarkInterior for the pointers on stack. This is necessary only when we are doing a
-        // GC while running a script as that is when the possiblity of a UAF after GC exists.
+        // GC while running a script or when we have a host who allocates objects on the Chakra heap.
         if (doSpecialMark)
         {
             ScanMemoryInline<true, true /* forceInterior */>((void**)stackTop, stackScanned

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -191,6 +191,7 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     allowDispose(false),
     inDisposeWrapper(false),
     hasDisposableObject(false),
+    hasNativeGCHost(false),
     tickCountNextDispose(0),
     transientPinnedObject(nullptr),
     pinnedObjectMap(1024, HeapAllocator::GetNoMemProtectInstance()),

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -908,6 +908,7 @@ private:
     bool inDisposeWrapper;
     bool needOOMRescan;
     bool hasDisposableObject;
+    bool hasNativeGCHost;
     DWORD tickCountNextDispose;
     bool inExhaustiveCollection;
     bool hasExhaustiveCandidate;
@@ -1168,6 +1169,8 @@ public:
     void SetIsThreadBound();
     void SetIsScriptActive(bool isScriptActive);
     void SetIsInScript(bool isInScript);
+    bool HasNativeGCHost() const;
+    void SetHasNativeGCHost();
     bool ShouldIdleCollectOnExit();
     void ScheduleNextCollection();
 


### PR DESCRIPTION
Currently, we skip scanning interior pointers from GC stack roots if we are not running script (or if we are in mem protect mode). When host objects are also placed on the Chakra heap for GC purposes, we must scan interior pointers from the stack even when not running script. To scope this fix to just native GC host scenarios, and to avoid regressing JSRT scenarios, we are introducing a bit on the recycler that will be set for native GC hosts. If this bit is set, we will always scan interior pointers from the stack, and if it is not set, we will continue doing what we do currently.

In order to set this bit, an API is being exposed on the JS thread service that is published and can be called by the host.