### PR TITLE
Post Op Bailout before first instr

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2697,8 +2697,8 @@ Instr::GetNextBranchOrLabel() const
 IR::Instr *
 Instr::GetNextByteCodeInstr() const
 {
-    IR::Instr * nextInstr = GetNextRealInstrOrLabel();
     uint32 currentOffset = GetByteCodeOffset();
+    IR::Instr * nextInstr = GetNextRealInstrOrLabel();
     const auto getNext = [](IR::Instr* nextInstr) -> IR::Instr*
     {
         if (nextInstr->IsBranchInstr())
@@ -2712,16 +2712,27 @@ Instr::GetNextByteCodeInstr() const
         }
         return nextInstr->GetNextRealInstrOrLabel();
     };
-    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
-        nextInstr->GetByteCodeOffset() == currentOffset)
+    if (currentOffset == Js::Constants::NoByteCodeOffset)
     {
-        nextInstr = getNext(nextInstr);
+        while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset)
+        {
+            nextInstr = getNext(nextInstr);
+        }
+        AssertMsg(nextInstr->GetByteCodeOffset() == 0, "Only instrs before the first one are allowed to not have a bytecode offset");
     }
-    // This can happen due to break block removal
-    while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
-        nextInstr->GetByteCodeOffset() < currentOffset)
+    else
     {
-        nextInstr = getNext(nextInstr);
+        while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
+            nextInstr->GetByteCodeOffset() == currentOffset)
+        {
+            nextInstr = getNext(nextInstr);
+        }
+        // This can happen due to break block removal
+        while (nextInstr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset ||
+            nextInstr->GetByteCodeOffset() < currentOffset)
+        {
+            nextInstr = getNext(nextInstr);
+        }
     }
     return nextInstr;
 }


### PR DESCRIPTION
Handle cases where we try to bailout before the first bytecode instr.
OS#17686612
Right now, it is possible to have a post-op bailout on LdScopeHandler which is added in IRBuilder.
I am not sure how to write a test that triggers this path, it seems specific to browser/node scenario

I have checked with @rajatd that a bailout there is fine since we will re-execute the code in the bailout path (more specifically in the first iteration of the interpreter).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5528)
<!-- Reviewable:end -->
