### PR TITLE
Fix a possible loss of property in the TypePath

### DIFF
--- a/lib/Runtime/Types/TypePath.h
+++ b/lib/Runtime/Types/TypePath.h
@@ -43,7 +43,12 @@ public:
             uint32 bucketIndex = ReduceKeyToIndex(key);
 
             byte i = buckets[bucketIndex];
-            if (i == NIL)
+
+            // if the bucket was empty (NIL), put a tagged value to indicate the end of the chain.
+            // NB: [OS:17745531] In extreme rare cases 127th pid to insert hashes into a a bucket still unused by the previous 126 values.
+            //     We cannot tag 127 since it would become NIL and we would lose the value. 
+            //     We can however chain 127 --> NIL, since it is the same as having two 127 in the bucket, which is ok.
+            if ((i == NIL) & (value != 127))
             {
                 // set the highest bit to mark the value as the last in the chain
                 buckets[bucketIndex] = value | 128;

--- a/test/Bugs/OS_17745531.js
+++ b/test/Bugs/OS_17745531.js
@@ -1,0 +1,42 @@
+
+var obj = {};
+
+// create enough pids to pick from
+for (let i = 0; i < 20000; i++)
+{
+    Object.defineProperty(obj, 'prop' + i, {
+        value: i,
+        writable: true
+    });
+}
+
+for (let j = 0; j < 127; j++)
+{
+
+    var obj1 = {};
+    // fill with pids that prone to collisions - to have some empty buckets when inserting 127th property
+    for (let i = 0; i < 127; i++)
+    {
+        Object.defineProperty(obj1, 'prop' + i * 144, {
+            value: i,
+            writable: true
+        });
+    }
+
+    // hopefully 'prop<j>' will hash into an empty bucket and it is also a 127th property.
+    // we will try multiple j - just in case the empty bucket moves due to minor changes in 
+    // hashing or how pids are assigned.
+    Object.defineProperty(obj1, 'prop' + j, {
+        value: obj['prop' + j],
+        writable: true
+    });
+
+
+    // compare the values, also keeps objects alive
+    if (obj['prop' + j] != obj1['prop' + j])
+    {
+        console.log("fail");
+    }
+}
+
+console.log("pass");

--- a/test/Bugs/OS_17745531.js
+++ b/test/Bugs/OS_17745531.js
@@ -1,3 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
 
 var obj = {};
 

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -505,5 +505,10 @@
     <default>
       <files>bug_OS17614914.js</files>
     </default>
-  </test>  
+  </test> 
+  <test>
+    <default>
+      <files>OS_17745531.js</files>
+    </default>
+  </test>   
 </regress-exe>


### PR DESCRIPTION
In a rare case TinyDictionary could lose the last value added.
We use the sign bit to tag last values in bucket chains. We also use `FF` for uninitialized/empty buckets.
In extreme rare cases 127th pid to insert may hash into a a bucket still unused by the previous 126 values.
Once 127 is tagged it becomes `FF` which will look like an empty bucket - the 127 value would be lost.

The fix is simple - detect the case as described and make 127 to chain to `FF` marker. In such case it will not be the last in the chain and will not be tagged.

Fixes: OS:#17745531