### PR TITLE
Fix assert for DeepCopy of DynamicObject with TaggedInt

### DIFF
--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -73,7 +73,7 @@ namespace Js
 #else
             dstSlots[i] = srcSlots[i];
 #endif
-            Assert(!ThreadContext::IsOnStack(dstSlots[i]));
+            Assert(!ThreadContext::IsOnStack(dstSlots[i]) || TaggedInt::Is(dstSlots[i]));
         }
 
         if (propertyCount > inlineSlotCapacity)
@@ -106,7 +106,7 @@ namespace Js
                 Assert(!ThreadContext::IsOnStack(instance->auxSlots[i]));
                 auxSlots[i] = instance->auxSlots[i];
 #endif
-                Assert(!ThreadContext::IsOnStack(auxSlots[i]));
+                Assert(!ThreadContext::IsOnStack(auxSlots[i]) || TaggedInt::Is(dstSlots[i]));
             }
         }
 


### PR DESCRIPTION
From earlier DeepCopy fixes, an assert was added to ensure that deep copied slots were never on the stack. However, TaggedInts can create a false positive, causing the assert to fail. The fix is to account for TaggedInts.
