### PR TITLE
Initialize write barrier card table for each thread that interacts with the JSRT

### DIFF
--- a/lib/Runtime/Base/ThreadContextTlsEntry.cpp
+++ b/lib/Runtime/Base/ThreadContextTlsEntry.cpp
@@ -87,6 +87,14 @@ bool ThreadContextTLSEntry::TrySetThreadContext(ThreadContext * threadContext)
     if (entry == NULL)
     {
         Assert(!threadContext->IsThreadBound());
+#ifdef RECYCLER_WRITE_BARRIER
+#ifdef TARGET_64
+        if (!Memory::RecyclerWriteBarrierManager::OnThreadInit())
+        {
+            return false;
+        }
+#endif
+#endif
         entry = CreateEntryForCurrentThread();
 #ifndef _WIN32
         ENTRY_FOR_CURRENT_THREAD() = entry;


### PR DESCRIPTION
The card table has code to handle stack allocations,
but this code was only run on the main thread and on,
our own background threads. Threads trying to use the
JSRT could end up getting segfaults from write barriers
from Fields on stack variables that weren't known to
the write barrier.

Fixes #5577