### PR TITLE
change GetSz to GetString where it's easy to

### DIFF
--- a/lib/Runtime/Debug/TTActionEvents.cpp
+++ b/lib/Runtime/Debug/TTActionEvents.cpp
@@ -202,7 +202,7 @@ namespace TTD
             Js::Var message = InflateVarInReplay(executeContext, GetVarItem_0(errorData));
             TTD_REPLAY_VALIDATE_INCOMING_REFERENCE(message, ctx);
 
-            *res = nullptr; 
+            *res = nullptr;
             switch(eventKind)
             {
             case EventKind::CreateErrorActionTag:
@@ -1067,7 +1067,7 @@ namespace TTD
             if(Js::JavascriptFunction::Is(funcVar))
             {
                 Js::JavascriptString* displayName = Js::JavascriptFunction::FromVar(funcVar)->GetDisplayName();
-                alloc.CopyStringIntoWLength(displayName->GetSz(), displayName->GetLength(), cfAction->FunctionName);
+                alloc.CopyStringIntoWLength(displayName->GetString(), displayName->GetLength(), cfAction->FunctionName);
             }
             else
             {

--- a/lib/Runtime/Debug/TTEventLog.cpp
+++ b/lib/Runtime/Debug/TTEventLog.cpp
@@ -201,7 +201,7 @@ namespace TTD
 
         for(TTEventListLink* curr = this->m_headBlock; curr != nullptr; curr = curr->Previous)
         {
-            size_t cpos = curr->StartPos; 
+            size_t cpos = curr->StartPos;
             while(cpos != curr->CurrPos)
             {
                 count++;
@@ -814,7 +814,7 @@ namespace TTD
     void EventLog::RecordTelemetryLogEvent(Js::JavascriptString* infoStringJs, bool doPrint)
     {
         NSLogEvents::TelemetryEventLogEntry* tEvent = this->RecordGetInitializedEvent_DataOnly<NSLogEvents::TelemetryEventLogEntry, NSLogEvents::EventKind::TelemetryLogTag>();
-        this->m_eventSlabAllocator.CopyStringIntoWLength(infoStringJs->GetSz(), infoStringJs->GetLength(), tEvent->InfoString);
+        this->m_eventSlabAllocator.CopyStringIntoWLength(infoStringJs->GetString(), infoStringJs->GetLength(), tEvent->InfoString);
         tEvent->DoPrint = doPrint;
 
 #if ENABLE_BASIC_TRACE || ENABLE_FULL_BC_TRACE
@@ -864,7 +864,7 @@ namespace TTD
         this->RecordGetInitializedEvent_DataOnly<NSLogEvents::ExplicitLogWriteEventLogEntry, NSLogEvents::EventKind::ExplicitLogWriteTag>();
 
         AutoArrayPtr<char> uri(HeapNewArrayZ(char, uriString->GetLength() * 3), uriString->GetLength() * 3);
-        size_t uriLength = utf8::EncodeInto((LPUTF8)((char*)uri), uriString->GetSz(), uriString->GetLength());
+        size_t uriLength = utf8::EncodeInto((LPUTF8)((char*)uri), uriString->GetString(), uriString->GetLength());
 
         this->EmitLog(uri, uriLength);
     }
@@ -901,7 +901,7 @@ namespace TTD
     void EventLog::RecordDateStringEvent(Js::JavascriptString* stringValue)
     {
         NSLogEvents::StringValueEventLogEntry* sEvent = this->RecordGetInitializedEvent_DataOnly<NSLogEvents::StringValueEventLogEntry, NSLogEvents::EventKind::StringTag>();
-        this->m_eventSlabAllocator.CopyStringIntoWLength(stringValue->GetSz(), stringValue->GetLength(), sEvent->StringValue);
+        this->m_eventSlabAllocator.CopyStringIntoWLength(stringValue->GetString(), stringValue->GetLength(), sEvent->StringValue);
     }
 
     void EventLog::ReplayDateTimeEvent(double* result)
@@ -949,12 +949,12 @@ namespace TTD
 #if ENABLE_TTD_INTERNAL_DIAGNOSTICS
         if(returnCode)
         {
-            this->m_eventSlabAllocator.CopyStringIntoWLength(propertyName->GetSz(), propertyName->GetLength(), peEvent->PropertyString);
+            this->m_eventSlabAllocator.CopyStringIntoWLength(propertyName->GetString(), propertyName->GetLength(), peEvent->PropertyString);
         }
 #else
         if(returnCode && pid == Js::Constants::NoProperty)
         {
-            this->m_eventSlabAllocator.CopyStringIntoWLength(propertyName->GetSz(), propertyName->GetLength(), peEvent->PropertyString);
+            this->m_eventSlabAllocator.CopyStringIntoWLength(propertyName->GetString(), propertyName->GetLength(), peEvent->PropertyString);
         }
 #endif
 
@@ -1335,7 +1335,7 @@ namespace TTD
         }
 
         //Now allocate the arrays for them and do the processing
-        snapEvent->LongLivedRefRootsIdArray = nullptr; 
+        snapEvent->LongLivedRefRootsIdArray = nullptr;
         if(snapEvent->LongLivedRefRootsCount != 0)
         {
             snapEvent->LongLivedRefRootsIdArray = this->m_eventSlabAllocator.SlabAllocateArray<TTD_LOG_PTR_ID>(snapEvent->LongLivedRefRootsCount);
@@ -2131,7 +2131,7 @@ namespace TTD
         NSLogEvents::EventLogEntry* evt = this->RecordGetInitializedEvent<NSLogEvents::JsRTByteBufferAction, NSLogEvents::EventKind::AllocateExternalArrayBufferActionTag>(&cAction);
         cAction->Length = size;
 
-        cAction->Buffer = nullptr; 
+        cAction->Buffer = nullptr;
         if(cAction->Length != 0)
         {
             cAction->Buffer = this->m_eventSlabAllocator.SlabAllocateArray<byte>(cAction->Length);

--- a/lib/Runtime/Debug/TTEvents.cpp
+++ b/lib/Runtime/Debug/TTEvents.cpp
@@ -433,7 +433,7 @@ namespace TTD
             ExternalCallEventLogEntry* callEvt = GetInlineEventDataAs<ExternalCallEventLogEntry, EventKind::ExternalCallTag>(evt);
 
             Js::JavascriptString* displayName = function->GetDisplayName();
-            alloc.CopyStringIntoWLength(displayName->GetSz(), displayName->GetLength(), callEvt->FunctionName);
+            alloc.CopyStringIntoWLength(displayName->GetString(), displayName->GetLength(), callEvt->FunctionName);
         }
 #endif
 

--- a/lib/Runtime/Debug/TTSerialize.cpp
+++ b/lib/Runtime/Debug/TTSerialize.cpp
@@ -802,7 +802,7 @@ namespace TTD
 
         if(!endFound)
         {
-            // no ending found 
+            // no ending found
             return NSTokens::ParseTokenKind::Error;
         }
 
@@ -966,7 +966,7 @@ namespace TTD
 
         if(!endFound)
         {
-            // no ending found 
+            // no ending found
             return NSTokens::ParseTokenKind::Error;
         }
 
@@ -1882,7 +1882,7 @@ namespace TTD
             this->AppendLiteral(", attrib: ");
             this->AppendInteger(attrib);
             this->AppendLiteral(", name: ");
-            this->AppendText(pname->GetSz(), (uint32)pname->GetLength());
+            this->AppendText(pname->GetString(), (uint32)pname->GetLength());
         }
 
         this->AppendLiteral(")\n");
@@ -1926,11 +1926,11 @@ namespace TTD
                 {
                     if(Js::JavascriptString::FromVar(var)->GetLength() <= 40)
                     {
-                        this->AppendText(Js::JavascriptString::FromVar(var)->GetSz(), Js::JavascriptString::FromVar(var)->GetLength());
+                        this->AppendText(Js::JavascriptString::FromVar(var)->GetString(), Js::JavascriptString::FromVar(var)->GetLength());
                     }
                     else
                     {
-                        this->AppendText(Js::JavascriptString::FromVar(var)->GetSz(), 40);
+                        this->AppendText(Js::JavascriptString::FromVar(var)->GetString(), 40);
                         this->AppendLiteral("...");
                         this->AppendInteger(Js::JavascriptString::FromVar(var)->GetLength());
                     }
@@ -1983,7 +1983,7 @@ namespace TTD
         Js::JavascriptString* displayName = function->GetDisplayName();
 
         this->AppendIndent();
-        const char16* nameStr = displayName->GetSz();
+        const char16* nameStr = displayName->GetString();
         uint32 nameLength = displayName->GetLength();
         this->AppendText(nameStr, nameLength);
 
@@ -2024,7 +2024,7 @@ namespace TTD
 
         this->AppendIndent();
         this->AppendLiteral("return(");
-        this->AppendText(displayName->GetSz(), displayName->GetLength());
+        this->AppendText(displayName->GetString(), displayName->GetLength());
         this->AppendLiteral(") -> ");
         this->WriteVar(res);
 
@@ -2042,7 +2042,7 @@ namespace TTD
 
         this->AppendIndent();
         this->AppendLiteral("return(");
-        this->AppendText(displayName->GetSz(), displayName->GetLength());
+        this->AppendText(displayName->GetString(), displayName->GetLength());
         this->AppendLiteral(") -> !!exception");
 
         this->AppendLiteral(" @ ");
@@ -2059,7 +2059,7 @@ namespace TTD
         this->m_currLength += sprintf_s(this->m_buffer + this->m_currLength, 128, "(l:%I32u, c:%I32u)\n", line + 1, column);
 
         ////
-        //Temp debugging help if needed 
+        //Temp debugging help if needed
         this->ForceFlush();
         //
         ////

--- a/lib/Runtime/Debug/TTSnapValues.cpp
+++ b/lib/Runtime/Debug/TTSnapValues.cpp
@@ -345,7 +345,7 @@ namespace TTD
                     break;
                 case Js::TypeIds_String:
                     snapValue->u_stringValue = alloc.SlabAllocateStruct<TTString>();
-                    alloc.CopyStringIntoWLength(Js::JavascriptString::FromVar(jsValue)->GetSz(), Js::JavascriptString::FromVar(jsValue)->GetLength(), *(snapValue->u_stringValue));
+                    alloc.CopyStringIntoWLength(Js::JavascriptString::FromVar(jsValue)->GetString(), Js::JavascriptString::FromVar(jsValue)->GetLength(), *(snapValue->u_stringValue));
                     break;
                 case Js::TypeIds_Symbol:
                     snapValue->u_propertyIdValue = jslib->ExtractPrimitveSymbolId_TTD(jsValue);
@@ -1902,7 +1902,7 @@ namespace TTD
             reader->ReadRecordEnd();
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv(const SnapContext* snapCtx1, const SnapContext* snapCtx2, const JsUtil::BaseDictionary<TTD_LOG_PTR_ID, NSSnapValues::SnapRootInfoEntry*, HeapAllocator>& allRootMap1, const JsUtil::BaseDictionary<TTD_LOG_PTR_ID, NSSnapValues::SnapRootInfoEntry*, HeapAllocator>& allRootMap2, TTDCompareMap& compareMap)
         {
             compareMap.DiagnosticAssert(snapCtx1->ScriptContextLogId == snapCtx2->ScriptContextLogId);

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -26,7 +26,7 @@ namespace Js
         stringBuilder->AppendCppLiteral(_u("Object, (Arguments)"));
         return TRUE;
     }
-    
+
     bool ArgumentsObject::Is(Var aValue)
     {
         return JavascriptOperators::GetTypeId(aValue) == TypeIds_Arguments;
@@ -402,7 +402,7 @@ namespace Js
 
     BOOL HeapArgumentsObject::SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
     {
-        AssertMsg(!PropertyRecord::IsPropertyNameNumeric(propertyNameString->GetSz(), propertyNameString->GetLength()),
+        AssertMsg(!PropertyRecord::IsPropertyNameNumeric(propertyNameString->GetString(), propertyNameString->GetLength()),
             "Numeric property names should have been converted to uint or PropertyRecord*");
 
         // TODO: In strict mode, "callee" and "caller" cannot be set.

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5218,7 +5218,7 @@ namespace Js
         str = JavascriptString::FromVar(var);
 
         charcount_t len = str->GetLength();
-        js_wmemcpy_s(ptr, remainingSpace, str->GetSz(), len);
+        js_wmemcpy_s(ptr, remainingSpace, str->GetString(), len);
         ptr += len;
         remainingSpace -= len;
 
@@ -5234,7 +5234,7 @@ namespace Js
             str = JavascriptString::FromVar(var);
 
             len = str->GetLength();
-            js_wmemcpy_s(ptr, remainingSpace, str->GetSz(), len);
+            js_wmemcpy_s(ptr, remainingSpace, str->GetString(), len);
             ptr += len;
             remainingSpace -= len;
         }
@@ -5300,7 +5300,7 @@ namespace Js
             }
 
             // If the strings at this index are not equal, the callsite objects are not equal.
-            if (!JsUtil::CharacterBuffer<char16>::StaticEquals(pid->Psz(), str->GetSz(), str->GetLength()))
+            if (!JsUtil::CharacterBuffer<char16>::StaticEquals(pid->Psz(), str->GetString(), str->GetLength()))
             {
                 return false;
             }
@@ -5324,7 +5324,7 @@ namespace Js
         }
 
         // If the strings at this index are not equal, the callsite objects are not equal.
-        if (!JsUtil::CharacterBuffer<char16>::StaticEquals(pid->Psz(), str->GetSz(), str->GetLength()))
+        if (!JsUtil::CharacterBuffer<char16>::StaticEquals(pid->Psz(), str->GetString(), str->GetLength()))
         {
             return false;
         }
@@ -6181,20 +6181,20 @@ namespace Js
     JavascriptPromiseThenFinallyFunction* JavascriptLibrary::CreatePromiseThenFinallyFunction(JavascriptMethod entryPoint, RecyclableObject* OnFinally, RecyclableObject* Constructor, bool shouldThrow)
     {
         Assert(scriptContext->GetConfig()->IsES6PromiseEnabled());
-        
+
         FunctionInfo* functionInfo = RecyclerNew(this->GetRecycler(), FunctionInfo, entryPoint);
         DynamicType* type = DynamicType::New(scriptContext, TypeIds_Function, functionPrototype, entryPoint, GetDeferredAnonymousFunctionTypeHandler());
 
         JavascriptPromiseThenFinallyFunction* function = RecyclerNewEnumClass(this->GetRecycler(), EnumFunctionClass, JavascriptPromiseThenFinallyFunction, type, functionInfo, OnFinally, Constructor, shouldThrow);
         function->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(1), PropertyConfigurable, nullptr);
-        
+
         return function;
     }
 
     JavascriptPromiseThunkFinallyFunction* JavascriptLibrary::CreatePromiseThunkFinallyFunction(JavascriptMethod entryPoint, Var value, bool shouldThrow)
     {
         Assert(scriptContext->GetConfig()->IsES6PromiseEnabled());
-        
+
         FunctionInfo* functionInfo = RecyclerNew(this->GetRecycler(), FunctionInfo, entryPoint);
         DynamicType* type = CreateDeferredPrototypeFunctionType(entryPoint);
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2237,15 +2237,15 @@ case_2:
 
         ScriptContext* scriptContext = pThis->type->GetScriptContext();
         ApiError error = ApiError::NoError;
-        const char16 *pThisSz = pThis->GetSz();
         charcount_t pThisLength = pThis->GetLength();
 
         if (useInvariant)
         {
+            const char16 *pThisString = pThis->GetString();
             bool isAscii = true;
             for (charcount_t i = 0; i < pThisLength; i++)
             {
-                if (pThisSz[i] >= 0x80)
+                if (pThisString[i] >= 0x80)
                 {
                     isAscii = false;
                     break;
@@ -2258,7 +2258,7 @@ case_2:
                 const char16 diffBetweenCases = 32;
                 for (charcount_t i = 0; i < pThisLength; i++)
                 {
-                    char16 cur = pThisSz[i];
+                    char16 cur = pThisString[i];
                     if (toUpper)
                     {
                         if (cur >= _u('a') && cur <= _u('z'))


### PR DESCRIPTION
I recently noticed a website spending 0.5% of main thread time copying the contents of substrings during decodeURIComponent. There is no reason to copy the string data here, as URIHelper::Decode already respects the string length and does not require zero termination.

This change updates callers of GetSz to use GetString instead, in any cases where I could very clearly see that it is safe to do so.
