### PR TITLE
OS#18260560 - ASSERTION : scope at GetEnclosingFunc

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2075,7 +2075,9 @@ void ByteCodeGenerator::CheckDeferParseHasMaybeEscapedNestedFunc()
     else
     {
         // We have to wait until it is parsed before we populate the stack nested func parent.
-        FuncInfo * parentFunc = top->GetParamScope() ? top->GetParamScope()->GetEnclosingFunc() : top->GetBodyScope()->GetEnclosingFunc();
+        FuncInfo * parentFunc = top->GetParamScope() ? top->GetParamScope()->GetEnclosingFunc() :
+                                top->GetBodyScope() ? top->GetBodyScope()->GetEnclosingFunc() :
+                                top->GetFuncExprScope()->GetEnclosingFunc();
         if (!parentFunc->IsGlobalFunction())
         {
             Assert(parentFunc->byteCodeFunction != rootFuncBody);

--- a/test/Bugs/bug_OS18260560.js
+++ b/test/Bugs/bug_OS18260560.js
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+(function foo(a = function bar() {
+  with ({}) {
+      foo;
+  }
+}()) {})();
+
+console.log("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -472,23 +472,23 @@
       <files>symcmpbug.js</files>
     </default>
   </test>
-  <test> 
-    <default> 
-      <files>bug_OS17417473.js</files> 
-      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags> 
-    </default> 
+  <test>
+    <default>
+      <files>bug_OS17417473.js</files>
+      <compile-flags>-pageheap:2 -CollectGarbage -lic:4 -Sja:4 -Fja:6 -maxInterpretCount:2 -MinBailOutsBeforeRejit:2 -args summary -endargs</compile-flags>
+    </default>
   </test>
-  <test> 
-    <default> 
+  <test>
+    <default>
       <files>HomeObjInLoop.js</files> 
-      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags> 
-    </default> 
-  </test> 
+      <compile-flags>-forceNative -forcejitloopbody -off:aggressiveinttypespec -off:ArrayCheckHoist</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>bug17785360.js</files>
     </default>
-  </test> 
+  </test>
   <test>
     <default>
       <files>bug_OS17530048.js</files>
@@ -505,5 +505,11 @@
     <default>
       <files>bug_OS17614914.js</files>
     </default>
-  </test>  
+  </test>
+  <test>
+    <default>
+      <files>bug_OS18260560.js</files>
+      <compile-flags>-force:deferparse</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Function expression with nested-function declared in default arguments containing a with statement which maybe escapes a nested function causes assert.

```javascript
(function foo(a = function bar() {
  with ({}) {
      foo;
  }
}()) {})();
```

We try and look at the param scope and body scope but we don't check the function expression scope in `ByteCodeGenerator::CheckDeferParseHasMaybeEscapedNestedFunc`. Simple fix is to check function expression scope if param and body scope are nullptr.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/18260560

Found vis oss-fuzz
