### PR TITLE
seperate compact counters lockdown and closing states

### DIFF
--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -33,7 +33,8 @@ namespace Js
         FieldWithBarrier(uint8) fieldSize;
 #if DBG
 
-        mutable FieldWithBarrier(bool) isLockedDown;
+        mutable FieldWithBarrier(bool) isLockedDown:1;
+		mutable FieldWithBarrier(bool) isClosing:1;
 #endif
         typename FieldWithBarrier(Fields*) fields;
 
@@ -42,6 +43,7 @@ namespace Js
             :fieldSize(0)
 #if DBG
             , isLockedDown(false)
+			, isClosing(false)
 #endif
         {
             AllocCounters<uint8>(host);

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -240,12 +240,12 @@ namespace Js
     }
     uint32 FunctionBody::SetCountField(FunctionBody::CounterFields fieldEnum, uint32 val)
     {
-        Assert(!counters.isLockedDown);
+        Assert(!counters.isLockedDown || counters.isClosing);
         return counters.Set(fieldEnum, val, this);
     }
     uint32 FunctionBody::IncreaseCountField(FunctionBody::CounterFields fieldEnum)
     {
-        Assert(!counters.isLockedDown);
+        Assert(!counters.isLockedDown || counters.isClosing);
         return counters.Increase(fieldEnum, this);
     }
 
@@ -7500,7 +7500,7 @@ namespace Js
             return;
         }
 
-        DebugOnly(this->UnlockCounters());
+        DebugOnly(this->SetIsClosing());
 
         CleanupRecyclerData(isScriptContextClosing, false /* capture entry point cleanup stack trace */);
         CleanUpForInCache(isScriptContextClosing);
@@ -7539,8 +7539,6 @@ namespace Js
 #endif
 
         this->cleanedUp = true;
-
-        DebugOnly(this->LockDownCounters());
     }
 
 

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1891,6 +1891,7 @@ namespace Js
 #if DBG
             void LockDownCounters() { counters.isLockedDown = true; };
             void UnlockCounters() { counters.isLockedDown = false; };
+			void SetIsClosing() { counters.isClosing = true; };
 #endif
 
             struct StatementMap


### PR DESCRIPTION
Compact counters on function body is locked when JIT started and then we should never  change it afterward (unless redefer and unlock first)

however when function body cleanup we do cleanup the counters, at that time we unlock and then lock the counters, in between this, there might be JIT thread accessing the counters hence we Assert that counters should be in locked state.

seperating lockdown and closing state to avoid this racing condition