### PR TITLE
Adding CPU times to timing counters where UI thread is blocked by GC

### DIFF
--- a/lib/Common/Memory/RecyclerTelemetryInfo.cpp
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.cpp
@@ -252,6 +252,41 @@ namespace Memory
         }
     }
 
+
+    void RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeUser(uint64 userMicroseconds, RecyclerWaitReason caller)
+    {
+        RecyclerTelemetryGCPassStats* lastPassStats = this->GetLastPassStats();
+#ifdef DBG
+        if (this->inPassActiveState)
+        {
+            AssertMsg(lastPassStats != nullptr && lastPassStats->isGCPassActive == true, "unexpected Value in  RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeUser");
+        }
+#endif
+
+        if (this->inPassActiveState && lastPassStats != nullptr)
+        {
+            AssertOnValidThread(this, RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeUser);
+            lastPassStats->uiThreadBlockedCpuTimesUser[caller] += userMicroseconds;
+        }
+    }
+
+    void RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeKernel(uint64 kernelMicroseconds, RecyclerWaitReason caller)
+    {
+        RecyclerTelemetryGCPassStats* lastPassStats = this->GetLastPassStats();
+#ifdef DBG
+        if (this->inPassActiveState)
+        {
+            AssertMsg(lastPassStats != nullptr && lastPassStats->isGCPassActive == true, "unexpected Value in  RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeKernel");
+        }
+#endif
+
+        if (this->inPassActiveState && lastPassStats != nullptr)
+        {
+            AssertOnValidThread(this, RecyclerTelemetryInfo::IncrementUserThreadBlockedCpuTimeKernel);
+            lastPassStats->uiThreadBlockedCpuTimesKernel[caller] += kernelMicroseconds;
+        }
+    }
+
     bool RecyclerTelemetryInfo::IsOnScriptThread() const
     {
         bool isValid = false;

--- a/lib/Common/Memory/RecyclerTelemetryInfo.h
+++ b/lib/Common/Memory/RecyclerTelemetryInfo.h
@@ -59,6 +59,8 @@ namespace Memory
         Js::TickDelta computeBucketStatsElapsedTime;
         FILETIME lastScriptExecutionEndTime;
         Js::TickDelta uiThreadBlockedTimes[static_cast<size_t>(RecyclerWaitReason::Other) + 1];
+        uint64 uiThreadBlockedCpuTimesUser[static_cast<size_t>(RecyclerWaitReason::Other) + 1];
+        uint64 uiThreadBlockedCpuTimesKernel[static_cast<size_t>(RecyclerWaitReason::Other) + 1];
         bool isInScript;
         bool isScriptActive;
         bool isGCPassActive;
@@ -99,7 +101,9 @@ namespace Memory
         void StartPass(CollectionState collectionState);
         void EndPass(CollectionState collectionState);
         void IncrementUserThreadBlockedCount(Js::TickDelta waitTime, RecyclerWaitReason source);
-        
+        void IncrementUserThreadBlockedCpuTimeUser(uint64 userMicroseconds, RecyclerWaitReason caller);
+        void IncrementUserThreadBlockedCpuTimeKernel(uint64 kernelMicroseconds, RecyclerWaitReason caller);
+
         inline const Js::Tick& GetRecyclerStartTime() const { return this->recyclerStartTime;  }
         RecyclerTelemetryGCPassStats* GetLastPassStats() const;
         inline const Js::Tick& GetLastTransmitTime() const { return this->lastTransmitTime; }
@@ -115,6 +119,8 @@ namespace Memory
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
         AllocatorDecommitStats* GetRecyclerWithBarrierPageAllocator_decommitStats() { return &this->recyclerWithBarrierPageAllocator_decommitStats; }
 #endif
+
+        bool ShouldStartTelemetryCapture() const;
 
     private:
         Recycler* recycler;
@@ -135,7 +141,6 @@ namespace Memory
         AllocatorDecommitStats recyclerWithBarrierPageAllocator_decommitStats;
 #endif
 
-        bool ShouldStartTelemetryCapture() const;
         bool ShouldTransmit() const;
         void FreeGCPassStats();
         void Reset();


### PR DESCRIPTION
We've been capturing wall-clock times for how long the user thread is blocked by GC.  This is useful but the data can be skewed by suspended tabs in the browser.  Adding capture of CPU time to give us better insight here. 
