### PR TITLE
Enable removing unreferenced labels for non-dbg as well

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1847,6 +1847,10 @@ FlowGraph::Destroy(void)
             }
         }
         NEXT_BLOCK;
+    }
+#endif
+    if (fHasTry)
+    {
         FOREACH_BLOCK_ALL(block, this)
         {
             if (block->GetFirstInstr()->IsLabelInstr())
@@ -1861,8 +1865,6 @@ FlowGraph::Destroy(void)
             }
         } NEXT_BLOCK;
     }
-#endif
-
     this->func->isFlowGraphValid = false;
 }
 


### PR DESCRIPTION
If the unreference label had a region, we will end up doing a lot of work in lowerer to generate returnthunks etc

Fixes OS#17415331
