### PR TITLE
Avoid deep recursion in `GetTypeOfString` when dealing with proxies

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1621,8 +1621,10 @@ namespace Js
 
     BOOL JavascriptProxy::GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
     {
+        const JavascriptProxy* proxy = UnwrapNestedProxies(this);
+
         //RecyclableObject* targetObj;
-        if (this->handler == nullptr)
+        if (proxy->handler == nullptr)
         {
             ThreadContext* threadContext = GetScriptContext()->GetThreadContext();
             // the proxy has been revoked; TypeError.
@@ -1630,7 +1632,7 @@ namespace Js
                 return FALSE;
             JavascriptError::ThrowTypeError(GetScriptContext(), JSERR_ErrorOnRevokedProxy, _u("getTypeString"));
         }
-        return target->GetDiagTypeString(stringBuilder, requestContext);
+        return proxy->target->GetDiagTypeString(stringBuilder, requestContext);
     }
 
     RecyclableObject* JavascriptProxy::ToObject(ScriptContext * requestContext)
@@ -1649,7 +1651,9 @@ namespace Js
 
     Var JavascriptProxy::GetTypeOfString(ScriptContext* requestContext)
     {
-        if (this->handler == nullptr)
+        const JavascriptProxy* proxy = UnwrapNestedProxies(this);
+
+        if (proxy->handler == nullptr)
         {
             // even if handler is nullptr, return typeof as "object"
             return requestContext->GetLibrary()->GetObjectTypeDisplayString();
@@ -1662,7 +1666,7 @@ namespace Js
         else
         {
             // handle nested cases recursively
-            return this->target->GetTypeOfString(requestContext);
+            return proxy->target->GetTypeOfString(requestContext);
         }
     }
 

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -54,6 +54,19 @@ namespace Js
         static BOOL Is(_In_ RecyclableObject* obj);
         static JavascriptProxy* FromVar(Var obj) { AssertOrFailFast(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
         static JavascriptProxy* UnsafeFromVar(Var obj) { Assert(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
+
+        // before recursively calling something on 'target' use this helper in case there is nesting of proxies.
+        // the proxies could be deep nested and cause SO when processed recursively.
+        static const JavascriptProxy* UnwrapNestedProxies(const JavascriptProxy* proxy)
+        {
+            while (proxy->handler != nullptr && JavascriptProxy::Is(proxy->target))
+            {
+                proxy = JavascriptProxy::FromVar(proxy->target);
+            }
+
+            return proxy;
+        }
+
 #ifndef IsJsDiag
         RecyclableObject* GetTarget();
         RecyclableObject* GetHandler();

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -59,9 +59,16 @@ namespace Js
         // the proxies could be deep nested and cause SO when processed recursively.
         static const JavascriptProxy* UnwrapNestedProxies(const JavascriptProxy* proxy)
         {
-            while (proxy->handler != nullptr && JavascriptProxy::Is(proxy->target))
+            // continue while we have a proxy that is not revoked
+            while (proxy->handler != nullptr)
             {
-                proxy = JavascriptProxy::FromVar(proxy->target);
+                JavascriptProxy* nestedProxy = JavascriptOperators::TryFromVar<JavascriptProxy>(proxy->target);
+                if (nestedProxy == nullptr)
+                {
+                    break;
+                }
+
+                proxy = nestedProxy;
             }
 
             return proxy;

--- a/test/es6/ProxyInProxy.baseline
+++ b/test/es6/ProxyInProxy.baseline
@@ -112,3 +112,5 @@ function
 *** proxied function and Function.prototype.toString.call
 function a() { }
 function a() { }
+*** deeply nested proxy and typeof
+pass

--- a/test/es6/ProxyInProxy.js
+++ b/test/es6/ProxyInProxy.js
@@ -225,17 +225,17 @@ function test7() {
 function test8() {
     print("*** deeply nested proxy and typeof");
 
-    var __v_8697 = Proxy.revocable([], {}).proxy;
-    for (var __v_8698 = 0; __v_8698 < 1e5; __v_8698++) {
-        __v_8697 = new Proxy(__v_8697, {});
+    var nestedProxy = Proxy.revocable([], {}).proxy;
+    for (let i = 0; i < 1e5; i++) {
+        nestedProxy = new Proxy(nestedProxy, {});
     }
-      var __v_8702 = new Proxy({}, {
-      });
-      (function () {
-        if (__v_8697 != null && typeof __v_8697 == "object") try {
+
+    (function () {
+        if (nestedProxy != null && typeof nestedProxy == "object")
+        {
             console.log("pass");
-        } catch (e) {}
-      })();
+        }
+    })();
 }
 
 test1();

--- a/test/es6/ProxyInProxy.js
+++ b/test/es6/ProxyInProxy.js
@@ -222,6 +222,22 @@ function test7() {
     // "function a() { }"
 }
 
+function test8() {
+    print("*** deeply nested proxy and typeof");
+
+    var __v_8697 = Proxy.revocable([], {}).proxy;
+    for (var __v_8698 = 0; __v_8698 < 1e5; __v_8698++) {
+        __v_8697 = new Proxy(__v_8697, {});
+    }
+      var __v_8702 = new Proxy({}, {
+      });
+      (function () {
+        if (__v_8697 != null && typeof __v_8697 == "object") try {
+            console.log("pass");
+        } catch (e) {}
+      })();
+}
+
 test1();
 test2();
 test3();
@@ -229,3 +245,4 @@ test4();
 test5();
 test6();
 test7();
+test8();


### PR DESCRIPTION
It is unusual, but possible that proxies contain proxies and could be deeply nested. Recursion over such objects causes stack overflow and should be avoided.
With this fix we will unwrap proxies to the inermost proxy without recursing.

Fixes: OS:18260402

Found by OSS-Fuzz
