### PR TITLE
update the build script to support LLVM > 9

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -546,7 +546,7 @@ else
 fi
 
 # check clang version (min required 3.7)
-VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]\.[0-9]*" --o)
+VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]*\.[0-9]*" --o)
 VERSION=${VERSION/./}
 
 if [[ $VERSION -lt 37 ]]; then


### PR DESCRIPTION
on Mojave

```sh
Apple LLVM version 10.0.0 (clang-1000.10.25.5)
Target: x86_64-apple-darwin18.0.0
Thread model: posix
InstalledDir: /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

`VERSION` ends up being `00`, rather than `100`