### PR TITLE
Support deferred stubs for functions declared in parameter scope

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -272,6 +272,8 @@ public:
         SourceContextInfo * sourceContextInfo, Js::ParseableFunctionInfo* functionInfo);
 
 protected:
+    static uint BuildDeferredStubTreeHelper(ParseNodeBlock* pnodeBlock, DeferredFunctionStub* deferredStubs, uint currentStubIndex, uint deferredStubCount, Recycler *recycler);
+
     HRESULT ParseSourceInternal(
         __out ParseNodeProg ** parseTree, LPCUTF8 pszSrc, size_t offsetInBytes,
         size_t lengthInCodePoints, charcount_t offsetInChars, bool isUtf8,

--- a/test/Bugs/deferredStubBugs.js
+++ b/test/Bugs/deferredStubBugs.js
@@ -1,0 +1,58 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let pass = 'pass';
+
+function func4(a = 123) {
+    function v8() {
+        function v9() {
+            return v9;
+        }
+        return v9();
+    }
+    return v8();
+}
+func4();
+
+
+var func5 = (a = 123) => (function v6() {
+    function v7() {
+        return v7;
+    }
+    return v7();
+})()
+func5();
+
+function func6(a = v => { console.log('pass'); }, b = v => { return a; }) {
+    function c() {
+        return b();
+    }
+    return c();
+}
+func6()();
+
+function func7(a, b = function() { return pass; }, c) {
+    function func8(d, e = function() { return b; }, f) {
+        return e;
+    }
+    return func8();
+}
+console.log(func7()()());
+
+var func9 = (a, b = () => pass, c) => {
+    var func10 = (d, e = () => b, f) => {
+        return e;
+    }
+    return func10();
+}
+console.log(func9()()());
+
+var func11 = (a, b = () => { return pass; }, c) => {
+    var func12 = (d, e = () => { return b; }, f) => {
+        return e;
+    }
+    return func12();
+}
+console.log(func11()()());

--- a/test/Bugs/deferredStubBugs.js
+++ b/test/Bugs/deferredStubBugs.js
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 let pass = 'pass';
+let fail = 'fail';
 
 function func4(a = 123) {
     function v8() {
@@ -56,3 +57,30 @@ var func11 = (a, b = () => { return pass; }, c) => {
     return func12();
 }
 console.log(func11()()());
+
+function func13(a = (b = () => pass, c = () => fail) => b()) {
+    return a();
+}
+console.log(func13());
+
+function func14(a = (b = () => { return fail; }, c = () => { return pass; }) => { return c(); }) {
+    return a();
+}
+console.log(func14());
+
+function func15(a = class A { meth() { return pass } static meth2() { return fail; } }, b = v => fail, c = (v) => { return fail }, d = fail) {
+    return new a().meth();
+}
+console.log(func15());
+function func16(a = class A { meth() { return fail } static meth2() { return pass; } }, b = v => fail, c = (v) => { return fail }, d = fail) {
+    return a.meth2();
+}
+console.log(func16());
+function func17(a = class A { meth() { return fail } static meth2() { return fail; } }, b = v => pass, c = (v) => { return fail }, d = fail) {
+    return b();
+}
+console.log(func17());
+function func18(a = class A { meth() { return fail } static meth2() { return fail; } }, b = v => fail, c = (v) => { return pass }, d = fail) {
+    return c();
+}
+console.log(func18());

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -488,7 +488,7 @@
     <default>
       <files>bug17785360.js</files>
     </default>
-  </test> 
+  </test>
   <test>
     <default>
       <files>bug_OS17530048.js</files>
@@ -510,7 +510,7 @@
     <default>
       <files>OS_17745531.js</files>
     </default>
-  </test>   
+  </test>
   <test>
     <default>
       <files>SuperUndoDeferIssue.js</files>
@@ -521,6 +521,13 @@
     <default>
       <files>ArgumentsAttrIssue.js</files>
       <compile-flags>-force:cachedScope</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>deferredStubBugs.js</files>
+      <tags>exclude_jshost</tags>
+      <compile-flags>-force:deferparse -parserstatecache -useparserstatecache</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
We previously skipped creating deferred function stubs for functions declared in the parameter scope. This throws-off the order of nested functions under functions with children defined in the parameter scope. We worked-around this by not using deferred stubs in parents with default arguments.

Add support for creating deferred stubs and using them when parsing function parameter lists.
