### PR TITLE
Always reduce `count` when removing items from SimpleHashTable

### DIFF
--- a/lib/Common/DataStructures/SimpleHashTable.h
+++ b/lib/Common/DataStructures/SimpleHashTable.h
@@ -149,7 +149,6 @@ public:
                     (*pOut) = current->value;
                 }
 
-                count--;
                 FreeEntry(current);
 #if PROFILE_DICTIONARY
                 if (stats)
@@ -308,6 +307,7 @@ private:
 
     void FreeEntry(EntryType* current)
     {
+        count--;
         if ( freecount < 10 )
         {
             current->key = nullptr;


### PR DESCRIPTION
In particlar `MapAndRemoveIf` used to not reduce `count`. That could cause the table to be larger than necessary in the long term.
It was also inflating the count of pinned references as reported in OOM postmotems.

Fixes: OS: #18369725
