### PR TITLE
Handle failure to reserve pre-reserved section when initializing server thread context. OS#15209418

### DIFF
--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -169,6 +169,12 @@ ServerThreadContext::CanCreatePreReservedSegment() const
     return m_canCreatePreReservedSegment;
 }
 
+void
+ServerThreadContext::SetCanCreatePreReservedSegment(bool value)
+{
+    m_canCreatePreReservedSegment = value;
+}
+
 bool
 ServerThreadContext::IsNumericProperty(Js::PropertyId propertyId)
 {

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -72,7 +72,7 @@ public:
     intptr_t GetRuntimeChakraBaseAddress() const;
     intptr_t GetRuntimeCRTBaseAddress() const;
     bool CanCreatePreReservedSegment() const;
-
+    void SetCanCreatePreReservedSegment(bool value);
     static intptr_t GetJITCRTBaseAddress();
 
 private:

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -221,6 +221,7 @@ ServerInitializeThreadContext(
         if (!PHASE_OFF1(Js::PreReservedHeapAllocPhase))
         {
             *prereservedRegionAddr = (intptr_t)contextInfo->GetPreReservedSectionAllocator()->EnsurePreReservedRegion();
+            contextInfo->SetCanCreatePreReservedSegment(*prereservedRegionAddr != 0);
         }
 #if !defined(_M_ARM)
         *jitThunkAddr = (intptr_t)contextInfo->GetJITThunkEmitter()->EnsureInitialized();


### PR DESCRIPTION
If we failed to reserve memory for the pre-reserved section when initializing the jit server thread context, when the jit process does the reservation, the client process has no way of knowing the start address of the pre-reserved section.

Instead, don't try to allocate memory for jitted code in pre-reserved section if we couldn't reserve when initializing server thread context