### PR TITLE
Code Quality: use legalizePostRegAlloc flag on Func instead of passing bool to Legalizers

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -72,6 +72,7 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     hasInstrNumber(false),
     maintainByteCodeOffset(true),
     frameSize(0),
+    topFunc(parentFunc ? parentFunc->topFunc : this),
     parentFunc(parentFunc),
     argObjSyms(nullptr),
     m_nonTempLocalVars(nullptr),
@@ -109,6 +110,7 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     isTJLoopBody(false),
     m_nativeCodeDataSym(nullptr),
     isFlowGraphValid(false),
+    legalizePostRegAlloc(false),
 #if DBG
     m_callSiteCount(0),
 #endif
@@ -1314,6 +1316,11 @@ Func::EndPhase(Js::Phase tag, bool dump)
     }
 #endif
 
+    if (tag == Js::RegAllocPhase)
+    {
+        this->legalizePostRegAlloc = true;
+    }
+
 #if DBG
     if (tag == Js::LowererPhase)
     {
@@ -1350,28 +1357,6 @@ Func::EndPhase(Js::Phase tag, bool dump)
     }
     this->m_alloc->MergeDelayFreeList();
 #endif
-}
-
-Func const *
-Func::GetTopFunc() const
-{
-    Func const * func = this;
-    while (!func->IsTopFunc())
-    {
-        func = func->parentFunc;
-    }
-    return func;
-}
-
-Func *
-Func::GetTopFunc()
-{
-    Func * func = this;
-    while (!func->IsTopFunc())
-    {
-        func = func->parentFunc;
-    }
-    return func;
 }
 
 StackSym *

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -4797,7 +4797,8 @@ IR::Instr* LinearScan::InsertLea(IR::RegOpnd *dst, IR::Opnd *src, IR::Instr *con
 {
     IR::Instr *instrPrev = insertBeforeInstr->m_prev;
 
-    IR::Instr *instrRet = Lowerer::InsertLea(dst, src, insertBeforeInstr, true);
+    AutoRestoreLegalize restore(insertBeforeInstr->m_func, true);
+    IR::Instr *instrRet = Lowerer::InsertLea(dst, src, insertBeforeInstr);
 
     for (IR::Instr *instr = instrPrev->m_next; instr != insertBeforeInstr; instr = instr->m_next)
     {

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -15376,7 +15376,7 @@ IR::Instr *Lowerer::InsertSub(
     return instr;
 }
 
-IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr, bool postRegAlloc)
+IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr)
 {
     Assert(dst);
     Assert(src);
@@ -15388,11 +15388,11 @@ IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::I
     IR::Instr *const instr = IR::Instr::New(LowererMD::MDLea, dst, src, func);
 
     insertBeforeInstr->InsertBefore(instr);
-    return ChangeToLea(instr, postRegAlloc);
+    return ChangeToLea(instr);
 }
 
 IR::Instr *
-Lowerer::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
+Lowerer::ChangeToLea(IR::Instr * instr)
 {
     Assert(instr);
     Assert(instr->GetDst());
@@ -15402,7 +15402,7 @@ Lowerer::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
     Assert(!instr->GetSrc2());
 
     instr->m_opcode = LowererMD::MDLea;
-    LowererMD::Legalize(instr, postRegAlloc);
+    LowererMD::Legalize(instr);
     return instr;
 }
 
@@ -27185,7 +27185,7 @@ Lowerer::SetHasBailedOut(IR::Instr * bailoutInstr)
     IR::SymOpnd * hasBailedOutOpnd = IR::SymOpnd::New(this->m_func->m_hasBailedOutSym, TyUint32, this->m_func);
     IR::Instr * setInstr = IR::Instr::New(LowererMD::GetStoreOp(TyUint32), hasBailedOutOpnd, IR::IntConstOpnd::New(1, TyUint32, this->m_func), this->m_func);
     bailoutInstr->InsertBefore(setInstr);
-    LowererMD::Legalize(setInstr, true);
+    LowererMD::Legalize(setInstr);
 }
 
 IR::Instr*
@@ -27236,7 +27236,7 @@ Lowerer::EmitSaveEHBailoutReturnValueAndJumpToRetThunk(IR::Instr * insertAfterIn
     IR::RegOpnd *eaxOpnd = IR::RegOpnd::New(NULL, LowererMD::GetRegReturn(TyMachReg), TyMachReg, this->m_func);
     IR::Instr * movInstr = IR::Instr::New(LowererMD::GetStoreOp(TyVar), bailoutReturnValueSymOpnd, eaxOpnd, this->m_func);
     insertAfterInstr->InsertAfter(movInstr);
-    LowererMD::Legalize(movInstr, true);
+    LowererMD::Legalize(movInstr);
 
     IR::BranchInstr * jumpInstr = IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, this->currentRegion->GetBailoutReturnThunkLabel(), this->m_func);
     movInstr->InsertAfter(jumpInstr);
@@ -27258,7 +27258,7 @@ Lowerer::EmitRestoreReturnValueFromEHBailout(IR::LabelInstr * restoreLabel, IR::
 
     epilogLabel->InsertBefore(restoreLabel);
     epilogLabel->InsertBefore(movInstr);
-    LowererMD::Legalize(movInstr, true);
+    LowererMD::Legalize(movInstr);
     restoreLabel->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, epilogLabel, this->m_func));
 }
 

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -397,8 +397,8 @@ public:
     static IR::BranchInstr *    InsertTestBranch(IR::Opnd *const testSrc1, IR::Opnd *const testSrc2, const Js::OpCode branchOpCode, const bool isUnsigned, IR::LabelInstr *const target, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertAdd(const bool needFlags, IR::Opnd *const dst, IR::Opnd *src1, IR::Opnd *src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertSub(const bool needFlags, IR::Opnd *const dst, IR::Opnd *src1, IR::Opnd *src2, IR::Instr *const insertBeforeInstr);
-    static IR::Instr *          InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr, bool postRegAlloc = false);
-    static IR::Instr *          ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false);
+    static IR::Instr *          InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
+    static IR::Instr *          ChangeToLea(IR::Instr *const instr);
     static IR::Instr *          InsertXor(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertAnd(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertOr(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);

--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -2401,7 +2401,7 @@ bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         }
 
         instr->ReplaceSrc(regOpnd, regOpnd->m_sym->GetConstOpnd());
-        LegalizeMD::LegalizeInstr(instr, false);
+        LegalizeMD::LegalizeInstr(instr);
 
         return true;
     }
@@ -2421,7 +2421,7 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         }
         IR::SymOpnd *symOpnd = IR::SymOpnd::New(regOpnd->m_sym, regOpnd->GetType(), instr->m_func);
         instr->ReplaceSrc(regOpnd, symOpnd);
-        LegalizeMD::LegalizeInstr(instr, false);
+        LegalizeMD::LegalizeInstr(instr);
 
         return true;
     }

--- a/lib/Backend/arm/LegalizeMD.h
+++ b/lib/Backend/arm/LegalizeMD.h
@@ -70,21 +70,23 @@ struct LegalInstrForms
 class LegalizeMD
 {
 public:
-    static void LegalizeInstr(IR::Instr * instr, bool fPostRegAlloc);
-    static void LegalizeDst(IR::Instr * instr, bool fPostRegAlloc);
-    static void LegalizeSrc(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
+    static void LegalizeInstr(IR::Instr * instr);
+    static void LegalizeDst(IR::Instr * instr);
+    static void LegalizeSrc(IR::Instr * instr, IR::Opnd * opnd, uint opndNum);
 
     static bool LegalizeDirectBranch(IR::BranchInstr *instr, uint32 branchOffset); // DirectBranch has no src & dst operands.
     //Returns IndexOpnd which is removed from VFP indirect operand
-    static void LegalizeIndirOpndForVFP(IR::Instr* insertInstr, IR::IndirOpnd *indirOpnd, bool fPostRegAlloc);
+    static void LegalizeIndirOpndForVFP(IR::Instr* insertInstr, IR::IndirOpnd *indirOpnd);
 
 private:
-    static IR::Instr *LegalizeStore(IR::Instr *instr, LegalForms forms, bool fPostRegAlloc);
-    static IR::Instr *LegalizeLoad(IR::Instr *instr, uint opndNum, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpnd, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeSymOffset(IR::Instr * instr, IR::SymOpnd * indirOpnd, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeImmed(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, IntConstType immed, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeLabelOpnd(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
+    static RegNum GetScratchReg(IR::Instr * instr);
+
+    static IR::Instr *LegalizeStore(IR::Instr *instr, LegalForms forms);
+    static IR::Instr *LegalizeLoad(IR::Instr *instr, uint opndNum, LegalForms forms);
+    static void LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpnd, LegalForms forms);
+    static void LegalizeSymOffset(IR::Instr * instr, IR::SymOpnd * indirOpnd, LegalForms forms);
+    static void LegalizeImmed(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, IntConstType immed, LegalForms forms);
+    static void LegalizeLabelOpnd(IR::Instr * instr, IR::Opnd * opnd, uint opndNum);
 
     static void LegalizeLDIMM(IR::Instr * instr, IntConstType immed);
     static void LegalizeLdLabel(IR::Instr * instr, IR::Opnd * opnd);

--- a/lib/Backend/arm/LinearScanMD.cpp
+++ b/lib/Backend/arm/LinearScanMD.cpp
@@ -183,7 +183,7 @@ LinearScanMD::LegalizeDef(IR::Instr * instr)
 
     // Legalize opcodes, etc., but do not expand symbol/indirs with large offsets
     // because we can't safely do this until all loads and stores are in place.
-    LegalizeMD::LegalizeDst(instr, false);
+    LegalizeMD::LegalizeDst(instr);
 }
 
 void
@@ -201,11 +201,11 @@ LinearScanMD::LegalizeUse(IR::Instr * instr, IR::Opnd * opnd)
     // because we can't safely do this until all loads and stores are in place.
     if (opnd == instr->GetSrc1())
     {
-        LegalizeMD::LegalizeSrc(instr, opnd, 1, false);
+        LegalizeMD::LegalizeSrc(instr, opnd, 1);
     }
     else
     {
-        LegalizeMD::LegalizeSrc(instr, opnd, 2, false);
+        LegalizeMD::LegalizeSrc(instr, opnd, 2);
     }
 }
 

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -210,7 +210,7 @@ public:
             IR::Opnd*           GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsInstr);
 
             template <bool verify = false>
-            static void         Legalize(IR::Instr *const instr, bool fPostRegAlloc = false);
+            static void         Legalize(IR::Instr *const instr);
 
             void                GenerateFastInlineBuiltInMathAbs(IR::Instr *callInstr);
             void                GenerateFastInlineBuiltInMathFloor(IR::Instr *callInstr);

--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -1635,7 +1635,7 @@ bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         }
 
         instr->ReplaceSrc(regOpnd, constOpnd);
-        LegalizeMD::LegalizeInstr(instr, false);
+        LegalizeMD::LegalizeInstr(instr);
 
         return true;
     }
@@ -1655,7 +1655,7 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         }
         IR::SymOpnd *symOpnd = IR::SymOpnd::New(regOpnd->m_sym, regOpnd->GetType(), instr->m_func);
         instr->ReplaceSrc(regOpnd, symOpnd);
-        LegalizeMD::LegalizeInstr(instr, false);
+        LegalizeMD::LegalizeInstr(instr);
 
         return true;
     }

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -75,22 +75,23 @@ struct LegalInstrForms
 class LegalizeMD
 {
 public:
-    static void LegalizeInstr(IR::Instr * instr, bool fPostRegAlloc);
-    static void LegalizeDst(IR::Instr * instr, bool fPostRegAlloc);
-    static void LegalizeSrc(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
+    static void LegalizeInstr(IR::Instr * instr);
+    static void LegalizeDst(IR::Instr * instr);
+    static void LegalizeSrc(IR::Instr * instr, IR::Opnd * opnd, uint opndNum);
 
     static bool LegalizeDirectBranch(IR::BranchInstr *instr, uintptr_t branchOffset);
     static bool LegalizeAdrOffset(IR::Instr *instr, uintptr_t instrOffset);
     static bool LegalizeDataAdr(IR::Instr *instr, uintptr_t dataOffset);
 
 private:
+    static RegNum GetScratchReg(IR::Instr * instr);
     static void LegalizeRegOpnd(IR::Instr* instr, IR::Opnd* opnd);
-    static IR::Instr *LegalizeStore(IR::Instr *instr, LegalForms forms, bool fPostRegAlloc);
-    static IR::Instr *LegalizeLoad(IR::Instr *instr, uint opndNum, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpnd, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeSymOffset(IR::Instr * instr, IR::SymOpnd * indirOpnd, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeImmed(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, IntConstType immed, LegalForms forms, bool fPostRegAlloc);
-    static void LegalizeLabelOpnd(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
+    static IR::Instr *LegalizeStore(IR::Instr *instr, LegalForms forms);
+    static IR::Instr *LegalizeLoad(IR::Instr *instr, uint opndNum, LegalForms forms);
+    static void LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpnd, LegalForms forms);
+    static void LegalizeSymOffset(IR::Instr * instr, IR::SymOpnd * indirOpnd, LegalForms forms);
+    static void LegalizeImmed(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, IntConstType immed, LegalForms forms);
+    static void LegalizeLabelOpnd(IR::Instr * instr, IR::Opnd * opnd, uint opndNum);
 
     static inline uint32 ShiftTo16(UIntConstType* immed)
     {
@@ -106,9 +107,9 @@ private:
 
     static void LegalizeLDIMM(IR::Instr * instr, IntConstType immed);
     static void LegalizeLdLabel(IR::Instr * instr, IR::Opnd * opnd);
-    static IR::Instr * GenerateLDIMM(IR::Instr * instr, uint opndNum, RegNum scratchReg, bool fPostRegAlloc);
+    static IR::Instr * GenerateLDIMM(IR::Instr * instr, uint opndNum, RegNum scratchReg);
 
-    static IR::Instr * GenerateHoistSrc(IR::Instr * instr, uint opndNum, Js::OpCode op, RegNum scratchReg, bool fPostRegAlloc);
+    static IR::Instr * GenerateHoistSrc(IR::Instr * instr, uint opndNum, Js::OpCode op, RegNum scratchReg);
 
     static void ObfuscateLDIMM(IR::Instr * instrMov, IR::Instr * instrMovt);
     static void EmitRandomNopBefore(IR::Instr * instrMov, UINT_PTR rand, RegNum targetReg);

--- a/lib/Backend/arm64/LinearScanMD.cpp
+++ b/lib/Backend/arm64/LinearScanMD.cpp
@@ -183,7 +183,7 @@ LinearScanMD::LegalizeDef(IR::Instr * instr)
 
     // Legalize opcodes, etc., but do not expand symbol/indirs with large offsets
     // because we can't safely do this until all loads and stores are in place.
-    LegalizeMD::LegalizeDst(instr, false);
+    LegalizeMD::LegalizeDst(instr);
 }
 
 void
@@ -201,11 +201,11 @@ LinearScanMD::LegalizeUse(IR::Instr * instr, IR::Opnd * opnd)
     // because we can't safely do this until all loads and stores are in place.
     if (opnd == instr->GetSrc1())
     {
-        LegalizeMD::LegalizeSrc(instr, opnd, 1, false);
+        LegalizeMD::LegalizeSrc(instr, opnd, 1);
     }
     else
     {
-        LegalizeMD::LegalizeSrc(instr, opnd, 2, false);
+        LegalizeMD::LegalizeSrc(instr, opnd, 2);
     }
 }
 


### PR DESCRIPTION
ARM and ARM64 legalizers behave differently before and after register allocation. We've had bugs in the past where, mainly through static helper functions similar to Lowerer::InsertMove where we've had the flag wrong. This commit adds a flag on Func to tell the legalizer if it should behave as if register allocation has happened or not, and removes the need to pass the flags. The flag was not used on x86 and x64

There were a couple of places where the flag passed did not agree with whether register allocation has finished, in particular LinearScan::InsertLea (passed the flag true) and ARM and ARM64 LowererMD::ChangeToAssign (always passed false). I've added an RAII auto-restore helper to change the flag on the Func while those calls are in progress . While not ideal, it does have the benefit of being mroe expressive.

I'm using a new flag instead of the existing (dbg only) isPostRegAlloc flag because the flag can be temporarily overriden.
