### PR TITLE
Implement Object Rest

### DIFF
--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -513,6 +513,10 @@ HELPERCALL(SpreadArrayLiteral, Js::JavascriptArray::SpreadArrayArgs, 0)
 HELPERCALL(SpreadCall, Js::JavascriptFunction::EntrySpreadCall, 0)
 
 HELPERCALL(SpreadObjectLiteral, Js::JavascriptObject::SpreadObjectLiteral, 0)
+HELPERCALL(Restify, Js::JavascriptObject::Restify, 0)
+HELPERCALL(NewPropIdArrForCompProps, Js::InterpreterStackFrame::OP_NewPropIdArrForCompProps, AttrCanNotBeReentrant)
+HELPERCALL(StPropIdArrFromVar, Js::InterpreterStackFrame::OP_StPropIdArrFromVar, 0)
+
 
 HELPERCALLCHK(LdHomeObj,           Js::JavascriptOperators::OP_LdHomeObj, AttrCanNotBeReentrant)
 HELPERCALLCHK(LdFuncObj,           Js::JavascriptOperators::OP_LdFuncObj, AttrCanNotBeReentrant)

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -144,6 +144,8 @@ private:
     IR::Instr *     LowerNewScGenFunc(IR::Instr *instr);
     IR::Instr *     LowerNewScFuncHomeObj(IR::Instr *instr);
     IR::Instr *     LowerNewScGenFuncHomeObj(IR::Instr *instr);
+    IR::Instr *     LowerStPropIdArrFromVar(IR::Instr *instr);
+    IR::Instr *     LowerRestify(IR::Instr *instr);
     IR::Instr*      GenerateCompleteStFld(IR::Instr* instr, bool emitFastPath, IR::JnHelperMethod monoHelperAfterFastPath, IR::JnHelperMethod polyHelperAfterFastPath,
                         IR::JnHelperMethod monoHelperWithoutFastPath, IR::JnHelperMethod polyHelperWithoutFastPath, bool withPutFlags, Js::PropertyOperationFlags flags);
     bool            GenerateStFldWithCachedType(IR::Instr * instrStFld, bool* continueAsHelperOut, IR::LabelInstr** labelHelperOut, IR::RegOpnd** typeOpndOut);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -191,12 +191,18 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
     IR::JnHelperMethod  helperMethod = instrCall->GetSrc1()->AsHelperCallOpnd()->m_fnHelper;
 
     instrCall->FreeSrc1();
-
+    
 #ifndef _M_X64
+    bool callHasDst = instrCall->GetDst() != nullptr;
     prevInstr = ChangeToHelperCall(instrCall, helperMethod);
-#endif
-
+    if (callHasDst)
+    {
+        prevInstr = prevInstr->m_prev;
+    }
+    Assert(prevInstr->GetSrc1()->IsHelperCallOpnd() && prevInstr->GetSrc1()->AsHelperCallOpnd()->m_fnHelper == helperMethod);
+#else
     prevInstr = instrCall;
+#endif
 
     while (argOpnd)
     {
@@ -206,11 +212,14 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
         Assert(regArg->m_sym->m_isSingleDef);
         IR::Instr *instrArg = regArg->m_sym->m_instrDef;
 
-        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A ||
-            (helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A)
-        );
+        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A || instrArg->m_opcode == Js::OpCode::ExtendArg_A &&
+        (
+            helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperRestify ||
+            helperMethod == IR::JnHelperMethod::HelperStPropIdArrFromVar
+        ));
         prevInstr = LoadHelperArgument(prevInstr, instrArg->GetSrc1());
 
         argOpnd = instrArg->GetSrc2();

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -209,10 +209,14 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
         Assert(regArg->m_sym->m_isSingleDef);
         IR::Instr *instrArg = regArg->m_sym->m_instrDef;
 
-        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A ||
-            (helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A));
+        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A || instrArg->m_opcode == Js::OpCode::ExtendArg_A &&
+        (
+            helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperRestify ||
+            helperMethod == IR::JnHelperMethod::HelperStPropIdArrFromVar
+        ));
         prevInstr = this->LoadHelperArgument(prevInstr, instrArg->GetSrc1());
 
         argOpnd = instrArg->GetSrc2();

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -223,10 +223,14 @@ LowererMD::LowerCallHelper(IR::Instr *instrCall)
         Assert(regArg->m_sym->m_isSingleDef);
         IR::Instr *instrArg = regArg->m_sym->m_instrDef;
 
-        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A ||
-            (helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A) ||
-            (helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj && instrArg->m_opcode == Js::OpCode::ExtendArg_A));
+        Assert(instrArg->m_opcode == Js::OpCode::ArgOut_A || instrArg->m_opcode == Js::OpCode::ExtendArg_A &&
+        (
+            helperMethod == IR::JnHelperMethod::HelperOP_InitCachedScope ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperScrFunc_OP_NewScGenFuncHomeObj ||
+            helperMethod == IR::JnHelperMethod::HelperRestify ||
+            helperMethod == IR::JnHelperMethod::HelperStPropIdArrFromVar
+        ));
         prevInstr = this->LoadHelperArgument(prevInstr, instrArg->GetSrc1());
 
         argOpnd = instrArg->GetSrc2();

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -626,7 +626,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6Spread               (true)
 #define DEFAULT_CONFIG_ES6String               (true)
 #define DEFAULT_CONFIG_ES6StringPrototypeFixes (true)
-#define DEFAULT_CONFIG_ES2018ObjectSpread      (false)
+#define DEFAULT_CONFIG_ES2018ObjectRestSpread  (false)
 #ifdef COMPILE_DISABLE_ES6PrototypeChain
     // If ES6PrototypeChain needs to be disabled by compile flag, DEFAULT_CONFIG_ES6PrototypeChain should be false
     #define DEFAULT_CONFIG_ES6PrototypeChain       (false)
@@ -1122,7 +1122,7 @@ FLAGPR           (Boolean, ES6, ES6Rest                , "Enable ES6 Rest parame
 FLAGPR           (Boolean, ES6, ES6Spread              , "Enable ES6 Spread support"                                , DEFAULT_CONFIG_ES6Spread)
 FLAGPR           (Boolean, ES6, ES6String              , "Enable ES6 String extensions"                             , DEFAULT_CONFIG_ES6String)
 FLAGPR           (Boolean, ES6, ES6StringPrototypeFixes, "Enable ES6 String.prototype fixes"                        , DEFAULT_CONFIG_ES6StringPrototypeFixes)
-FLAGPR           (Boolean, ES6, ES2018ObjectSpread     , "Enable ES2018 Object Spread"                              , DEFAULT_CONFIG_ES2018ObjectSpread)
+FLAGPR           (Boolean, ES6, ES2018ObjectRestSpread , "Enable ES2018 Object Rest/Spread"                         , DEFAULT_CONFIG_ES2018ObjectRestSpread)
 
 #ifndef COMPILE_DISABLE_ES6PrototypeChain
     #define COMPILE_DISABLE_ES6PrototypeChain 0

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -391,6 +391,8 @@ private:
     ParseNodeParamPattern * CreateParamPatternNode(ParseNodePtr pnode1);
     ParseNodeParamPattern * CreateDummyParamPatternNode(charcount_t ichMin);
 
+    ParseNodeObjLit * CreateObjectPatternNode(ParseNodePtr pnodeMemberList, charcount_t ichMin, charcount_t ichLim, bool convertToPattern=false);
+
     Symbol*      AddDeclForPid(ParseNodeVar * pnode, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl);
     void         CheckRedeclarationErrorForBlockId(IdentPtr pid, int blockId);
 
@@ -733,8 +735,15 @@ public:
         else
         {
             ForEachItemInList(patternNode->AsParseNodeUni()->pnode1, [&](ParseNodePtr item) {
-                Assert(item->nop == knopObjectPatternMember);
-                MapBindIdentifierFromElement(item->AsParseNodeBin()->pnode2, handler);
+                Assert(item->nop == knopObjectPatternMember || item->nop == knopEllipsis);
+                if (item->nop == knopObjectPatternMember)
+                {
+                    MapBindIdentifierFromElement(item->AsParseNodeBin()->pnode2, handler);
+                }
+                else
+                {
+                    MapBindIdentifierFromElement(item->AsParseNodeUni()->pnode1, handler);
+                }
             });
         }
     }
@@ -1026,7 +1035,7 @@ private:
         BOOL *nativeForOkay = nullptr);
 
     template <bool buildAST>
-    ParseNodePtr ParseDestructuredVarDecl(tokens declarationType, bool isDecl, bool *hasSeenRest, bool topLevel = true, bool allowEmptyExpression = true);
+    ParseNodePtr ParseDestructuredVarDecl(tokens declarationType, bool isDecl, bool *hasSeenRest, bool topLevel = true, bool allowEmptyExpression = true, bool isObjectPattern = false);
 
     template <bool buildAST>
     ParseNodePtr ParseDestructuredInitializer(ParseNodeUni * lhsNode,

--- a/lib/Parser/ptlist.h
+++ b/lib/Parser/ptlist.h
@@ -148,7 +148,7 @@ PTNODE(knopTry        , "try"              , Nop      , Try         , fnopNotExp
 PTNODE(knopThrow      , "throw"            , Nop      , Uni         , fnopNotExprStmt        , "ThrowStmt"                     )
 PTNODE(knopFinally    , "finally"          , Nop      , Finally     , fnopNotExprStmt|fnopCleanup, "FinallyStmt"               )
 PTNODE(knopTryFinally , "try-finally"      , Nop      , TryFinally  , fnopNotExprStmt        , "TryFinallyStmt"                )
-PTNODE(knopObjectPattern, "{} = "          , Nop      , Uni         , fnopUni                , "ObjectAssignmentPattern"       )
+PTNODE(knopObjectPattern, "{} = "          , Nop      , ObjLit      , fnopUni                , "ObjectAssignmentPattern"       )
 PTNODE(knopObjectPatternMember, "{:} = "   , Nop      , Bin         , fnopBin                , "ObjectAssignmentPatternMember" )
 PTNODE(knopArrayPattern, "[] = "           , Nop      , ArrLit      , fnopUni                , "ArrayAssignmentPattern"        )
 PTNODE(knopParamPattern, "({[]})"          , Nop      , ParamPattern, fnopUni                , "DestructurePattern"            )

--- a/lib/Parser/ptree.cpp
+++ b/lib/Parser/ptree.cpp
@@ -103,6 +103,13 @@ ParseNodeArrLit * ParseNode::AsParseNodeArrLit()
     return reinterpret_cast<ParseNodeArrLit*>(this);
 }
 
+ParseNodeObjLit * ParseNode::AsParseNodeObjLit()
+{
+    // Currently only Object Assignment Pattern needs extra field to count members
+    Assert(this->nop == knopObjectPattern);
+    return reinterpret_cast<ParseNodeObjLit*>(this);
+}
+
 ParseNodeCall * ParseNode::AsParseNodeCall()
 {
     Assert(this->nop == knopCall || this->nop == knopNew);
@@ -393,6 +400,11 @@ ParseNodeVar::ParseNodeVar(OpCode nop, charcount_t ichMin, charcount_t ichLim, I
 
 ParseNodeArrLit::ParseNodeArrLit(OpCode nop, charcount_t ichMin, charcount_t ichLim)
     : ParseNodeUni(nop, ichMin, ichLim, nullptr)
+{
+}
+
+ParseNodeObjLit::ParseNodeObjLit(OpCode nop, charcount_t ichMin, charcount_t ichLim, uint staticCnt, uint computedCnt, bool rest)
+    : ParseNodeUni(nop, ichMin, ichLim, nullptr), staticCount(staticCnt), computedCount(computedCnt), hasRest(rest)
 {
 }
 

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -84,6 +84,7 @@ class ParseNodeExportDefault;
 class ParseNodeStrTemplate;
 class ParseNodeSuperReference;
 class ParseNodeArrLit;
+class ParseNodeObjLit;
 class ParseNodeClass;
 class ParseNodeParamPattern;
 
@@ -129,6 +130,7 @@ public:
     ParseNodeStrTemplate * AsParseNodeStrTemplate();
     ParseNodeSuperReference * AsParseNodeSuperReference();
     ParseNodeArrLit * AsParseNodeArrLit();
+    ParseNodeObjLit * AsParseNodeObjLit();
 
     ParseNodeCall * AsParseNodeCall();
     ParseNodeSuperCall * AsParseNodeSuperCall();
@@ -403,6 +405,18 @@ public:
     BYTE hasMissingValues:1;
 
     DISABLE_SELF_CAST(ParseNodeArrLit);
+};
+
+class ParseNodeObjLit : public ParseNodeUni
+{
+public:
+    ParseNodeObjLit(OpCode nop, charcount_t ichMin, charcount_t ichLim, uint staticCnt=0, uint computedCnt=0, bool rest=false);
+
+    uint staticCount;
+    uint computedCount;
+    bool hasRest;
+
+    DISABLE_SELF_CAST(ParseNodeObjLit);
 };
 
 class FuncInfo;

--- a/lib/Runtime/ByteCode/ByteCodeCacheReleaseFileVersion.h
+++ b/lib/Runtime/ByteCode/ByteCodeCacheReleaseFileVersion.h
@@ -4,6 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 // NOTE: If there is a merge conflict the correct fix is to make a new GUID.
 
-// {0C0FCC1A-2895-4AEE-A6D1-159A42C12947}
+// {39DEDDF4-EEE4-43E8-A2C8-2550A26007D6}
 const GUID byteCodeCacheReleaseFileVersion =
-{ 0x0C0FCC1A, 0x2895, 0x4AEE, { 0xA6, 0xD1, 0x15, 0x9A, 0x42, 0xC1, 0x29, 0x47 } };
+{ 0x39DEDDF4, 0xEEE4, 0x43E8, { 0xA2, 0xC8, 0x25, 0x50, 0xA2, 0x60, 0x07, 0xD6 } };

--- a/lib/Runtime/ByteCode/ByteCodeDumper.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeDumper.cpp
@@ -804,6 +804,11 @@ namespace Js
                 DumpU4(data->C1);
                 break;
             }
+            case OpCode::NewPropIdArrForCompProps:
+            {
+                Output::Print(_u(" R%u = [%u] "), data->R0, data->C1);
+                break;
+            }
             default:
                 DumpReg(data->R0);
                 Output::Print(_u("="));
@@ -840,6 +845,7 @@ namespace Js
 #endif
             case OpCode::StObjSlot:
             case OpCode::StObjSlotChkUndecl:
+            case OpCode::StPropIdArrFromVar:
                 Output::Print(_u(" R%d[%d] = R%d "),data->Instance,data->SlotIndex,data->Value);
                 break;
             case OpCode::LdSlot:
@@ -877,7 +883,7 @@ namespace Js
             case OpCode::LdEnvObj:
             case OpCode::LdLocalObjSlot:
             case OpCode::LdParamObjSlot:
-                Output::Print(_u(" R%d = [%d] "),data->Value, data->SlotIndex);
+                Output::Print(_u(" R%d = [%d] "), data->Value, data->SlotIndex);
                 break;
             case OpCode::NewScFunc:
             case OpCode::NewStackScFunc:

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -4547,7 +4547,7 @@ public:
         auto propertyCount = serialized->propertyCount;
         auto extraSlotCount = serialized->extraSlots;
 
-        Assert(serialized->offset + sizeof(PropertyIdArray) < deserializeInto->GetLength());
+        Assert(serialized->offset + sizeof(PropertyIdArray) <= deserializeInto->GetLength());
         auto result = (PropertyIdArray *)(deserializeInto->GetBuffer() + serialized->offset);
         result->count = propertyCount;
         result->extraSlots = extraSlotCount;

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -1525,6 +1525,7 @@ StoreCommon:
 #endif
         case OpCode::StObjSlot:
         case OpCode::StObjSlotChkUndecl:
+        case OpCode::StPropIdArrFromVar:
             break;
 
         default:

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -827,7 +827,11 @@ MACRO_BACKEND_ONLY(     TrapIfMinIntOverNegOne, Reg3,       OpSideEffect)
 MACRO_BACKEND_ONLY(     TrapIfZero,         Reg3,           OpSideEffect)
 MACRO_BACKEND_ONLY(     TrapIfUnalignedAccess, Reg3,        OpSideEffect)
 
-MACRO_EXTEND_WMS(       SpreadObjectLiteral, Reg2,          OpSideEffect|OpHasImplicitCall)
+MACRO_EXTEND_WMS(       SpreadObjectLiteral,Reg2,           OpSideEffect|OpHasImplicitCall)
+MACRO_EXTEND_WMS(       StPropIdArrFromVar, ElementSlot,    OpSideEffect|OpHasImplicitCall)
+MACRO_EXTEND_WMS(       Restify,            Reg4,           OpSideEffect|OpHasImplicitCall)
+MACRO_EXTEND_WMS(       NewPropIdArrForCompProps, Reg1Unsigned1, OpSideEffect)
+
 
 // All SIMD ops are backend only for non-asmjs.
 #define MACRO_SIMD(opcode, asmjsLayout, opCodeAttrAsmJs, OpCodeAttr, ...) MACRO_BACKEND_ONLY(opcode, Empty, OpCodeAttr)

--- a/lib/Runtime/Language/InterpreterHandler.inl
+++ b/lib/Runtime/Language/InterpreterHandler.inl
@@ -397,6 +397,9 @@ EXDEF3_WMS(CUSTOM,                  EmitTmpRegCount,            OP_EmitTmpRegCou
 #endif
 EXDEF2    (EMPTY,                   BeginBodyScope,             OP_BeginBodyScope)
 EXDEF2_WMS(A2toXXMem,               SpreadObjectLiteral,        JavascriptObject::SpreadObjectLiteral)
+EXDEF2_WMS(A2A2NonVartoXXMem,       Restify,                    JavascriptObject::Restify)
+EXDEF2_WMS(SET_ELEM_SLOTMem,        StPropIdArrFromVar,         OP_StPropIdArrFromVar)
+EXDEF2_WMS(SIZEtoA1MemNonVar,       NewPropIdArrForCompProps,   OP_NewPropIdArrForCompProps)
 
 
 #endif

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -106,7 +106,7 @@ namespace Js
         Var* m_inParams;                // Range of 'in' parameters
         Var* m_outParams;               // Range of 'out' parameters (offset in m_localSlots)
         Var* m_outSp;                   // Stack pointer for next outparam
-        Var* m_outSpCached;             // Stack pointer for caching previos SP (in order to assist in try..finally)
+        Var* m_outSpCached;             // Stack pointer for caching previous SP (in order to assist in try..finally)
         Var  m_arguments;               // Dedicated location for this frame's arguments object
         StackScriptFunction * stackNestedFunctions;
         FrameDisplay * localFrameDisplay;
@@ -365,6 +365,9 @@ namespace Js
         static InterpreterStackFrame* CreateInterpreterStackFrameForGenerator(ScriptFunction* function, FunctionBody* executeFunction, JavascriptGenerator* generator, bool doProfile);
 
         void InitializeClosures();
+
+        static void OP_StPropIdArrFromVar(Var instance, uint32 index, Var value, ScriptContext* scriptContext);
+        static Js::PropertyIdArray * OP_NewPropIdArrForCompProps(uint32 size, ScriptContext* scriptContext);
 
     private:
 #if DYNAMIC_INTERPRETER_THUNK

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -112,14 +112,15 @@ namespace Js
         static bool IsPrototypeOfStopAtProxy(RecyclableObject* proto, RecyclableObject* obj, ScriptContext* scriptContext);
 
         static void SpreadObjectLiteral(Var source, Var to, ScriptContext* scriptContext);
+        static void Restify(Var source, Var to, void* excludedStatic, void* excludedComputed, ScriptContext* scriptContext);
 
     private:
         template <bool tryCopy, bool assign>
-        static void CopyDataPropertiesHelper(Var source, RecyclableObject* to, ScriptContext* scriptContext, PropertyId* excluded = nullptr, uint32 excludedLength = 0);
+        static void CopyDataPropertiesHelper(Var source, RecyclableObject* to, ScriptContext* scriptContext, const BVSparse<Recycler>* excluded = nullptr);
         template <bool assign>
-        static void CopyDataPropertiesForGenericObjects(RecyclableObject* from, RecyclableObject* to, PropertyId* excluded, uint32 excludedLength, ScriptContext* scriptContext);
+        static void CopyDataPropertiesForGenericObjects(RecyclableObject* from, RecyclableObject* to, const BVSparse<Recycler>* excluded, ScriptContext* scriptContext);
         template <bool assign>
-        static void CopyDataPropertiesForProxyObjects(RecyclableObject* from, RecyclableObject* to, PropertyId* excluded, uint32 excludedLength, ScriptContext* scriptContext);
+        static void CopyDataPropertiesForProxyObjects(RecyclableObject* from, RecyclableObject* to, const BVSparse<Recycler>* excluded, ScriptContext* scriptContext);
 
         static BOOL CreateDataProperty(RecyclableObject* obj, PropertyId key, Var value, ScriptContext* scriptContext);
         static JavascriptArray* CreateKeysHelper(RecyclableObject* object, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool includeSymbolProperties, bool includeStringProperties, bool includeSpecialProperties);

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -80,7 +80,7 @@ namespace Js
         virtual void const * GetOriginalStringReference();  // Get the allocated object that owns the original full string buffer
 
 #if ENABLE_TTD
-        //Get the associated property id for this string if there is on (e.g. it is a propertystring otherwise return Js::PropertyIds::_none)
+        //Get the associated property id for this string if there is one (e.g. it is a propertystring otherwise return Js::PropertyIds::_none)
         virtual Js::PropertyId TryGetAssociatedPropertyId() const { return Js::PropertyIds::_none; }
 #endif
 

--- a/test/Object/ObjectRest_JIT.js
+++ b/test/Object/ObjectRest_JIT.js
@@ -1,0 +1,76 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Object Rest JIT unit tests
+
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "Test JIT basic behavior",
+        body: function() {
+            function f() {
+                let {a, ...rest} = {a: 1, b: 2};
+                return rest;
+            }
+            
+            f();
+            let rest = f();
+
+            assert.areEqual(2, rest.b);
+        }
+    },
+    {
+        name: "Test JIT basic behavior on binding pattern",
+        body: function() {
+            function f({a, ...rest}) {
+                return rest;
+            }
+            
+            f({a: 1, b: 2});
+            let rest = f({a: 1, b: 2});
+
+            assert.areEqual(2, rest.b);
+        }
+    },
+    // TODO: Fix bug regarding nested destrucuring in array rest. 
+    // Disabling this test for now
+    // {
+    //     name: "Test JIT basic behavior with object rest nested in array rest",
+    //     body: function() {
+    //         function f(a, ...{...rest}) {
+    //             return rest;
+    //         }
+            
+    //         f(1, 2);
+    //         let rest = f(1, 2);
+
+    //         assert.areEqual(2, rest[0]);
+    //     }
+    // },
+    {
+        name: "Test JIT bailout",
+        body: function() {
+            const obj = {a: 2};
+            function f(x) {
+                const a = obj.a;
+                const {...unused} = x;
+                return a + obj.a;
+            }
+
+            // Train it that ...x is not reentrant, so it emits code that assumes the second obj.a matches the first
+            const result = f({});
+            assert.areEqual(4, result);
+
+            // Now call with a getter and verify that it bails out when the previous assumption is invalidated
+            const reentrantResult = f({ get b() { obj.a = 3; } });
+            assert.areEqual(5, reentrantResult);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Object/ObjectRest_Simple.js
+++ b/test/Object/ObjectRest_Simple.js
@@ -1,0 +1,325 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Object Rest unit tests
+
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "let assignment with simple Object",
+        body: function() {
+            let {a, b, ...rest} = {a: 1, b: 2, c: 3, d: 4};
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual({c: 3, d: 4}, rest);
+        }
+    },
+    {
+        name: "var assignment with simple Object",
+        body: function() {
+            var {a, b, ...rest} = {a: 1, b: 2, c: 3, d: 4};
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual({c: 3, d: 4}, rest);
+        }
+    },
+    {
+        name: "Rest in assignment expression",
+        body: function() {
+            ({a, b, ...rest} = {a: 1, b: 2, c: 3, d: 4});
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual({c: 3, d: 4}, rest);
+        }
+    },
+    {
+        name: "Rest with simple function parameter Object",
+        body: function() {
+            function foo({a: _a, b: _b, ..._rest}) {
+                assert.areEqual(1, _a);
+                assert.areEqual(2, _b);
+                assert.areEqual({c: 3, d: 4}, _rest);
+            }
+            foo({a: 1, b: 2, c: 3, d: 4});
+        }
+    },
+    {
+        name: "Rest with simple catch parameter Object",
+        body: function() {
+            try {
+                throw {a: 1, b: 2, c: 3, d: 4};
+            } catch({a: _a, b: _b, ..._rest}) {
+                assert.areEqual(1, _a);
+                assert.areEqual(2, _b);
+                assert.areEqual({c: 3, d: 4}, _rest);
+            }
+        }
+    },
+    {
+        name: "Rest with simple for variable declaration",
+        body: function() {
+            bar = [{a: 1, b: 2, c: 3, d: 4}];
+            for({a, b, ...rest} of bar) {
+                assert.areEqual(1, a);
+                assert.areEqual(2, b);
+                assert.areEqual({c: 3, d: 4}, rest);
+            }
+        }
+    },
+    {
+        name: "Rest nested in destructuring",
+        body: function() {
+            let {a, b, double: {c, ...rest}} = {a: 1, b: 2, double: {c: 3, d: 4}};
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual(3, c);
+            assert.areEqual({d: 4}, rest);
+        }
+    },
+    {
+        name: "Rest with nested function parameter Object",
+        body: function() {
+            function foo({a: _a, b: _b, double: {c: _c, ..._rest}}) {
+                assert.areEqual(1, _a);
+                assert.areEqual(2, _b);
+                assert.areEqual(3, _c);
+                assert.areEqual({d: 4}, _rest);
+            }
+            foo({a: 1, b: 2, double: {c: 3, d: 4}});
+        }
+    },
+    {
+        name: "Rest with computed properties",
+        body: function() {
+            let {a, ["b"]:b, ...rest} = {a: 1, b: 2, c: 3, d: 4};
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual({c: 3, d: 4}, rest);
+        }
+    },
+    {
+        name: "Rest with computed properties in function parameter binding",
+        body: function() {
+            function foo({a: _a, ["b"]: _b, ..._rest}) {
+                assert.areEqual(1, _a);
+                assert.areEqual(2, _b);
+                assert.areEqual({c: 3, d: 4}, _rest);
+            }
+            foo({a: 1, b: 2, c: 3, d: 4});
+        }
+    },
+    {
+        name: "Rest inside re-entrant function",
+        body: function() {
+            function foo(r) {
+                if (r) {
+                    var {a, [foo(false)]:b, ...rest} = {a: 1, b: 2, c: 3, d: 4};
+                    assert.areEqual(1, a);
+                    assert.areEqual(2, b);
+                    assert.areEqual({c: 3, d: 4}, rest);
+                } else {
+                    var {one, ...rest} = {one:1, two:2, three:3};
+                    assert.areEqual(1, one);
+                    assert.areEqual({two: 2, three: 3}, rest);
+                }
+                return "b";
+            }
+            foo(true);
+        }
+    },
+    {
+        name: "Rest nested in Computed Value",
+        body: function() {
+            let {[eval("let {..._rest} = {a: 1, b: 2, c: 3, d: 4};\"a\"")]:nest, ...rest} = {a: 10, b: 20, c: 30, d: 40};
+            assert.areEqual(10, nest);
+            assert.areEqual({b: 20, c: 30, d: 40}, rest);
+        }
+    },
+    {
+        name: "Rest with no values left to destructure",
+        body: function() {
+            let {a, b, ...rest} = {a: 1, b: 2};
+            assert.areEqual(1, a);
+            assert.areEqual(2, b);
+            assert.areEqual({}, rest);
+        }
+    },
+    {
+        name: "Getters in rhs object should be evaluated",
+        body: function() {
+            let getterExecuted = false;
+            let obj = {a: 1, get b() {getterExecuted = true; return 2;}};
+            let {...rest} = obj;
+            assert.areEqual(1, rest.a);
+            assert.isTrue(getterExecuted);
+            assert.areEqual(2, rest.b);
+        }
+    },
+    {
+        name: "Rest modifying source object",
+        body: function() {
+            let val = 1;
+            let source = {get a() {val++; return 1;}, get b() {return val;}};
+            let {b, ...rest} = source;
+            assert.areEqual(1, b);
+            assert.areEqual(1, rest.a);
+        }
+    },
+    {
+        name: "Source object changed by destructuring before Rest",
+        body: function() {
+            let val = 1;
+            let source = {get a() {val++; return 1;}, get b() {return val;}};
+            let {a, ...rest} = source;
+            assert.areEqual(1, a);
+            assert.areEqual(2, rest.b);
+        }
+    },
+    {
+        name: "Copy only own properties",
+        body: function() {
+            let parent = {i: 1, j: 2};
+            let child = Object.create(parent);
+            child.i = 3;
+            let {...rest} = child;
+
+            assert.areEqual(3, child.i);
+            assert.areEqual(2, child.j);
+            assert.areEqual(3, rest.i);
+            assert.isFalse(rest.hasOwnProperty("j"));
+        }
+    },
+    {
+        name: "Rest includes symbols in properties",
+        body: function() {
+            let sym = Symbol("foo");
+            let a = {};
+            a[sym] = 1;
+            let {...rest} = a;
+            assert.areEqual(1, rest[sym], "property with Symbol property name identifier should be copied over");
+            assert.areEqual(1, Object.getOwnPropertySymbols(rest).length);
+        }
+    },
+    {
+        name: "Object Rest interacting with Arrays",
+        body: function() {
+            let arr = [1, 2, 3];
+            let {[2]:foo, ...rest} = arr;
+            assert.areEqual(2, Object.keys(rest).length);
+            assert.areEqual(1, rest[0]);
+            assert.areEqual(2, rest[1]);
+            assert.areEqual(3, foo);
+        }
+    },
+    // TODO: Fix bug regarding nested destrucuring in array rest. 
+    // Disabling this test for now
+    // {
+    //     name: "Object Rest interacting with Array Rest",
+    //     body: function() {
+    //         function foo(a, ...{...rest}) {
+    //             assert.areEqual(1, a);
+    //             assert.areEqual(2, rest[0]);
+    //             assert.areEqual(3, rest[1]);
+    //             assert.areEqual(2, Object.keys(rest).length);
+    //         }            
+    //         foo(1, 2, 3);
+    //     }
+    // },
+    {
+        name: "Object Rest interacting with Numbers",
+        body: function() {
+            let {...rest} = 1;
+            assert.areEqual(0, Object.keys(rest).length);
+        }
+    },
+    {
+        name: "Object Rest interacting with Functions",
+        body: function() {
+            let {...rest} = function i() {return 1;}
+            assert.areEqual(0, Object.keys(rest).length);
+        }
+    },
+    {
+        name: "Object Rest interacting with Strings",
+        body: function() {
+            let {...rest} = "edge";
+            assert.areEqual(4, Object.keys(rest).length);
+            assert.areEqual("e", rest[0]);
+            assert.areEqual("d", rest[1]);
+            assert.areEqual("g", rest[2]);
+            assert.areEqual("e", rest[3]);
+        }
+    },
+    {
+        name: "Test Proxy Object",
+        body: function() {
+            let proxy = new Proxy({i: 1, j: 2}, {});
+            let {...rest} = proxy;
+            assert.areEqual(2, Object.keys(rest).length);
+            assert.areEqual(1, rest.i);
+            assert.areEqual(2, rest.j);
+        }
+    },
+    {
+        name: "Test Proxy Object with custom getter",
+        body: function() {
+            let handler = {get: function(obj, prop) {return obj[prop];}};
+            let proxy = new Proxy({i: 1, j: 2}, handler);
+            let {...rest} = proxy;
+            assert.areEqual(2, Object.keys(rest).length);
+            assert.areEqual(1, rest.i);
+            assert.areEqual(2, rest.j);
+        }
+    },
+    {
+        name: "Test Proxy Object with custom getter and setter",
+        body: function() {
+            let setterCalled = false;
+            let handler = {
+                get: function(obj, prop) {
+                    return obj[prop];
+                },
+                set: function(obj, prop, value) {
+                    setterCalled = true;
+                }
+            };
+            let proxy = new Proxy({i: 1, j: 2}, handler);
+            let {...rest} = proxy;
+            assert.areEqual(2, Object.keys(rest).length);
+            assert.areEqual(1, rest.i);
+            assert.areEqual(2, rest.j);
+            assert.isFalse(setterCalled);
+        }
+    },
+    {
+        name: "Test Syntax Errors",
+        body: function() {
+            assert.throws(function () { eval("let {...rest1, ...rest2} = {a:1, b:2};"); }, SyntaxError, "Destructuring assignment can only have 1 Rest", "Destructuring rest variables must be in the last position of the expression");
+            assert.throws(function () { eval("let {...{a, b}} = {a:1, b:2};"); }, SyntaxError, "Destructuring inside Rest is invalid syntax", "Expected identifier");
+            assert.throws(function () { eval("let {...{a, ...rest}} = {a:1, b:2};"); }, SyntaxError, "Nested Rest is invalid syntax", "Expected identifier");
+            assert.throws(function () { eval("let {...rest, a} = {a:1, b:2};"); }, SyntaxError, "Rest before other variables is invalid syntax", "Destructuring rest variables must be in the last position of the expression");
+            assert.throws(function () { eval("...(rest)"); }, SyntaxError, "Rest must be inside destructuring", "Invalid use of the ... operator. Spread can only be used in call arguments or an array literal.");
+            assert.throws(function () { eval("let {...(rest)} = {a:1, b:2};"); }, SyntaxError, "Destructuring expressions can only have identifier references");
+            assert.throws(function () { eval("let {...++rest} = {a: 1, b: 2};"); }, SyntaxError, "Prefix operators before rest is invalid syntax", "Unexpected operator in destructuring expression");
+            assert.throws(function () { eval("let {...rest++} = {a: 1, b: 2};"); }, SyntaxError, "Postfix operators after rest is invalid syntax", "Unexpected operator in destructuring expression");
+            assert.throws(function () { eval("let {...rest+1} = {a: 1, b: 2};"); }, SyntaxError, "Infix operators after rest is invalid syntax", "Unexpected operator in destructuring expression");
+            assert.throws(function () { eval("let {... ...rest} = {};"); }, SyntaxError, "Incomplete rest expression", "Unexpected operator in destructuring expression");
+            assert.throws(function () { eval("let {...} = {};"); }, SyntaxError, "Incomplete rest expression", "Destructuring expressions can only have identifier references");
+            assert.throws(function () { eval("function foo({...rest={}}){};"); }, SyntaxError, "Rest cannot be default initialized", "Unexpected default initializer");
+        }
+    },
+    {
+        name: "Test Type Errors",
+        body: function() {
+            assert.throws(function () { eval("let {...rest} = undefined;"); }, TypeError, "Cannot destructure undefined", "Cannot convert null or undefined to object");
+            assert.throws(function () { eval("let {...rest} = null;"); }, TypeError, "Cannot destructure null", "Cannot convert null or undefined to object");
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -453,19 +453,37 @@
   <test>
     <default>
       <files>ObjectSpread_Simple.js</files>
-      <compile-flags>-args summary -endargs -NoNative -ES2018ObjectSpread</compile-flags>
+      <compile-flags>-args summary -endargs -NoNative -ES2018ObjectRestSpread</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>ObjectSpread_JIT.js</files>
-      <compile-flags>-args summary -endargs -ES2018ObjectSpread -bgjit -maxinterpretcount:1 -off:simplejit</compile-flags>
+      <compile-flags>-args summary -endargs -ES2018ObjectRestSpread -bgjit- -maxinterpretcount:1 -off:simplejit</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>ObjectSpread_Limits.js</files>
-      <compile-flags>-args summary -endargs -ES2018ObjectSpread</compile-flags>
+      <compile-flags>-args summary -endargs -ES2018ObjectRestSpread</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>ObjectRest_Simple.js</files>
+      <compile-flags>-args summary -endargs -NoNative -ES2018ObjectRestSpread -forceserialized</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>ObjectRest_Simple.js</files>
+      <compile-flags>-args summary -endargs -NoNative -ES2018ObjectRestSpread</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>ObjectRest_JIT.js</files>
+      <compile-flags>-args summary -endargs -ES2018ObjectRestSpread -off:simplejit</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
- Currently defaults to off under the ES2018ObjectRestSpread flag.
- Parser changes:
    - Added ParseNodeObjLit as new type of node used to store info for Rest
- Bytecode changes:
    - Added 3 new bytecodes: Restify, NewPropIdArr, and StPropIdArrFromVar
    - Restify: copies leftover properties from the source object to a new empty object (runtime semantics are equivalent to Object Spread)
    - NewPropIdArr: creates a new Recycler allocated array to store computed properties' ids (for keeping track of which properties have already been used)
    - StPropIdArrFromVar: converts a computed property string (stored in a Var) into a property id and stores it in the heap allocated array at the specified index
    - ByteCodeEmitter only emits the above bytecodes when Rest is seen in the object pattern. This simplifies destructuring if rest is not used (and removes need for Recycler allocated array). The array is also not allocated if no computed properties are seen.
- JIT changes:
    - All new bytecodes are changed to their respective helper calls
- Fixed typo in JavascriptString
- Added unit tests for Object Rest
- test262 results for feature "object-rest":
    - All tests passed except for async-gen and async related tests
