### PR TITLE
fixes #5572 clear unused exception for WScript.LoadScript

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -381,6 +381,15 @@ JsValueRef WScriptJsrt::LoadScriptHelper(JsValueRef callee, bool isConstructCall
 Error:
     if (errorCode != JsNoError)
     {
+        // check and clear exception if any
+        bool hasException;
+        if (ChakraRTInterface::JsHasException(&hasException) == JsNoError && hasException)
+        {
+            JsValueRef unusedException = JS_INVALID_REFERENCE;
+            ChakraRTInterface::JsGetAndClearException(&unusedException);
+            unusedException;
+        }
+
         JsValueRef errorObject;
         JsValueRef errorMessageString;
 

--- a/test/Bugs/bug_5572_wscript_loadscript_loadmodule.js
+++ b/test/Bugs/bug_5572_wscript_loadscript_loadmodule.js
@@ -1,0 +1,95 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Expect exception with invalid file name to WScript.LoadScript",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadScript(``, ``, {
+                toString: function () {
+                    func_0();
+                }}
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadScript", 
+        "ScriptError");
+    }
+  },
+  {
+    name: "Expect exception with invalid type to WScript.LoadScript",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadScript(``, {
+                toString: function () {
+                    func_0();
+                }}, ``
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadScript", 
+        "ScriptError");
+    }
+  },
+  {
+    name: "Expect exception with invalid content to WScript.LoadScript",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadScript({
+                toString: function () {
+                    func_0();
+                }}, ``, ``
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadScript", 
+        "ScriptError");
+    }
+  },
+  {
+    name: "Expect exception with invalid file name to WScript.LoadModule",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadModule(``, ``, {
+                toString: function () {
+                    func_0();
+                }}
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadModule", 
+        "ScriptError");
+    }
+  },
+  {
+    name: "Expect exception with invalid type to WScript.LoadModule",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadModule(``, {
+                toString: function () {
+                    func_0();
+                }}, ``
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadModule", 
+        "ScriptError");
+    }
+  },
+  {
+    name: "Expect exception with invalid content to WScript.LoadModule",
+    body: function () {  
+        assert.throws(function () { 
+            WScript.LoadModule({
+                toString: function () {
+                    func_0();
+                }}, ``, ``
+            );        
+        }, Error, 
+        "Should throw for invalid input to WScript.LoadModule", 
+        "ScriptError");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -537,4 +537,10 @@
       <tags>exclude_jshost</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_5572_wscript_loadscript_loadmodule.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
we try to convert inputs to string but for some invalid input, this call sets and records exception along with return error code to context thread. In this case, context thread need to clear unused exception before set and record new exception.