### PR TITLE
OS:18468078:Adding a check for the case where lambda method accessing super in global scope

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -12323,7 +12323,7 @@ IdentPtr Parser::ParseSuper(bool fAllowCall)
     {
         // Any super access is good within a class constructor
     }
-    else if ((this->m_grfscr & fscrEval) == fscrEval || currentNonLambdaFunc->superRestrictionState == SuperRestrictionState::PropertyAllowed)
+    else if ((this->m_grfscr & fscrEval) == fscrEval || (currentNonLambdaFunc != nullptr && currentNonLambdaFunc->superRestrictionState == SuperRestrictionState::PropertyAllowed))
     {
         // Currently for eval cases during compile time we use propertyallowed and throw during runtime for error cases
         if (m_token.tk == tkLParen)

--- a/test/Bugs/SuperAccessInGlobalLambda.baseline
+++ b/test/Bugs/SuperAccessInGlobalLambda.baseline
@@ -1,0 +1,2 @@
+SyntaxError: Invalid use of the 'super' keyword
+	at code (SuperAccessInGlobalLambda.js:6:12)

--- a/test/Bugs/SuperAccessInGlobalLambda.js
+++ b/test/Bugs/SuperAccessInGlobalLambda.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+() => super.a;

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -523,4 +523,11 @@
       <compile-flags>-force:cachedScope</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>SuperAccessInGlobalLambda.js</files>
+      <baseline>SuperAccessInGlobalLambda.baseline</baseline>
+      <tags>exclude_jshost</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When a labmda method access super property in the global scope the currentnonlambdafunc will be nullptr. This should be a SyntaxError.
