### PR TITLE
Removing stray tab characters

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -287,7 +287,7 @@ BOOL JavascriptObject::ChangePrototype(RecyclableObject* object, RecyclableObjec
         JavascriptOperators::MapObjectAndPrototypesUntil<true>(object->GetPrototype(), [](RecyclableObject* obj)->bool
         {
             return obj->ClearProtoCachesWereInvalidated();
-		});
+        });
     }
 
     // Set to new prototype


### PR DESCRIPTION
I believe that this was introduced during the 1.10 to master merge, I don't see the tabs present in 1.10.