### PR TITLE
Removing write barrier on non-recycler data

### DIFF
--- a/lib/Jsrt/JsrtExternalArrayBuffer.h
+++ b/lib/Jsrt/JsrtExternalArrayBuffer.h
@@ -20,12 +20,12 @@ namespace Js {
 
     private:
         FieldNoBarrier(JsFinalizeCallback) finalizeCallback;
-        Field(void *) callbackState;
+        FieldNoBarrier(void *) callbackState;
 
         class JsrtExternalArrayBufferDetachedState : public ExternalArrayBufferDetachedState
         {
             FieldNoBarrier(JsFinalizeCallback) finalizeCallback;
-            Field(void *) callbackState;
+            FieldNoBarrier(void *) callbackState;
         public:
             JsrtExternalArrayBufferDetachedState(BYTE* buffer, uint32 bufferLength, JsFinalizeCallback finalizeCallback, void *callbackState);
             virtual void ClearSelfOnly() override;


### PR DESCRIPTION
When detaching a `JsrtExternalArrayBuffer` we heap allocate a `JsrtExternalArrayBufferDetachedState`, but on this non-recycler object we had a `Field` which would attempt to set the dirty bit in the card table. 

Because the object wasn't recycler allocated, the index is out of bounds of the card table, leading to an access violation.

Fixes #5461