### PR TITLE
SetElementI fastpath ignores prototype chain

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4538,34 +4538,38 @@ CommonNumber:
         }
         else
         {
-            if (TaggedInt::Is(index))
+            if (!(RecyclableObject::Is(instance)
+                && JavascriptOperators::CheckIfPrototypeChainContainsProxyObject(RecyclableObject::FromVar(instance)->GetPrototype())))
             {
-            TaggedIntIndex:
-                switch (instanceType)
+                if (TaggedInt::Is(index))
                 {
-                case TypeIds_NativeIntArray:
-                case TypeIds_NativeFloatArray:
-                case TypeIds_Array: // fast path for array
-                {
-                    int indexInt = TaggedInt::ToInt32(index);
-                    if (indexInt >= 0 && scriptContext->optimizationOverrides.IsEnabledArraySetElementFastPath())
+                TaggedIntIndex:
+                    switch (instanceType)
                     {
-                        JavascriptArray::UnsafeFromVar(instance)->SetItem((uint32)indexInt, value, flags);
-                        return TRUE;
+                    case TypeIds_NativeIntArray:
+                    case TypeIds_NativeFloatArray:
+                    case TypeIds_Array: // fast path for array
+                    {
+                        int indexInt = TaggedInt::ToInt32(index);
+                        if (indexInt >= 0 && scriptContext->optimizationOverrides.IsEnabledArraySetElementFastPath())
+                        {
+                            JavascriptArray::UnsafeFromVar(instance)->SetItem((uint32)indexInt, value, flags);
+                            return TRUE;
+                        }
+                        break;
                     }
-                    break;
+                    }
                 }
-                }
-            }
-            else if (JavascriptNumber::Is_NoTaggedIntCheck(index))
-            {
-                double dIndexValue = JavascriptNumber::GetValue(index);
-                uint32 uint32Index = JavascriptConversion::ToUInt32(index, scriptContext);
-
-                if ((double)uint32Index == dIndexValue && !TaggedInt::IsOverflow(uint32Index))
+                else if (JavascriptNumber::Is_NoTaggedIntCheck(index))
                 {
-                    index = TaggedInt::ToVarUnchecked(uint32Index);
-                    goto TaggedIntIndex;
+                    double dIndexValue = JavascriptNumber::GetValue(index);
+                    uint32 uint32Index = JavascriptConversion::ToUInt32(index, scriptContext);
+
+                    if ((double)uint32Index == dIndexValue && !TaggedInt::IsOverflow(uint32Index))
+                    {
+                        index = TaggedInt::ToVarUnchecked(uint32Index);
+                        goto TaggedIntIndex;
+                    }
                 }
             }
         }

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -484,6 +484,29 @@ var tests = [
             var obj2 = Reflect.construct(proxy2, [20]);
             assert.areEqual(20, obj2.x);
         }
+    },
+    {
+        name: "Getter/setter on array should trigger proxy traps in prototype",
+        body() {
+            var setterCalled = 0;
+            var getterCalled = 0;
+            var obj = [];
+            var p = new Proxy({}, {
+              get(t, k) {
+                getterCalled = 1;
+                return Reflect.get(t, k);
+              },
+              set(t, k, v) {
+                setterCalled = 1;
+                return Reflect.set(t, k, v);
+              }
+            });
+            Object.setPrototypeOf(obj, p);
+            obj[0] = 3;
+            obj[0];
+            assert.areEqual(1, getterCalled, "Get trap on proxy in array prototype chain is called");
+            assert.areEqual(1, setterCalled, "Set trap on proxy in array prototype chain is called");
+        }
     }
 ];
 


### PR DESCRIPTION
Fixes #3187

JavascriptOperators::OP_SetElementI has an array fastpath that wasn't checking for proxies in the prototype chain.
