### PR TITLE
Enable deadstore of SlotArrayCheck for jit loop bodies with try

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -7461,7 +7461,8 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
         }
     }
 
-    if (isUsed || !this->DoDeadStore())
+    if (isUsed || (!this->DoDeadStore() &&
+        !(instr->m_opcode == Js::OpCode::SlotArrayCheck && this->func->HasTry() && this->func->IsLoopBody())))
     {
         return false;
     }

--- a/test/EH/loopcrash.js
+++ b/test/EH/loopcrash.js
@@ -1,0 +1,32 @@
+//------------------------------------------------------------------------------------------------------- 
+// Copyright (C) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information. 
+//------------------------------------------------------------------------------------------------------- 
+function test0() { 
+  var i32 = new Int32Array(1); 
+  { 
+    class class0 { 
+    } 
+    class class8 { 
+    } 
+    class class17 { 
+      static func91(argMath135) { 
+        if (new class0() * h) { 
+        }  
+      } 
+      static func94() { 
+        return class8.func78; 
+      } 
+    } 
+    for (var _strvar2 in i32) { // jit loop body
+      continue; // RemoveUnreachableCode after this
+      try { 
+      } catch (ex) { 
+        class8; // LdSlot;SlotArrayCheck at top of jit loop body
+      } 
+    } 
+  } 
+} 
+test0(); 
+test0(); 
+print("Passed"); 

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -204,4 +204,10 @@
        <files>tfjitloopbug.js</files>
   </default>
   </test>
+  <test>
+    <default>
+       <files>loopcrash.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport  -bgjit- -loopinterpretcount:1 </compile-flags>
+  </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes OS#17447405

We insert LdSlots at the top of the function in jitloopbody for all syms
that are coming in live to the loop. These LdSlots should be restored
correctly on BailOutFromSimpleJitToJitLoopBody.
However we do unreachable code elimination in flowgraph in simplejit,
which can dead code the uses of these syms, and so they will not be
restored on bailout.
This works if we run deadstore pass which will cleanup all the LdSlots
inserted at the top of the function, after we run unreachable block
elimination phase.
But since we turn off deadstore for functions with try/catch, we end up
having a nullptr AV when we do a SlotArrayCheck followed by LdSlot
