### PR TITLE
Relaxing an assert in TinyDictionary

### DIFF
--- a/lib/Runtime/Types/TypePath.h
+++ b/lib/Runtime/Types/TypePath.h
@@ -86,7 +86,7 @@ public:
                         break;
                     }
 
-                    Assert(idx != (next[idx] & 127));
+                    Assert(next[idx] == NIL || (next[idx] & 127) != idx);
                     i = next[idx];
                 }
             }

--- a/test/Bugs/OS_17745531.js
+++ b/test/Bugs/OS_17745531.js
@@ -41,6 +41,13 @@ for (let j = 0; j < 127; j++)
     {
         console.log("fail");
     }
+
+    // just check for asserts when doing lookups
+    for (let i = 0; i < 500; i++) {
+        if (obj1['prop' + i] == "qq") {
+            console.log("hmm");
+        }
+    }
 }
 
 console.log("pass");


### PR DESCRIPTION
It is possible and ok for the `data` part of the dictionary to contain `FF`.
The assert that we have in `TryGetValue` could get triggered if an unsuccessfull lookup goes through such value. The added test code does that, as an example.
