### PR TITLE
OS#15997192: Disable strict valuetype assert for hoistable syms

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -14323,10 +14323,8 @@ GlobOpt::OptIsInvariant(Sym *sym, BasicBlock *block, Loop *loop, Value *srcVal, 
         return false;
     }
 
-    // If the loopHeadVal is primitive, the current value should be as well.  This really should be
-    // srcVal->GetValueInfo()->IsPrimitive() instead of IsLikelyPrimitive, but this stronger assertion
-    // doesn't hold in some cases when this method is called out of the array code.
-    Assert((!loopHeadVal->GetValueInfo()->IsPrimitive()) || srcVal->GetValueInfo()->IsLikelyPrimitive());
+    // Disabling this assert, because it does not hold true when we force specialize in the loop landing pad
+    //Assert((!loopHeadVal->GetValueInfo()->IsPrimitive()) || srcVal->GetValueInfo()->IsLikelyPrimitive());
 
     return true;
 }

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1568,4 +1568,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -off:aggressiveinttypespec</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>valuetypegap.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -force:inline</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Optimizer/valuetypegap.js
+++ b/test/Optimizer/valuetypegap.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  function leaf() {
+  }
+  (function (argMath6, argMath7) {
+    do {
+    }
+    while (argMath6 * (argMath7 /= test0));
+  }(leaf, leaf));
+}
+
+test0();
+test0();
+test0();
+test0();
+print("Passed\n");


### PR DESCRIPTION
The assert says that for a hoistable value, if its valuetype is primitive in the loop landing pad, it should be atleast LikelyPrimitive inside the loop.
This assert does not hold true in a few cases when we force specialize syms in the loop landing pad.
Ex :

  landingPad:
    a = v1;
    b = v1;
  loop :
    b = v2; // forces float conversion in landing pad
    c = a;
  jump loop

During force specializing in loop landing pad of b, both a and b have the same valueinfo, so they transition to a DefiniteFloat.
This takes b to definite float in the loop landing pad but not inside the loop.
We do not have a way to force Specialize a in the loop, we cannot assume force specializing b again in the loop will update the valueInfo of a,
because they may have different value numbers in the loop. Since we don't have a way to lookup values by valueNumber, there is no easy way to fix this gap currently.

Added test to keep track of this gap.
