### PR TITLE
Extra OOM crash buckets.

### DIFF
--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -181,4 +181,48 @@ _NOINLINE void OutOfMemoryAllocationPolicy_unrecoverable_error()
     ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
 }
 
+///////
+//
+// The following variety of OOM unrecoverable errors are similar to the ones above 
+// and exist specifically for additional distinct bucketing of crash dumps for 
+// diagnostics purposes.
+//
+///////
+
+_NOINLINE void OutOfMemoryTooManyPinnedObjects_unrecoverable_error_visible()
+{
+    int scenario = 15;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
+_NOINLINE void OutOfMemoryTooManyClosedContexts_unrecoverable_error_visible()
+{
+    int scenario = 16;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
+_NOINLINE void OutOfMemoryAllocationPolicy_unrecoverable_error_visible()
+{
+    int scenario = 17;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
+_NOINLINE void OutOfMemoryTooManyPinnedObjects_unrecoverable_error_notvisible()
+{
+    int scenario = 18;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
+_NOINLINE void OutOfMemoryTooManyClosedContexts_unrecoverable_error_notvisible()
+{
+    int scenario = 19;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
+_NOINLINE void OutOfMemoryAllocationPolicy_unrecoverable_error_notvisible()
+{
+    int scenario = 20;
+    ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_OutOfMemory, scenario);
+}
+
 #pragma optimize("",on)

--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -76,9 +76,66 @@ void RpcFailure_unrecoverable_error(HRESULT hr);
 void OutOfMemory_unrecoverable_error();
 void RecyclerSingleAllocationLimit_unrecoverable_error();
 void MemGCSingleAllocationLimit_unrecoverable_error();
+
 void OutOfMemoryTooManyPinnedObjects_unrecoverable_error();
 void OutOfMemoryTooManyClosedContexts_unrecoverable_error();
 void OutOfMemoryAllocationPolicy_unrecoverable_error();
+
+void OutOfMemoryTooManyPinnedObjects_unrecoverable_error_visible();
+void OutOfMemoryTooManyClosedContexts_unrecoverable_error_visible();
+void OutOfMemoryAllocationPolicy_unrecoverable_error_visible();
+
+void OutOfMemoryTooManyPinnedObjects_unrecoverable_error_notvisible();
+void OutOfMemoryTooManyClosedContexts_unrecoverable_error_notvisible();
+void OutOfMemoryAllocationPolicy_unrecoverable_error_notvisible();
+
+inline void OutOfMemoryTooManyPinnedObjects_unrecoverable_error(BYTE visibility)
+{
+    switch (visibility)
+    {
+    case 1:
+        OutOfMemoryTooManyPinnedObjects_unrecoverable_error_visible();
+        break;
+    case 2:
+        OutOfMemoryTooManyPinnedObjects_unrecoverable_error_notvisible();
+        break;
+    default:
+        OutOfMemoryTooManyPinnedObjects_unrecoverable_error();
+        break;
+    }
+}
+
+inline void OutOfMemoryTooManyClosedContexts_unrecoverable_error(BYTE visibility)
+{
+    switch (visibility)
+    {
+    case 1:
+        OutOfMemoryTooManyClosedContexts_unrecoverable_error_visible();
+        break;
+    case 2:
+        OutOfMemoryTooManyClosedContexts_unrecoverable_error_notvisible();
+        break;
+    default:
+        OutOfMemoryTooManyClosedContexts_unrecoverable_error();
+        break;
+    }
+}
+
+inline void OutOfMemoryAllocationPolicy_unrecoverable_error(BYTE visibility)
+{
+    switch (visibility)
+    {
+    case 1:
+        OutOfMemoryAllocationPolicy_unrecoverable_error_visible();
+        break;
+    case 2:
+        OutOfMemoryAllocationPolicy_unrecoverable_error_notvisible();
+        break;
+    default:
+        OutOfMemoryAllocationPolicy_unrecoverable_error();
+        break;
+    }
+}
 
 #ifndef DISABLE_SEH
 // RtlReportException is available on Vista and up, but we cannot use it for OOB release.

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -213,6 +213,7 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     , reentrancySafeOrHandled(false)
     , isInReentrancySafeRegion(false)
     , closedScriptContextCount(0)
+    , visibilityState(VisibilityState::Undefined)
 {
     pendingProjectionContextCloseList = JsUtil::List<IProjectionContext*, ArenaAllocator>::New(GetThreadAlloc());
     hostScriptContextStack = Anew(GetThreadAlloc(), JsUtil::Stack<HostScriptContext*>, GetThreadAlloc());

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -866,6 +866,16 @@ public:
     // high number may indicate that context leaks have occured.
     uint closedScriptContextCount;
 
+    enum VisibilityState : BYTE
+    {
+        Undefined = 0,
+        Visible = 1,
+        NotVisible = 2
+    };
+
+    // indicates the visibility state of the hosting application/window/tab if known.
+    VisibilityState visibilityState;
+
 #if ENABLE_NATIVE_CODEGEN
     PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() { return &preReservedVirtualAllocator; }
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)


### PR DESCRIPTION
It could be useful for the analysis purposes to know whether the state at the time of the crash was visible or not visible, if known.
