### PR TITLE
Update JsInstanceOf to use OP_IsInst

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1415,7 +1415,8 @@ CHAKRA_API JsInstanceOf(_In_ JsValueRef object, _In_ JsValueRef constructor, _Ou
         VALIDATE_INCOMING_REFERENCE(constructor, scriptContext);
         PARAM_NOT_NULL(result);
 
-        *result = Js::RecyclableObject::FromVar(constructor)->HasInstance(object, scriptContext) ? true : false;
+        Js::Var value = Js::JavascriptOperators::OP_IsInst(object, constructor, scriptContext, nullptr);
+        *result = !!Js::JavascriptBoolean::FromVar(value)->GetValue();
 
         return JsNoError;
     });

--- a/lib/Runtime/Debug/TTActionEvents.cpp
+++ b/lib/Runtime/Debug/TTActionEvents.cpp
@@ -506,8 +506,8 @@ namespace TTD
             Js::Var constructor = InflateVarInReplay(executeContext, GetVarItem_1(action));
             TTD_REPLAY_VALIDATE_INCOMING_REFERENCE(constructor, ctx);
 
-            //Result is not needed but trigger computation for any effects
-            Js::RecyclableObject::FromVar(constructor)->HasInstance(object, ctx);
+            // Result is not needed but trigger computation for any effects
+            Js::JavascriptOperators::OP_IsInst(object, constructor, ctx, nullptr);
         }
 
         void EqualsAction_Execute(const EventLogEntry* evt, ThreadContextTTD* executeContext)


### PR DESCRIPTION
`OP_IsInst` correctly handles the ES6 `Symbol.hasInstance` property
when determining whether an object is an instance of a constructor.
