### PR TITLE
OS#18423345 : Use ToVarIntCheck in ToIntegerFunction, which will convert Number to TaggedInt if possible

### DIFF
--- a/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/JsBuiltInEngineInterfaceExtensionObject.cpp
@@ -416,7 +416,7 @@ namespace Js
             return value;
         }
 
-        return JavascriptNumber::ToVarNoCheck(JavascriptConversion::ToInteger(value, scriptContext), scriptContext);
+        return JavascriptNumber::ToVarIntCheck(JavascriptConversion::ToInteger(value, scriptContext), scriptContext);
     }
 
     Var JsBuiltInEngineInterfaceExtensionObject::EntryJsBuiltIn_Internal_GetLength(RecyclableObject *function, CallInfo callInfo, ...)


### PR DESCRIPTION
This will mitigate taking slow path if indexOf ever gets a Number as the index.
