### PR TITLE
Use correct deferred stubs for functions declared in parameter scope of function expression

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -273,6 +273,7 @@ public:
 
 protected:
     static uint BuildDeferredStubTreeHelper(ParseNodeBlock* pnodeBlock, DeferredFunctionStub* deferredStubs, uint currentStubIndex, uint deferredStubCount, Recycler *recycler);
+    void ShiftCurrDeferredStubToChildFunction(ParseNodeFnc* pnodeFnc, ParseNodeFnc* pnodeFncParent);
 
     HRESULT ParseSourceInternal(
         __out ParseNodeProg ** parseTree, LPCUTF8 pszSrc, size_t offsetInBytes,

--- a/test/Bugs/deferredStubBugs.js
+++ b/test/Bugs/deferredStubBugs.js
@@ -26,7 +26,7 @@ var func5 = (a = 123) => (function v6() {
 })()
 func5();
 
-function func6(a = v => { console.log('pass'); }, b = v => { return a; }) {
+function func6(a = v => { console.log(pass); }, b = v => { return a; }) {
     function c() {
         return b();
     }
@@ -84,3 +84,13 @@ function func18(a = class A { meth() { return fail } static meth2() { return fai
     return c();
 }
 console.log(func18());
+
+function func19() {
+  return (function(a = { b() {} }){ return pass; })();
+}
+console.log(func19());
+
+function func20() {
+  return (function(a = { b() {} }, c = function() { return pass; }){ return c(); })();
+}
+console.log(func20());


### PR DESCRIPTION
We failed to shift the deferred stubs down to those belonging to the child function when parsing the argument list of a function expression.
