### PR TITLE
Update global toStringTag to match attributes from v8

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1142,7 +1142,10 @@ namespace Js
         AddMember(globalObject, PropertyIds::Infinity, positiveInfinite, PropertyNone);
         AddMember(globalObject, PropertyIds::undefined, undefinedValue, PropertyNone);
         // Note: for global object, we need to set toStringTag to global like other engines (v8)
-        AddMember(globalObject, PropertyIds::_symbolToStringTag, scriptContext->GetPropertyString(PropertyIds::global) , PropertyNone);
+        if (globalObject->GetScriptContext()->GetConfig()->IsES6ToStringTagEnabled())
+        {
+            AddMember(globalObject, PropertyIds::_symbolToStringTag, scriptContext->GetPropertyString(PropertyIds::global), PropertyConfigurable | PropertyWritable | PropertyEnumerable);
+        }
 
         // Note: Any global function added/removed/changed here should also be updated in JavascriptLibrary::ProfilerRegisterBuiltinFunctions
         // so that the new functions show up in the profiler too.

--- a/test/Debugger/JsDiagGetStackProperties.js.dbg.baseline
+++ b/test/Debugger/JsDiagGetStackProperties.js.dbg.baseline
@@ -3,6 +3,7 @@
     "this": "Object {...}",
     "{exception}": "number 1",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "globalVar": "undefined undefined",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>"
@@ -12,6 +13,7 @@
     "this": "Object {...}",
     "{exception}": "Error Caught Error",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "globalVar": "undefined undefined",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>"
@@ -44,6 +46,7 @@
       "level1Var": "Object {...}"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "globalVar": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>"
@@ -97,6 +100,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "globalVar": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>"

--- a/test/Debugger/MultipleContextStack.js.dbg.baseline
+++ b/test/Debugger/MultipleContextStack.js.dbg.baseline
@@ -82,6 +82,7 @@
       "x": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "script1": "Object {...}",
       "script2": "Object {...}",
       "Func2": "function <large string>",

--- a/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
@@ -23,6 +23,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "x": "undefined undefined",
       "Run": "function <large string>"
     }

--- a/test/DebuggerCommon/ES6_letconst_const_reassignment_globalscope.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_const_reassignment_globalscope.js.dbg.baseline
@@ -5,7 +5,8 @@
     },
     "locals": {
       "a": "number 1",
-      "b": "number 2"
+      "b": "number 2",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   },

--- a/test/DebuggerCommon/ES6_letconst_eval_nonstrict.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_eval_nonstrict.js.dbg.baseline
@@ -4,7 +4,8 @@
       "Symbol.toStringTag": "string global"
     },
     "locals": {
-      "a": "number 1"
+      "a": "number 1",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   }

--- a/test/DebuggerCommon/ES6_letconst_eval_strict_fn.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_eval_strict_fn.js.dbg.baseline
@@ -14,6 +14,7 @@
       "a": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },

--- a/test/DebuggerCommon/ES6_letconst_for.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_for.js.dbg.baseline
@@ -3,6 +3,7 @@
     "this": "Object {...}",
     "locals": {
       "y": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   },
@@ -14,6 +15,7 @@
     "locals": {
       "z": "number 1",
       "y": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}
@@ -22,6 +24,7 @@
     "this": "Object {...}",
     "locals": {
       "y": "number 2",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   },
@@ -33,6 +36,7 @@
     "locals": {
       "z": "number 1",
       "y": "number 2",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}
@@ -41,6 +45,7 @@
     "this": "Object {...}",
     "locals": {
       "y": "number 3",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   }

--- a/test/DebuggerCommon/ES6_letconst_forin.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_forin.js.dbg.baseline
@@ -6,6 +6,7 @@
     },
     "locals": {
       "y": "string x",
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": "Object {...}",
         "x": "number 2",
@@ -21,6 +22,7 @@
     },
     "locals": {
       "y": "string y",
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": "Object {...}",
         "x": "number 2",

--- a/test/DebuggerCommon/ES6_letconst_redcl.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_redcl.js.dbg.baseline
@@ -10,7 +10,8 @@
     },
     "locals": {
       "a": "number 100",
-      "b": "number 200"
+      "b": "number 200",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   }

--- a/test/DebuggerCommon/ES6_letconst_shadow_eval_with.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_shadow_eval_with.js.dbg.baseline
@@ -15,6 +15,7 @@
       "b": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -34,6 +35,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -53,6 +55,7 @@
       "a": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -72,6 +75,7 @@
       "b": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/ES6_letconst_trycatch_simple_fast.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_letconst_trycatch_simple_fast.js.dbg.baseline
@@ -17,6 +17,7 @@
       "z": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 3",
       "Call": "function <large string>",
       "bar": "function <large string>",
@@ -47,6 +48,7 @@
       "z": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 3",
       "Call": "function <large string>",
       "bar": "function <large string>",

--- a/test/DebuggerCommon/ES6_proto_simple.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_proto_simple.js.dbg.baseline
@@ -12,6 +12,7 @@
       }
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": {
           "constructor": "function <large string>",

--- a/test/DebuggerCommon/ES6_proto_userDefinedObject.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_proto_userDefinedObject.js.dbg.baseline
@@ -25,6 +25,7 @@
       }
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": {
           "constructor": "function <large string>",

--- a/test/DebuggerCommon/ES6_spread.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_spread.js.dbg.baseline
@@ -21,6 +21,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "a": "Array [1,2,check]",
       "bar": "function <large string>",
       "foo": "function <large string>"

--- a/test/DebuggerCommon/IntlInit.js.dbg.baseline
+++ b/test/DebuggerCommon/IntlInit.js.dbg.baseline
@@ -5,7 +5,8 @@
       "[Intl.getCanonicalLocales returned]": "Array [en-US]"
     },
     "locals": {
-      "x": "number 0"
+      "x": "number 0",
+      "Symbol.toStringTag": "string global"
     }
   },
   {
@@ -14,7 +15,8 @@
       "[Intl.getCanonicalLocales returned]": "Array [en-US]"
     },
     "locals": {
-      "x": "number 1"
+      "x": "number 1",
+      "Symbol.toStringTag": "string global"
     }
   }
 ]

--- a/test/DebuggerCommon/JIT_localsAtNativeFrame1.js.dbg.baseline
+++ b/test/DebuggerCommon/JIT_localsAtNativeFrame1.js.dbg.baseline
@@ -55,6 +55,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>",
       "Run": "function <large string>"
@@ -116,6 +117,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>",
       "Run": "function <large string>"
@@ -177,6 +179,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>",
       "Run": "function <large string>"
@@ -238,6 +241,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>",
       "Run": "function <large string>"

--- a/test/DebuggerCommon/JIT_localsAtNativeFrame2.js.dbg.baseline
+++ b/test/DebuggerCommon/JIT_localsAtNativeFrame2.js.dbg.baseline
@@ -84,10 +84,10 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
-      "F5_1": "function <large string>",
       "x": "number 20",
       "y": "Object {...}",
-      "t1": "number 22.2"
+      "t1": "number 22.2",
+      "F5_1": "function <large string>"
     }
   },
   {
@@ -160,6 +160,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -332,10 +333,10 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
-      "F5_1": "function <large string>",
       "x": "number 20",
       "y": "Object {...}",
-      "t1": "number 22.2"
+      "t1": "number 22.2",
+      "F5_1": "function <large string>"
     }
   },
   {
@@ -408,6 +409,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -580,10 +582,10 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
-      "F5_1": "function <large string>",
       "x": "number 20",
       "y": "Object {...}",
-      "t1": "number 22.2"
+      "t1": "number 22.2",
+      "F5_1": "function <large string>"
     }
   },
   {
@@ -656,6 +658,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -828,10 +831,10 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
-      "F5_1": "function <large string>",
       "x": "number 20",
       "y": "Object {...}",
-      "t1": "number 22.2"
+      "t1": "number 22.2",
+      "F5_1": "function <large string>"
     }
   },
   {
@@ -904,6 +907,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",

--- a/test/DebuggerCommon/ObjLit_step_into_out.js.dbg.baseline
+++ b/test/DebuggerCommon/ObjLit_step_into_out.js.dbg.baseline
@@ -122,6 +122,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "a1": "number 10",
       "foo": "function <large string>",
       "sub_expression_step_into": "function <large string>"

--- a/test/DebuggerCommon/ObjLit_step_over.js.dbg.baseline
+++ b/test/DebuggerCommon/ObjLit_step_over.js.dbg.baseline
@@ -81,6 +81,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "a1": "number 10",
       "foo": "function <large string>",
       "sub_expression_step_over": "function <large string>"

--- a/test/DebuggerCommon/argument_disp.js.dbg.baseline
+++ b/test/DebuggerCommon/argument_disp.js.dbg.baseline
@@ -16,6 +16,7 @@
       "a": "string Hello"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>"
     }

--- a/test/DebuggerCommon/array_prototest.js.dbg.baseline
+++ b/test/DebuggerCommon/array_prototest.js.dbg.baseline
@@ -194,6 +194,7 @@
       "dummy": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": {
         "#__proto__": "function <large string>",
         "prototype": "Object {...}",
@@ -438,6 +439,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": {
         "#__proto__": "function <large string>",
         "prototype": "Object {...}",
@@ -485,6 +487,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "foo1": "function <large string>",
       "foo2": "function <large string>"
@@ -512,6 +515,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "foo1": "function <large string>",
       "foo2": "function <large string>"
@@ -540,6 +544,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "foo1": "function <large string>",
       "foo2": "function <large string>"
@@ -572,6 +577,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "foo1": "function <large string>",
       "foo2": "function <large string>"

--- a/test/DebuggerCommon/async.js.dbg.baseline
+++ b/test/DebuggerCommon/async.js.dbg.baseline
@@ -81,10 +81,11 @@
       "Symbol.iterator": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
+      "p": "Promise [...]",
       "foo": "function <large string>",
       "af1": "function <large string>",
-      "af2": "function <large string>",
-      "p": "Promise [...]"
+      "af2": "function <large string>"
     }
   },
   {

--- a/test/DebuggerCommon/attachWithDeferParse.js.dbg.baseline
+++ b/test/DebuggerCommon/attachWithDeferParse.js.dbg.baseline
@@ -18,6 +18,7 @@
       "g": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "inEvalFunc1": "function <large string>"
     }
@@ -55,6 +56,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "inEvalFunc1": "function <large string>"
     }
@@ -106,6 +108,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "inEvalFunc1": "function <large string>"
     }

--- a/test/DebuggerCommon/blockScopeActivationObjectCapture.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeActivationObjectCapture.js.dbg.baseline
@@ -30,6 +30,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>"
     }
@@ -73,6 +74,7 @@
       "verify": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>"
     }

--- a/test/DebuggerCommon/blockScopeBasicLetConstTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeBasicLetConstTest.js.dbg.baseline
@@ -78,6 +78,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeBasicLetConstTestFunc": {
         "#__proto__": "function <large string>",
         "prototype": "Object {...}",

--- a/test/DebuggerCommon/blockScopeForTest.bug183991.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeForTest.bug183991.js.dbg.baseline
@@ -6,6 +6,7 @@
     },
     "locals": {
       "y": "string x",
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": "Object {...}",
         "x": "number 2",
@@ -21,6 +22,7 @@
     },
     "locals": {
       "y": "string y",
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": "Object {...}",
         "x": "number 2",

--- a/test/DebuggerCommon/blockScopeFunctionDeclarationGlobalTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeFunctionDeclarationGlobalTest.js.dbg.baseline
@@ -2,18 +2,21 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "f": "undefined undefined"
     }
   },
   {
     "this": "Object {...}",
     "locals": {
-      "f": "function function f() { }"
+      "f": "function function f() { }",
+      "Symbol.toStringTag": "string global"
     }
   },
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "f": "function function f() { }"
     }
   }

--- a/test/DebuggerCommon/blockScopeGlobalBlockTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeGlobalBlockTest.js.dbg.baseline
@@ -5,7 +5,8 @@
     },
     "locals": {
       "b": "number 2",
-      "a": "number 1"
+      "a": "number 1",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   },
@@ -22,7 +23,8 @@
   {
     "this": "Object {...}",
     "locals": {
-      "a": "number 1"
+      "a": "number 1",
+      "Symbol.toStringTag": "string global"
     }
   }
 ]

--- a/test/DebuggerCommon/blockScopeGlobalDeadZoneTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeGlobalDeadZoneTest.js.dbg.baseline
@@ -2,12 +2,14 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": "undefined undefined"
     }
   },
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": "number 0"
     }
   },
@@ -15,6 +17,7 @@
     "this": "Object {...}",
     "locals": {
       "b": "number 1",
+      "Symbol.toStringTag": "string global",
       "a": "number 0"
     }
   },
@@ -23,6 +26,7 @@
     "locals": {
       "b": "number 1",
       "c": "number 2",
+      "Symbol.toStringTag": "string global",
       "a": "number 0"
     }
   }

--- a/test/DebuggerCommon/blockScopeGlobalSlotArrayTest.bug222631.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeGlobalSlotArrayTest.bug222631.js.dbg.baseline
@@ -17,6 +17,7 @@
       "e": "string level1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "c": "function <large string>"
     }
   },
@@ -29,6 +30,7 @@
       "b": "string level2",
       "a": "string level2level3",
       "e": "string level1",
+      "Symbol.toStringTag": "string global",
       "c": {
         "#__proto__": "function <large string>",
         "prototype": "Object {...}",

--- a/test/DebuggerCommon/blockScopeGlobalTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeGlobalTest.js.dbg.baseline
@@ -13,6 +13,7 @@
     "globals": {
       "gA": "number 1",
       "gConstB": "number 2",
+      "Symbol.toStringTag": "string global",
       "blockScopeGlobalTestFunc": "function <large string>"
     }
   },
@@ -34,6 +35,7 @@
       "gConstB": "number 2",
       "gC": "number 3",
       "gD": "number 4",
+      "Symbol.toStringTag": "string global",
       "blockScopeGlobalTestFunc": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/blockScopeNestedFunctionTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeNestedFunctionTest.js.dbg.baseline
@@ -47,6 +47,7 @@
       "aConst": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeNestedFunctionTestFunc": "function <large string>"
     }
   },
@@ -78,6 +79,7 @@
       "aConst": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeNestedFunctionTestFunc": "function <large string>"
     }
   },
@@ -105,6 +107,7 @@
       "aConst": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeNestedFunctionTestFunc": "function <large string>"
     }
   },
@@ -132,6 +135,7 @@
       "aConst": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeNestedFunctionTestFunc": "function <large string>"
     }
   },
@@ -163,6 +167,7 @@
       "aConst": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeNestedFunctionTestFunc": "function <large string>"
     }
   },

--- a/test/DebuggerCommon/blockScopeSlotArrayCapture.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeSlotArrayCapture.js.dbg.baseline
@@ -30,6 +30,7 @@
       "level_0_identifier_0": "string level0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>",
       "Run1": "function <large string>"
@@ -71,6 +72,7 @@
       "verify": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>",
       "Run1": "function <large string>"

--- a/test/DebuggerCommon/blockScopeSlotArrayCaptureAttach.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeSlotArrayCaptureAttach.js.dbg.baseline
@@ -35,6 +35,7 @@
       "level_0_identifier_0": "string level0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>",
       "Run1": "function <large string>"
@@ -76,6 +77,7 @@
       "verify": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "verify": "function function verify(){}",
       "Run": "function <large string>",
       "Run1": "function <large string>"

--- a/test/DebuggerCommon/blockScopeSlotArrayTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeSlotArrayTest.js.dbg.baseline
@@ -15,6 +15,7 @@
       "a": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "g": "function <large string>",
       "test": "function <large string>"
     }

--- a/test/DebuggerCommon/blockScopeTryCatchTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeTryCatchTest.js.dbg.baseline
@@ -16,6 +16,7 @@
       "ex": "string Exception!"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeTryCatchTestFunc": "function <large string>"
     }
   },
@@ -38,6 +39,7 @@
       "ex": "string Exception!"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeTryCatchTestFunc": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/blockScopeWithTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeWithTest.js.dbg.baseline
@@ -22,6 +22,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeWithTestFunc": "function <large string>"
     }
   },
@@ -46,6 +47,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeWithTestFunc": "function <large string>"
     }
   },
@@ -69,6 +71,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeWithTestFunc": "function <large string>"
     }
   },
@@ -91,6 +94,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "blockScopeWithTestFunc": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/blockscope_func_declaration_ES6.js.dbg.baseline
+++ b/test/DebuggerCommon/blockscope_func_declaration_ES6.js.dbg.baseline
@@ -7,6 +7,7 @@
       "bar": "undefined undefined"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "undefined undefined",
       "foo": "undefined undefined",
       "bar": "undefined undefined"
@@ -21,6 +22,7 @@
       "bar": "function <large string>"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "foo": {
         "#__proto__": "function <large string>",

--- a/test/DebuggerCommon/blockscope_func_expression_ES6.js.dbg.baseline
+++ b/test/DebuggerCommon/blockscope_func_expression_ES6.js.dbg.baseline
@@ -6,6 +6,7 @@
       "bar": "undefined undefined"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "undefined undefined",
       "bar": "undefined undefined"
     },
@@ -18,6 +19,7 @@
       "bar": "function <large string>"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "bar": {
         "#__proto__": "function <large string>",

--- a/test/DebuggerCommon/blockscope_func_insidescopes.js.dbg.baseline
+++ b/test/DebuggerCommon/blockscope_func_insidescopes.js.dbg.baseline
@@ -19,6 +19,7 @@
       "bar4": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -53,6 +54,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -87,6 +89,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   },
@@ -121,6 +124,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/breakpoints.js.dbg.baseline
+++ b/test/DebuggerCommon/breakpoints.js.dbg.baseline
@@ -10,6 +10,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },
@@ -46,6 +47,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },
@@ -92,6 +94,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },
@@ -122,6 +125,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },
@@ -158,6 +162,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },
@@ -204,6 +209,7 @@
       "test": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f": "function <large string>"
     }
   },

--- a/test/DebuggerCommon/bug_177146.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_177146.js.dbg.baseline
@@ -16,6 +16,7 @@
       "a": "string Hello"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>"
     }

--- a/test/DebuggerCommon/bug_291582.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_291582.js.dbg.baseline
@@ -2,6 +2,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": "number 1",
       "x": "undefined undefined"
     }

--- a/test/DebuggerCommon/bug_592506.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_592506.js.dbg.baseline
@@ -15,6 +15,7 @@
       "k": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "test": "function <large string>",
       "bar": "function <large string>"
     }
@@ -41,6 +42,7 @@
       "k": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "test": "function <large string>",
       "bar": "function <large string>",
       "ttt1": "number 31"

--- a/test/DebuggerCommon/bug_622304.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_622304.js.dbg.baseline
@@ -20,6 +20,7 @@
       "x": "number 10"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/bug_os_2946365.js.dbg.baseline
+++ b/test/DebuggerCommon/bug_os_2946365.js.dbg.baseline
@@ -59,6 +59,7 @@
       "x": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "a": {
         "#__proto__": "Array []",
         "length": "number 10",

--- a/test/DebuggerCommon/catchInspection.js.dbg.baseline
+++ b/test/DebuggerCommon/catchInspection.js.dbg.baseline
@@ -36,6 +36,7 @@
       "e": "Error <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "undefined undefined",
       "bar": "function <large string>",
@@ -88,6 +89,7 @@
       "e": "Error <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "undefined undefined",
       "bar": "function <large string>",
@@ -144,6 +146,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -186,6 +189,7 @@
       "e": "Error <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -237,6 +241,7 @@
       "k": "number 10"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -289,6 +294,7 @@
       "k": "number 10"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -341,6 +347,7 @@
       "k": "number 10"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -389,6 +396,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -437,6 +445,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -485,6 +494,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -534,6 +544,7 @@
       "m1": "number 10"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -574,6 +585,7 @@
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
+      "Symbol.toStringTag": "string global",
       "top": {
         "#__proto__": "Object {...}",
         "f1": "function <large string>"
@@ -773,6 +785,7 @@
       "fa": "number 123"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -837,6 +850,7 @@
       "e1": "number -1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",
@@ -910,6 +924,7 @@
       "foo0": "number 12"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "startTest": "function <large string>",
       "bar": "function <large string>",

--- a/test/DebuggerCommon/default.js.dbg.baseline
+++ b/test/DebuggerCommon/default.js.dbg.baseline
@@ -9967,6 +9967,7 @@
       "b": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -9994,6 +9995,7 @@
       "c": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10024,6 +10026,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10056,6 +10059,7 @@
       "d": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10079,6 +10083,7 @@
       "b": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10100,6 +10105,7 @@
       "c": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10123,6 +10129,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10148,6 +10155,7 @@
       "c": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10172,6 +10180,7 @@
       "b": "number 11"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10207,6 +10216,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10230,6 +10240,7 @@
       "b": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10264,6 +10275,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10294,6 +10306,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10344,6 +10357,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10384,6 +10398,7 @@
       "c": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10410,6 +10425,7 @@
       "c": "number 11"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10440,6 +10456,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10468,6 +10485,7 @@
       "c": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10501,6 +10519,7 @@
       "d": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },
@@ -10534,6 +10553,7 @@
       "d": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "glob": "Object {...}"
     }
   },

--- a/test/DebuggerCommon/detachBasicTest.js.dbg.baseline
+++ b/test/DebuggerCommon/detachBasicTest.js.dbg.baseline
@@ -14,6 +14,7 @@
       "a": "number 0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "detachBasicTest": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/es6_forof_decl-2.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl-2.js.dbg.baseline
@@ -2,7 +2,8 @@
   {
     "this": "Object {...}",
     "locals": {
-      "x": "number 1"
+      "x": "number 1",
+      "Symbol.toStringTag": "string global"
     }
   },
   {
@@ -12,7 +13,8 @@
     },
     "locals": {
       "z": "number 1",
-      "x": "number 1"
+      "x": "number 1",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   },
@@ -23,7 +25,8 @@
     },
     "locals": {
       "z": "number 1",
-      "x": "number 1"
+      "x": "number 1",
+      "Symbol.toStringTag": "string global"
     },
     "globals": {}
   }

--- a/test/DebuggerCommon/es6_forof_decl-3.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl-3.js.dbg.baseline
@@ -2,6 +2,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   },
@@ -12,6 +13,7 @@
     },
     "locals": {
       "z": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 0"
     },
     "globals": {}
@@ -23,6 +25,7 @@
     },
     "locals": {
       "z": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}

--- a/test/DebuggerCommon/es6_forof_decl-4.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl-4.js.dbg.baseline
@@ -8,6 +8,7 @@
     },
     "locals": {
       "y": "number 2",
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "a": {
         "#__proto__": "Array []",
@@ -27,6 +28,7 @@
     },
     "locals": {
       "y": "number 2",
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "a": {
         "#__proto__": "Array []",

--- a/test/DebuggerCommon/es6_forof_decl-5.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl-5.js.dbg.baseline
@@ -3,6 +3,7 @@
     "this": "Object {...}",
     "locals": {
       "x": "string <large string>",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     }
   },
@@ -14,6 +15,7 @@
     "locals": {
       "y": "string <large string>",
       "x": "number 0",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -27,6 +29,7 @@
       "z": "number 1",
       "y": "number 0",
       "x": "number 0",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -40,6 +43,7 @@
       "z": "number 1",
       "y": "number 1",
       "x": "number 0",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -53,6 +57,7 @@
       "z": "number 1",
       "y": "number 2",
       "x": "number 0",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -65,6 +70,7 @@
     "locals": {
       "y": "string <large string>",
       "x": "number 1",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -78,6 +84,7 @@
       "z": "number 1",
       "y": "number 0",
       "x": "number 1",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -91,6 +98,7 @@
       "z": "number 1",
       "y": "number 1",
       "x": "number 1",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -104,6 +112,7 @@
       "z": "number 1",
       "y": "number 2",
       "x": "number 1",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -116,6 +125,7 @@
     "locals": {
       "y": "string <large string>",
       "x": "number 2",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -129,6 +139,7 @@
       "z": "number 1",
       "y": "number 0",
       "x": "number 2",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -142,6 +153,7 @@
       "z": "number 1",
       "y": "number 1",
       "x": "number 2",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}
@@ -155,6 +167,7 @@
       "z": "number 1",
       "y": "number 2",
       "x": "number 2",
+      "Symbol.toStringTag": "string global",
       "q": "number 1"
     },
     "globals": {}

--- a/test/DebuggerCommon/es6_forof_decl-6.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl-6.js.dbg.baseline
@@ -2,6 +2,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   },
@@ -13,6 +14,7 @@
     },
     "locals": {
       "z": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "y": "number 0"
     },
@@ -26,6 +28,7 @@
     },
     "locals": {
       "z": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1",
       "y": "number 1"
     },

--- a/test/DebuggerCommon/es6_forof_decl.js.dbg.baseline
+++ b/test/DebuggerCommon/es6_forof_decl.js.dbg.baseline
@@ -3,6 +3,7 @@
     "this": "Object {...}",
     "locals": {
       "y": "string <large string>",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     }
   },
@@ -14,6 +15,7 @@
     "locals": {
       "z": "number 1",
       "y": "number 0",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}
@@ -26,6 +28,7 @@
     "locals": {
       "z": "number 1",
       "y": "number 1",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}
@@ -38,6 +41,7 @@
     "locals": {
       "z": "number 1",
       "y": "number 2",
+      "Symbol.toStringTag": "string global",
       "x": "number 1"
     },
     "globals": {}

--- a/test/DebuggerCommon/funcExprCrash_150491.js.dbg.baseline
+++ b/test/DebuggerCommon/funcExprCrash_150491.js.dbg.baseline
@@ -29,6 +29,7 @@
       "p": "boolean false"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "top": "Object {...}",
       "Pass": "function <large string>",
       "test": "function <large string>"

--- a/test/DebuggerCommon/funcExprName.js.dbg.baseline
+++ b/test/DebuggerCommon/funcExprName.js.dbg.baseline
@@ -24,6 +24,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "outer": "function <large string>"
     }
@@ -61,6 +62,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "outer": "function <large string>"
     }
@@ -82,6 +84,7 @@
       "a": "boolean false"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "outer": "function <large string>"
     }
@@ -111,6 +114,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "outer": "function <large string>"
     }
@@ -140,6 +144,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "outer": "function <large string>"
     }

--- a/test/DebuggerCommon/funcSource.js.dbg.baseline
+++ b/test/DebuggerCommon/funcSource.js.dbg.baseline
@@ -36,6 +36,8 @@
         }
       }
     },
-    "globals": {}
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   }
 ]

--- a/test/DebuggerCommon/getterInspection.js.dbg.baseline
+++ b/test/DebuggerCommon/getterInspection.js.dbg.baseline
@@ -28,6 +28,7 @@
       "nothrow": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "test": "function <large string>"
     }
   },
@@ -65,6 +66,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "test": "function <large string>"
     }
   }

--- a/test/DebuggerCommon/globalFuncVars.js.dbg.baseline
+++ b/test/DebuggerCommon/globalFuncVars.js.dbg.baseline
@@ -16,6 +16,7 @@
       "c1": "undefined undefined"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "obj": "undefined undefined",
       "c": "undefined undefined",
       "foo": "function <large string>",
@@ -75,6 +76,7 @@
       "c1": "Array [1]"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "obj": "undefined undefined",
       "c": "undefined undefined",
       "foo": "function <large string>",
@@ -100,6 +102,7 @@
       "bar": "function <large string>"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "obj": "undefined undefined",
       "c": "undefined undefined",
       "foo": {
@@ -137,6 +140,7 @@
         "number": "number -2146823279",
         "stack": "string <large string>"
       },
+      "Symbol.toStringTag": "string global",
       "obj": "undefined undefined",
       "c": "undefined undefined",
       "foo": {
@@ -167,6 +171,7 @@
       "bar": "function <large string>"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "obj": {
         "#__proto__": "Object {...}",
         "x": "number 10",

--- a/test/DebuggerCommon/indexprop.js.dbg.baseline
+++ b/test/DebuggerCommon/indexprop.js.dbg.baseline
@@ -135,14 +135,18 @@
         }
       }
     },
-    "globals": {}
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
       "Symbol.toStringTag": "string global",
       "[200]": "string 200"
     },
-    "locals": {},
+    "locals": {
+      "Symbol.toStringTag": "string global"
+    },
     "globals": {}
   }
 ]

--- a/test/DebuggerCommon/jit_exprEval1.js.dbg.baseline
+++ b/test/DebuggerCommon/jit_exprEval1.js.dbg.baseline
@@ -37,6 +37,7 @@
       "x": "number 20"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -96,6 +97,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -165,6 +167,7 @@
       "x": "number 20"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -224,6 +227,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -288,6 +292,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",
@@ -331,6 +336,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F2": "function <large string>",
       "F3": "function <large string>",
       "F5": "function <large string>",

--- a/test/DebuggerCommon/multiple_argumentsdisp_safeguard.js.dbg.baseline
+++ b/test/DebuggerCommon/multiple_argumentsdisp_safeguard.js.dbg.baseline
@@ -16,6 +16,7 @@
       "a": "string Hello"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "F1": "function <large string>",
       "F2": "function <large string>"
     }

--- a/test/DebuggerCommon/negzerotest.js.dbg.baseline
+++ b/test/DebuggerCommon/negzerotest.js.dbg.baseline
@@ -2,6 +2,7 @@
   {
     "this": "Object {...}",
     "locals": {
+      "Symbol.toStringTag": "string global",
       "y": "number 0"
     }
   }

--- a/test/DebuggerCommon/protoTest2.js.dbg.baseline
+++ b/test/DebuggerCommon/protoTest2.js.dbg.baseline
@@ -6,7 +6,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -15,7 +17,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -24,7 +28,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -33,7 +39,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -42,7 +50,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -51,7 +61,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -60,7 +72,9 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   },
   {
     "this": {
@@ -69,6 +83,8 @@
     "locals": {
       "arguments": "object null"
     },
-    "globals": "undefined undefined"
+    "globals": {
+      "Symbol.toStringTag": "string global"
+    }
   }
 ]

--- a/test/DebuggerCommon/returnedvaluetests2.js.dbg.baseline
+++ b/test/DebuggerCommon/returnedvaluetests2.js.dbg.baseline
@@ -49,6 +49,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "obj1": "Object {...}",
       "A": "function <large string>",
       "test1": "function <large string>",
@@ -84,6 +85,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "obj1": "Object {...}",
       "A": "function <large string>",
       "test1": "function <large string>",

--- a/test/DebuggerCommon/setframe.js.dbg.baseline
+++ b/test/DebuggerCommon/setframe.js.dbg.baseline
@@ -18,6 +18,7 @@
       "HHH_C": "number 0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "GGG": "function <large string>",
       "FFF": "function <large string>",
       "HHH": "function <large string>"
@@ -52,6 +53,7 @@
       "GGG_closure": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "GGG": "function <large string>",
       "FFF": "function <large string>",
       "HHH": "function <large string>"
@@ -76,6 +78,7 @@
       "FFF_C": "number 0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "GGG": "function <large string>",
       "FFF": "function <large string>",
       "HHH": "function <large string>"
@@ -148,6 +151,7 @@
       "GGG_closure": "number 3"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "GGG": "function <large string>",
       "FFF": "function <large string>",
       "HHH": "function <large string>"
@@ -172,6 +176,7 @@
       "FFF_C": "number 0"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "GGG": "function <large string>",
       "FFF": "function <large string>",
       "HHH": "function <large string>"

--- a/test/DebuggerCommon/shadow_with.js.dbg.baseline
+++ b/test/DebuggerCommon/shadow_with.js.dbg.baseline
@@ -5,6 +5,7 @@
       "a": "number 1"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "a": "number 1"
     },
     "globals": {}

--- a/test/DebuggerCommon/step_in_ES6_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_in_ES6_attach.js.dbg.baseline
@@ -18,6 +18,7 @@
       "x": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "baz": "function <large string>",
@@ -48,6 +49,7 @@
       "a": "string bar"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "baz": "function <large string>",
@@ -78,6 +80,7 @@
       "a": "string foo"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "baz": "function <large string>",

--- a/test/DebuggerCommon/step_in_from_interpreted_function_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_in_from_interpreted_function_attach.js.dbg.baseline
@@ -233,6 +233,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": {
         "#__proto__": "function <large string>",
         "prototype": "Object {...}",

--- a/test/DebuggerCommon/step_out_ES6.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_ES6.js.dbg.baseline
@@ -16,6 +16,7 @@
       "z": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "Run": "function <large string>"
@@ -38,6 +39,7 @@
       "z": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "Run": "function <large string>"

--- a/test/DebuggerCommon/step_out_direct_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_direct_attach.js.dbg.baseline
@@ -38,6 +38,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>",
       "bar": "function <large string>"
     }
@@ -82,6 +83,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>",
       "bar": "function <large string>"
     }
@@ -125,6 +127,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>",
       "bar": "function <large string>"
     }
@@ -169,6 +172,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "Run": "function <large string>",
       "bar": "function <large string>"
     }

--- a/test/DebuggerCommon/step_out_from_JITted_function_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_from_JITted_function_attach.js.dbg.baseline
@@ -45,6 +45,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "Run": "function <large string>"

--- a/test/DebuggerCommon/step_out_from_catch_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_from_catch_attach.js.dbg.baseline
@@ -23,6 +23,7 @@
       "z": "number 1"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "Run": "function <large string>"

--- a/test/DebuggerCommon/step_out_from_interpreted_function_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_out_from_interpreted_function_attach.js.dbg.baseline
@@ -46,6 +46,7 @@
       "x": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 5",
       "foo": "function <large string>",
       "bar": "function <large string>",
@@ -107,6 +108,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 5",
       "foo": "function <large string>",
       "bar": "function <large string>",
@@ -143,6 +145,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 5",
       "foo": "function <large string>",
       "bar": "function <large string>",

--- a/test/DebuggerCommon/step_over_ES6_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_over_ES6_attach.js.dbg.baseline
@@ -17,6 +17,7 @@
       "x": "number 2"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "foo": "function <large string>",
       "bar": "function <large string>",
       "baz": "function <large string>",

--- a/test/DebuggerCommon/step_over_JITd_fn_from_Intrprt_fn_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/step_over_JITd_fn_from_Intrprt_fn_attach.js.dbg.baseline
@@ -24,6 +24,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "callcount": "number 5",
       "foo": "function <large string>",
       "bar": "function <large string>",

--- a/test/DebuggerCommon/stringkeyedtypehandler.js.dbg.baseline
+++ b/test/DebuggerCommon/stringkeyedtypehandler.js.dbg.baseline
@@ -53,6 +53,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "o": {
         "#__proto__": "Object {...}"
       },

--- a/test/DebuggerCommon/targeted.js.dbg.baseline
+++ b/test/DebuggerCommon/targeted.js.dbg.baseline
@@ -131,6 +131,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 0",
       "g": {
         "#__proto__": "function <large string>",
@@ -299,6 +300,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 1",
       "g": {
         "#__proto__": "function <large string>",
@@ -467,6 +469,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 2",
       "g": {
         "#__proto__": "function <large string>",
@@ -635,6 +638,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 3",
       "g": {
         "#__proto__": "function <large string>",
@@ -803,6 +807,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 4",
       "g": {
         "#__proto__": "function <large string>",
@@ -860,6 +865,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 5",
       "g": "function <large string>",
       "f": "function <large string>",
@@ -889,6 +895,7 @@
       }
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "i": "number 5",
       "g": "function <large string>",
       "f": "function <large string>",

--- a/test/DebuggerCommon/with_shadow.js.dbg.baseline
+++ b/test/DebuggerCommon/with_shadow.js.dbg.baseline
@@ -78,6 +78,7 @@
       "foo": "function <large string>"
     },
     "globals": {
+      "Symbol.toStringTag": "string global",
       "f1": "function <large string>"
     }
   }

--- a/test/Intl/IntlReturnedValueTests.js.dbg.baseline
+++ b/test/Intl/IntlReturnedValueTests.js.dbg.baseline
@@ -5,6 +5,7 @@
       "[Intl.DateTimeFormat returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "undefined undefined",
@@ -23,6 +24,7 @@
       "[Intl.DateTimeFormat.prototype.format returned]": "string ‎2‎/‎1‎/‎2000"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -40,6 +42,7 @@
       "[toLocaleString returned]": "string <large string>"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -57,6 +60,7 @@
       "[Intl.DateTimeFormat.supportedLocalesOf returned]": "Array [en-US]"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -74,6 +78,7 @@
       "[resolvedOptions returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -91,6 +96,7 @@
       "[Intl.NumberFormat returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -109,6 +115,7 @@
       "[Intl.NumberFormat.prototype.format returned]": "string 123.456"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -126,6 +133,7 @@
       "[Intl.NumberFormat.supportedLocalesOf returned]": "Array [en-US]"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -143,6 +151,7 @@
       "[resolvedOptions returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -160,6 +169,7 @@
       "[Intl.Collator returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -178,6 +188,7 @@
       "[Intl.Collator.prototype.compare returned]": "number -1"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -195,6 +206,7 @@
       "[Intl.Collator.supportedLocalesOf returned]": "Array [en-US]"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",
@@ -212,6 +224,7 @@
       "[resolvedOptions returned]": "Object {...}"
     },
     "locals": {
+      "Symbol.toStringTag": "string global",
       "options": "Object {...}",
       "dateFormat1": "Object {...}",
       "date1": "Date <large string>",

--- a/test/LetConst/delete.js
+++ b/test/LetConst/delete.js
@@ -13,7 +13,7 @@ if (this.x)
 WScript.Echo(this.x);
 
 Object.preventExtensions(this);
-Object.getOwnPropertyNames(this).forEach(function (p) {
+Object.getOwnPropertyNames(this).concat(Object.getOwnPropertySymbols(this)).forEach(function (p) {
     Object.defineProperty(this, p, { configurable: false });
 });
 

--- a/test/LetConst/seal.js
+++ b/test/LetConst/seal.js
@@ -6,7 +6,7 @@
 let x = "let x";
 
 Object.preventExtensions(this);
-Object.getOwnPropertyNames(this).forEach(function (p) {
+Object.getOwnPropertyNames(this).concat(Object.getOwnPropertySymbols(this)).forEach(function (p) {
     Object.defineProperty(this, p, { configurable: false });
 });
 

--- a/test/LetConst/seal1.js
+++ b/test/LetConst/seal1.js
@@ -6,7 +6,7 @@
 const x = "const x";
 
 Object.preventExtensions(this);
-Object.getOwnPropertyNames(this).forEach(function (p) {
+Object.getOwnPropertyNames(this).concat(Object.getOwnPropertySymbols(this)).forEach(function (p) {
     Object.defineProperty(this, p, { configurable: false });
 });
 

--- a/test/LetConst/seal2.js
+++ b/test/LetConst/seal2.js
@@ -8,7 +8,7 @@ this.x = 20;
 delete(this.x);
 
 Object.preventExtensions(this);
-Object.getOwnPropertyNames(this).forEach(function (p) {
+Object.getOwnPropertyNames(this).concat(Object.getOwnPropertySymbols(this)).forEach(function (p) {
     Object.defineProperty(this, p, { configurable: false });
 });
 

--- a/test/Object/propertyDescriptorNonObject.js
+++ b/test/Object/propertyDescriptorNonObject.js
@@ -36,11 +36,10 @@ var tests = [
     {
         name: "Object.create in sloppy mode with `this` as a propertyDescriptor when it contains non-object properties",
         body: function() {
-            a = 0;
             assert.throws(function() { Object.create({}, this) },
                 TypeError,
-                "Should throw TypeError because property 'a' is defined on `this` and is a non-object.",
-                "Invalid descriptor for property 'a'")
+                "Should throw TypeError because property Symbol.toStringTag is defined on `this` and is a non-object.",
+                "Invalid descriptor for property 'Symbol.toStringTag'")
         }
     },
 ];

--- a/test/Object/toStringWithGlobalObject.baseline
+++ b/test/Object/toStringWithGlobalObject.baseline
@@ -1,2 +1,5 @@
 [object global]
 global
+true
+true
+true

--- a/test/Object/toStringWithGlobalObject.js
+++ b/test/Object/toStringWithGlobalObject.js
@@ -6,3 +6,7 @@
 let global = new Function('return this;')();
 console.log(global.toString());
 console.log(global[Symbol.toStringTag]);
+let descriptor = Object.getOwnPropertyDescriptor(global, Symbol.toStringTag);
+console.log(descriptor.writable);
+console.log(descriptor.enumerable);
+console.log(descriptor.configurable);


### PR DESCRIPTION
We saw failures in node-chakracore because it tries to reconfigure global[Symbol.toStringTag]. This change updates the attributes to match what v8 does.