### PR TITLE
Fix a case where ExternalArrayBuffer could report memory freed without ever reporting memory allocated

### DIFF
--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -217,14 +217,19 @@ namespace Js
         }
     }
 
+    void ArrayBuffer::ReportExternalMemoryFree()
+    {
+        Recycler* recycler = GetType()->GetLibrary()->GetRecycler();
+        recycler->ReportExternalMemoryFree(bufferLength);
+    }
+
     void ArrayBuffer::Detach()
     {
         Assert(!this->isDetached);
 
         // we are about to lose track of the buffer to another owner
         // report that we no longer own the memory
-        Recycler* recycler = GetType()->GetLibrary()->GetRecycler();
-        recycler->ReportExternalMemoryFree(bufferLength);
+        ReportExternalMemoryFree();
 
         this->buffer = nullptr;
         this->bufferLength = 0;
@@ -1089,6 +1094,11 @@ namespace Js
     {
         return HeapNew(ExternalArrayBufferDetachedState, buffer, bufferLength);
     };
+
+    void ExternalArrayBuffer::ReportExternalMemoryFree()
+    {
+        // This type does not own the external memory, so don't ReportExternalMemoryFree like other ArrayBuffer types do
+    }
 
 #if ENABLE_TTD
     TTD::NSSnapObjects::SnapObjectType ExternalArrayBuffer::GetSnapTag_TTD() const

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -196,6 +196,7 @@ namespace Js
         static uint32 ToIndex(Var value, int32 errorCode, ScriptContext *scriptContext, uint32 MaxAllowedLength, bool checkSameValueZero = true);
 
     protected:
+        virtual void ReportExternalMemoryFree();
         void Detach();
 
         typedef void __cdecl FreeFn(void* ptr);
@@ -343,6 +344,7 @@ namespace Js
         static ExternalArrayBuffer* Create(byte* buffer, DECLSPEC_GUARD_OVERFLOW uint32 length, DynamicType * type);
     protected:
         virtual ArrayBufferDetachedStateBase* CreateDetachedState(BYTE* buffer, DECLSPEC_GUARD_OVERFLOW uint32 bufferLength) override;
+        virtual void ReportExternalMemoryFree() override;
 
 #if ENABLE_TTD
     public:


### PR DESCRIPTION
Make ExternalArrayBuffer's behavior during Detach match its behavior during Create and Finalize: it should not tell the recycler any external memory was added or removed, because it has no direct control over the external allocation.