### PR TITLE
Trailing comma in an arrow function should be valid.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -108,6 +108,7 @@ Parser::Parser(Js::ScriptContext* scriptContext, BOOL strictMode, PageAllocator 
     m_isInParsingArgList(false),
     m_hasDestructuringPattern(false),
     m_hasDeferredShorthandInitError(false),
+    m_deferCommaError(false),
     m_pnestedCount(nullptr),
 
     wellKnownPropertyPids(), // should initialize to nullptrs
@@ -125,7 +126,7 @@ Parser::Parser(Js::ScriptContext* scriptContext, BOOL strictMode, PageAllocator 
     m_funcParenExprDepth(0),
     m_deferEllipsisError(false),
     m_deferEllipsisErrorLoc(), // calls default initializer
-
+    m_deferCommaErrorLoc(),
     m_tryCatchOrFinallyDepth(0),
 
     m_pstmtCur(nullptr),
@@ -3107,9 +3108,7 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
         uint saveCurrBlockId = GetCurrentBlock()->blockId;
         GetCurrentBlock()->blockId = m_nextBlockId++;
 
-        // Push the deferred error state for ellipsis errors. It is possible that another syntax error will occur before we undefer this one.
-        bool deferEllipsisErrorSave = m_deferEllipsisError;
-        RestorePoint ellipsisErrorLocSave = m_deferEllipsisErrorLoc;
+        AutoDeferErrorsRestore deferErrorRestore(this);
 
         this->m_funcParenExprDepth++;
         pnode = ParseExpr<buildAST>(koplNo, &fCanAssign, TRUE, FALSE, nullptr, nullptr /*nameLength*/, nullptr  /*pShortNameOffset*/, &term, true, nullptr, plastRParen);
@@ -3129,21 +3128,21 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
             // Put back the original next-block-ID so the existing pid ref stacks will be correct.
             m_nextBlockId = saveNextBlockId;
         }
-
-        // Emit a deferred ... error if one was parsed.
-        if (m_deferEllipsisError && m_token.tk != tkDArrow)
-        {
-            this->GetScanner()->SeekTo(m_deferEllipsisErrorLoc);
-            Error(ERRInvalidSpreadUse);
-        }
         else
         {
-            m_deferEllipsisError = false;
+            // Emit a deferred ... error if one was parsed.
+            if (m_deferEllipsisError)
+            {
+                this->GetScanner()->SeekTo(m_deferEllipsisErrorLoc);
+                Error(ERRInvalidSpreadUse);
+            }
+            else if (m_deferCommaError)
+            {
+                // Emit a comma error if that was deferred.
+                this->GetScanner()->SeekTo(m_deferCommaErrorLoc);
+                Error(ERRsyntax);
+            }
         }
-
-        // We didn't error out, so restore the deferred error state.
-        m_deferEllipsisError = deferEllipsisErrorSave;
-        m_deferEllipsisErrorLoc = ellipsisErrorLocSave;
 
         break;
     }
@@ -8866,6 +8865,14 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
         }
         else // a binary operator
         {
+            if (nop == knopComma && m_token.tk == tkRParen)
+            {
+                // Trailing comma
+                this->GetScanner()->Capture(&m_deferCommaErrorLoc);
+                m_deferCommaError = true;
+                break;
+            }
+
             ParseNode* pnode1 = pnode;
 
             // Parse the operand, make a new node, and look for more

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -431,6 +431,8 @@ private:
     bool m_hasDestructuringPattern;
     // This bool is used for deferring the shorthand initializer error ( {x = 1}) - as it is allowed in the destructuring grammar.
     bool m_hasDeferredShorthandInitError;
+    bool m_deferEllipsisError;
+    bool m_deferCommaError;
     uint * m_pnestedCount; // count of functions nested at one level below the current node
 
     struct WellKnownPropertyPids
@@ -480,8 +482,8 @@ private:
 
     // Used for issuing spread and rest errors when there is ambiguity with lambda parameter lists and parenthesized expressions
     uint m_funcParenExprDepth;
-    bool m_deferEllipsisError;
     RestorePoint m_deferEllipsisErrorLoc;
+    RestorePoint m_deferCommaErrorLoc;
 
     uint m_tryCatchOrFinallyDepth;  // Used to determine if parsing is currently in a try/catch/finally block in order to throw error on yield expressions inside them
 
@@ -568,6 +570,33 @@ private:
         // For very basic validation purpose - to check that we are not going restore to some other block.
         BlockInfoStack *m_currentBlockInfo;
 #endif
+    };
+
+    class AutoDeferErrorsRestore
+    {
+    public:
+        AutoDeferErrorsRestore(Parser *p)
+            : m_parser(p)
+        {
+            m_deferEllipsisErrorSave = m_parser->m_deferEllipsisError;
+            m_deferCommaError = m_parser->m_deferCommaError;
+            m_ellipsisErrorLocSave = m_parser->m_deferEllipsisErrorLoc;
+            m_commaErrorLocSave = m_parser->m_deferCommaErrorLoc;
+        }
+
+        ~AutoDeferErrorsRestore()
+        {
+            m_parser->m_deferEllipsisError = m_deferEllipsisErrorSave;
+            m_parser->m_deferCommaError = m_deferCommaError;
+            m_parser->m_deferEllipsisErrorLoc = m_ellipsisErrorLocSave;
+            m_parser->m_deferCommaErrorLoc = m_commaErrorLocSave;
+        }
+    private:
+        Parser *m_parser;
+        RestorePoint m_ellipsisErrorLocSave;
+        RestorePoint m_commaErrorLocSave;
+        bool m_deferEllipsisErrorSave;
+        bool m_deferCommaError;
     };
 
     // This function is going to capture some of the important current state of the parser to an object. Once we learn

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -169,8 +169,8 @@ var tests = [
     {
         name: "Interesting valid and invalid syntax",
         body: function () {
+            assert.doesNotThrow(() => { eval('(x, ) => {};'); }, SyntaxError, "Trailing comma is valid syntax");
             assert.throws(() => { eval('(var x) => {};'); }, SyntaxError, "var not used in formals declaration", "Syntax error");
-            assert.throws(() => { eval('(x, ) => {};'); }, SyntaxError, "missing formal identifier in parameter list", "Syntax error");
             assert.throws(() => { eval('a.x => {};'); }, SyntaxError, "valid expression syntax that is invalid parameter list syntax on lhs of =>", "Syntax error");
             assert.throws(() => { eval('(x, y)[7] => {};'); }, SyntaxError, "valid expression syntax that is invalid parameter list syntax on lhs of =>", "Expected '=>'");
             assert.throws(() => { eval('x() => {};'); }, SyntaxError, "valid expression syntax that is invalid parameter list syntax on lhs of =>", "Syntax error");

--- a/test/es6/trailingcomma.js
+++ b/test/es6/trailingcomma.js
@@ -24,6 +24,16 @@ var tests = [
             assert.doesNotThrow(function () { eval("function foo() {}; foo(1, 2,);"); }, "Trailing comma in a user function call is a valid syntax");
             assert.doesNotThrow(function () { eval("Math.min(1, 2, );"); }, "Trailing comma in built-in function call is a valid syntax");
         }
+    },
+    {
+        name: "Trailing comma in arrow function",
+        body: function () {
+            assert.doesNotThrow(function () { eval("(a,) => {}"); }, "Trailing comma in an arrow function is a valid syntax");
+            assert.doesNotThrow(function () { eval("let f = (a,) => {}"); }, "Trailing comma in an arrow function is a valid syntax");
+            assert.doesNotThrow(function () { eval("(b = (a,) => {}) => {}"); }, "Trailing comma in an nested arrow function is a valid syntax");
+            assert.doesNotThrow(function () { eval("({b = (a,) => {}}) => {}"); }, "Trailing comma in an nested arrow function in destructuring is a valid syntax");
+            assert.throws(function () { eval("(b = (a,)) => {}"); }, SyntaxError, "Trailing comma in a comma expression is not valid syntax");
+        }
     }
 ];
 


### PR DESCRIPTION
Trailing commas is allowed for all function including arrow function. Since we don't know that an expression can be formals of the lambda function we need to defer the error till we determine that
we indeed are going to have the arrow function.
