### PR TITLE
Adding unit tests

### DIFF
--- a/test/Bugs/bug_OS17289059.js
+++ b/test/Bugs/bug_OS17289059.js
@@ -1,0 +1,40 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let shouldBailout = false;
+let desc = {
+    get: function () {
+        return 3;
+    }
+};
+
+let arr = [42, 123];
+function test0() {
+    for (let a in arr) {
+        arr[a] =
+            (
+                (shouldBailout
+                    ? this.p = ((() => 1)()) // should attempt to assign 1 to this.p (which will fail, if this.p has been defined because there is no setter)
+                    : this.p)
+                !== this.p // checks that the result of `get this.p` is not the same as `set this.p` (which is true if this.p has been defined with a getter and no setter)
+            ) ? 8000 : 700
+                +
+                (
+                    shouldBailout
+                        ? (Object.defineProperty(this, 'p', desc), 60)
+                        : 5
+                );
+    }
+    if (shouldBailout && arr[1] !== 8000) {
+        throw new Error("Unexpected result");
+    }
+}
+
+// this sequence necessary
+test0();
+shouldBailout = true;
+test0();
+
+console.log("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -505,5 +505,11 @@
     <default>
       <files>bug_OS17614914.js</files>
     </default>
-  </test>  
+  </test>
+  <test>
+    <default>
+      <files>bug_OS17289059.js</files>
+      <compile-flags>-loopinterpretcount:1 -off:bailonnoprofile -off:objtypespec</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Jitted code for:
```
(shouldBailout ? this.p = ((()=>1)()) : this.p) !== this.p 
```
evaluates to false, while it should be true when there is a getter and no setter for p and shouldBailout is true.

The reason for the problem is that in the forward pass a symbol with the result of  ((()=>1)()) is replaced with a symbol from this.p, a ByteCodeUses is emitted and instructions are marked with BailOutOnImplicitCalls.
But the in the DeadStore pass the BailOutOnImplicitCalls are removed because apparently there are no live fields.
This is not correct: there should be at least one live field for the ByteCodeUses symbol.

This PR modifies BackwardPass::ProcessByteCodeUsesInstr() to make sure that all ByteCodeUses symbols are added to currentBlock->upwardExposedFields.