### PR TITLE
Stricter check for not aggregating bytecode uses across blocks. OS #17449647

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -1001,20 +1001,6 @@ void ByteCodeUsesInstr::AggregateFollowingByteCodeUses()
     }
 }
 
-void ByteCodeUsesInstr::AggregatePrecedingByteCodeUses()
-{
-    IR::Instr * instr = this->m_prev;
-    while(instr && CanAggregateByteCodeUsesAcrossInstr(instr))
-    {
-        if (instr->IsByteCodeUsesInstr() && instr->GetByteCodeOffset() == this->GetByteCodeOffset())
-        {
-            IR::ByteCodeUsesInstr* precedingByteCodeUsesInstr = instr->AsByteCodeUsesInstr();
-            this->Aggregate(precedingByteCodeUsesInstr);
-        }
-        instr = instr->m_prev;
-    }
-}
-
 void ByteCodeUsesInstr::Aggregate(ByteCodeUsesInstr * byteCodeUsesInstr)
 {
     Assert(this->m_func == byteCodeUsesInstr->m_func);
@@ -1037,7 +1023,7 @@ void ByteCodeUsesInstr::Aggregate(ByteCodeUsesInstr * byteCodeUsesInstr)
 
 bool Instr::CanAggregateByteCodeUsesAcrossInstr(Instr * instr)
 {
-    return !instr->EndsBasicBlock() && 
+    return !instr->StartsBasicBlock() && 
         instr->m_func == this->m_func &&
         ((instr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset) ||
         (instr->GetByteCodeOffset() == this->GetByteCodeOffset()));

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -579,7 +579,6 @@ public:
     // problems because we end up with an instruction losing atomicity in terms of its
     // bytecode use and generation lifetimes.
     void AggregateFollowingByteCodeUses();
-    void AggregatePrecedingByteCodeUses();
 
 private:
     void Aggregate(ByteCodeUsesInstr * byteCodeUsesInstr);


### PR DESCRIPTION
Stop bytecodeuses aggregation upon seeing an instruction that `StartsBasicBlock` instead of one that `EndsBasicBlock`. This is because the previous block may have been optimized away with all its instructions, including the branch at the end, converted to ByteCodeUses.