### PR TITLE
Add empty ByteCodeUses instr with correct bytecode offset for for InlineeEnd cases in path dependent branch folding

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -4854,13 +4854,15 @@ BasicBlock::CheckLegalityAndFoldPathDepBranches(GlobOpt* globOpt)
             if (branchTarget != this->GetLastInstr()->GetNextRealInstrOrLabel())
             {
                 IR::Instr* lastInstr = this->GetLastInstr();
+                // We add an empty ByteCodeUses with correct bytecodeoffset, for correct info on a post-op bailout of the previous instr
+                IR::Instr* emptyByteCodeUse = IR::ByteCodeUsesInstr::New(lastInstr->m_func, lastInstr->GetByteCodeOffset());
+                lastInstr->InsertAfter(emptyByteCodeUse);
                 IR::BranchInstr * newBranch = IR::BranchInstr::New(Js::OpCode::Br, branchTarget, branchTarget->m_func);
-                newBranch->SetByteCodeOffset(lastInstr);
                 if (lastInstr->IsBranchInstr())
                 {
                     globOpt->ConvertToByteCodeUses(lastInstr);
                 }
-                this->GetLastInstr()->InsertAfter(newBranch);
+                emptyByteCodeUse->InsertAfter(newBranch);
                 globOpt->func->m_fg->AddEdge(this, branchTarget->GetBasicBlock());
                 this->IncrementDataUseCount();
             }

--- a/test/Optimizer/pathdepbug.js
+++ b/test/Optimizer/pathdepbug.js
@@ -1,0 +1,28 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function test0() {
+  var arrObj0 = {};
+  var func0 = function () {
+    for (; arrObj0.prop1; ) {
+      __loopSecondaryVar4_0 = 2;
+      break;
+    }
+    return 1;
+  };
+  var func2 = function () {
+    var __loopvar4 = 8;
+    for (;;) {
+      if (__loopvar4 > 8) {
+        break;
+      }
+      __loopvar4++;
+      func0() >= 0 ? func0() : 0;
+    }
+  };
+  return func2(func2());
+}
+test0();
+test0();
+print("Passed\n");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1562,4 +1562,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1  -loopinterpretcount:1 -oopjit- -bgjit-</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>pathdepbug.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -off:aggressiveinttypespec</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes OS#17678270
