### PR TITLE
Fix incorrect length of display name when tracing ETW events for the JIT queue.

### DIFF
--- a/lib/Backend/CodeGenWorkItem.h
+++ b/lib/Backend/CodeGenWorkItem.h
@@ -213,12 +213,11 @@ public:
     {
         const WCHAR* name = functionBody->GetExternalDisplayName();
         size_t nameSizeInChars = wcslen(name) + 1;
-        size_t sizeInBytes = nameSizeInChars * sizeof(WCHAR);
-        if(displayName == NULL || sizeInChars < nameSizeInChars)
+        if (displayName == NULL || sizeInChars < nameSizeInChars)
         {
-           return nameSizeInChars;
+            return nameSizeInChars;
         }
-        js_wmemcpy_s(displayName, sizeInChars, name, sizeInBytes);
+        js_wmemcpy_s(displayName, nameSizeInChars, name, nameSizeInChars);
         return nameSizeInChars;
     }
 


### PR DESCRIPTION
Fix incorrect length of display name when tracing ETW events for the JIT queue.

Fixes:#5631
