### PR TITLE
OS#17531342 : Fix provability check on BrOnObject

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6790,7 +6790,7 @@ GlobOpt::CanProveConditionalBranch(IR::Instr *instr, Value *src1Val, Value *src2
         {
             return false;
         }
-        *result = src1ValueInfo->IsObject();
+        *result = !src1ValueInfo->IsPrimitive();
         break;
     }
     default:


### PR DESCRIPTION
BrOnObject returns true for all non primitives in the interpreter, fix the case for BrOnObject while checking for provability to reflect the same.
