### PR TITLE
Fixing possible overflow in BoundFunction::NewInstance.

### DIFF
--- a/lib/Runtime/Base/CallInfo.cpp
+++ b/lib/Runtime/Base/CallInfo.cpp
@@ -16,7 +16,7 @@ namespace Js
     {
         AssertOrFailFastMsg(count < Constants::UShortMaxValue - 1, "ArgList too large");
         ArgSlot argSlotCount = (ArgSlot)count;
-        if (flags & CallFlags_ExtraArg)
+        if (CallInfo::HasExtraArg(flags))
         {
             argSlotCount++;
         }
@@ -25,7 +25,7 @@ namespace Js
 
     uint CallInfo::GetLargeArgCountWithExtraArgs(CallFlags flags, uint count)
     {
-        if (flags & CallFlags_ExtraArg)
+        if (CallInfo::HasExtraArg(flags))
         {
             UInt32Math::Inc(count);
         }
@@ -35,7 +35,7 @@ namespace Js
     ArgSlot CallInfo::GetArgCountWithoutExtraArgs(CallFlags flags, ArgSlot count)
     {
         ArgSlot newCount = count;
-        if (flags & Js::CallFlags_ExtraArg)
+        if (CallInfo::HasExtraArg(flags))
         {
             if (count == 0)
             {

--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -93,6 +93,10 @@ namespace Js
 
         static bool HasExtraArg(CallFlags flags)
         {
+            // Generally HasNewTarget should not be true if CallFlags_ExtraArg is not set.
+            Assert(!CallInfo::HasNewTarget(flags) || flags & CallFlags_ExtraArg);
+
+            // we will still check HasNewTarget to be safe in case if above invariant does not hold.
             return (flags & CallFlags_ExtraArg) || CallInfo::HasNewTarget(flags);
         }
 

--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -77,7 +77,7 @@ namespace Js
 
         bool HasExtraArg() const
         {
-            return (this->Flags & CallFlags_ExtraArg) || this->HasNewTarget();
+            return  CallInfo::HasExtraArg(this->Flags);
         }
 
         bool HasNewTarget() const
@@ -90,6 +90,11 @@ namespace Js
         static uint GetLargeArgCountWithExtraArgs(CallFlags flags, uint count);
 
         static ArgSlot GetArgCountWithoutExtraArgs(CallFlags flags, ArgSlot count);
+
+        static bool HasExtraArg(CallFlags flags)
+        {
+            return (flags & CallFlags_ExtraArg) || CallInfo::HasNewTarget(flags);
+        }
 
         static bool HasNewTarget(CallFlags flags)
         {


### PR DESCRIPTION
Not sure if the possibility is practically reachable, but the static checker complains about a  possible overflow.

We allocate an extra element in `newValues` based only on `CallFlags_ExtraArg` flag. Therefore we should be consistent when writing to that element.

`args.HasExtraArg` looks at more flags and, in theory, could result in writing to an element that does not exist. That seems to be making OACR unhappy.

Fixes: OS:#17999665
Fixes: OS:#18010300