### PR TITLE
use correct property descriptor for array built ins CreateDataProperty

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -3129,13 +3129,22 @@ using namespace Js;
     {
         ScriptContext* scriptContext = pDestObj->GetScriptContext();
 
+        PropertyRecord const * propertyRecord;
         if (idxDest.IsSmallIndex())
         {
-            return pDestObj->SetItem(idxDest.GetSmallIndex(), aItem, Js::PropertyOperation_ThrowIfNotExtensible);
+            JavascriptOperators::GetPropertyIdForInt(idxDest.GetSmallIndex(), scriptContext, &propertyRecord);
         }
-        PropertyRecord const * propertyRecord;
-        JavascriptOperators::GetPropertyIdForInt(idxDest.GetBigIndex(), scriptContext, &propertyRecord);
-        return pDestObj->SetProperty(propertyRecord->GetPropertyId(), aItem, PropertyOperation_ThrowIfNotExtensible, nullptr);
+        else
+        {
+            JavascriptOperators::GetPropertyIdForInt(idxDest.GetBigIndex(), scriptContext, &propertyRecord);
+        }
+
+        PropertyDescriptor propertyDescriptor;
+        propertyDescriptor.SetConfigurable(true);
+        propertyDescriptor.SetEnumerable(true);
+        propertyDescriptor.SetWritable(true);
+        propertyDescriptor.SetValue(aItem);
+        return JavascriptObject::DefineOwnPropertyHelper(pDestObj, propertyRecord->GetPropertyId(), propertyDescriptor, scriptContext, false);
     }
 
     template<typename T>

--- a/test/Array/FilterWithTypedArray.js
+++ b/test/Array/FilterWithTypedArray.js
@@ -1,0 +1,43 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+class dummy {
+    constructor() {
+        return new Int16Array(4);
+    }
+}
+
+var handler = {
+    get: function(oTarget, sKey) {
+        if (sKey.toString()=="constructor") {
+            return { [Symbol.species] : dummy };
+        } else {
+            return 4;
+        }
+    },
+
+    has: function (oTarget, sKey) {
+        return Reflect.has(oTarget, sKey);
+    },
+};
+
+var array = [1];
+var proxy = new Proxy(array, handler);
+
+try
+{
+    // By spec, Array.prototype.filter (and other built-ins) adds configurable properties to a new array, created from ArraySpeciesCreate. 
+    // If the constructed array is a TypedArray, setting of index properties should throw a type error because they cannot be configurable.
+    var boundFilter = Array.prototype.filter.bind(proxy);
+    boundFilter(function() { return true; });
+    WScript.Echo("TypeError expected. TypedArray indicies should be non-configurable.");
+}
+catch (e)
+{
+    if (e == "TypeError: Cannot redefine property '0'")
+    {
+        WScript.Echo("passed");
+    }
+}

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -774,4 +774,9 @@
       <files>bug16717501.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>FilterWithTypedArray.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
This affects the code path for several Array.prototype.xxx methods when called with non-array objects

fixes issue #3532
