### PR TITLE
Remove duplicate bytecode generation

### DIFF
--- a/RegenAllByteCodeNoBuild.cmd
+++ b/RegenAllByteCodeNoBuild.cmd
@@ -32,9 +32,4 @@ setlocal
     call GenByteCode.cmd
     call GenByteCode.cmd -nojit
   popd
-
-  pushd %_reporoot%\lib\Runtime\Library\JsBuiltIn
-    call GenByteCode.cmd
-    call GenByteCode.cmd -nojit
-  popd
 endlocal


### PR DESCRIPTION
This got added by two different branches resulting in a duplicate.

Fixes #5591 