### PR TITLE
Fixes #5532 null pointer dereference in EmitBooleanExpression 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -9260,15 +9260,15 @@ void ByteCodeGenerator::EmitInvertedLoop(ParseNodeLoop* outerLoop, ParseNodeFor*
     this->m_writer.MarkLabel(invertedLoopLabel);
 
     // Emit a zero trip test for the original outer-loop if the outer-loop
-	// has a condition
-	if (outerLoop->AsParseNodeFor()->pnodeCond)
-	{
-		Js::ByteCodeLabel zeroTrip = this->m_writer.DefineLabel();
-		ParseNode* testNode = this->GetParser()->CopyPnode(outerLoop->AsParseNodeFor()->pnodeCond);
-		EmitBooleanExpression(testNode, zeroTrip, afterInvertedLoop, this, funcInfo, true, false);
-		this->m_writer.MarkLabel(zeroTrip);
-		funcInfo->ReleaseLoc(testNode);
-	}
+    // has a condition
+    if (outerLoop->AsParseNodeFor()->pnodeCond)
+    {
+        Js::ByteCodeLabel zeroTrip = this->m_writer.DefineLabel();
+        ParseNode* testNode = this->GetParser()->CopyPnode(outerLoop->AsParseNodeFor()->pnodeCond);
+        EmitBooleanExpression(testNode, zeroTrip, afterInvertedLoop, this, funcInfo, true, false);
+        this->m_writer.MarkLabel(zeroTrip);
+        funcInfo->ReleaseLoc(testNode);
+    }
 
     // emit inverted
     Emit(invertedLoop->pnodeInit, this, funcInfo, false);

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -9259,12 +9259,16 @@ void ByteCodeGenerator::EmitInvertedLoop(ParseNodeLoop* outerLoop, ParseNodeFor*
     this->m_writer.Br(afterInvertedLoop);
     this->m_writer.MarkLabel(invertedLoopLabel);
 
-    // Emit a zero trip test for the original outer-loop
-    Js::ByteCodeLabel zeroTrip = this->m_writer.DefineLabel();
-    ParseNode* testNode = this->GetParser()->CopyPnode(outerLoop->AsParseNodeFor()->pnodeCond);
-    EmitBooleanExpression(testNode, zeroTrip, afterInvertedLoop, this, funcInfo, true, false);
-    this->m_writer.MarkLabel(zeroTrip);
-    funcInfo->ReleaseLoc(testNode);
+    // Emit a zero trip test for the original outer-loop if the outer-loop
+	// has a condition
+	if (outerLoop->AsParseNodeFor()->pnodeCond)
+	{
+		Js::ByteCodeLabel zeroTrip = this->m_writer.DefineLabel();
+		ParseNode* testNode = this->GetParser()->CopyPnode(outerLoop->AsParseNodeFor()->pnodeCond);
+		EmitBooleanExpression(testNode, zeroTrip, afterInvertedLoop, this, funcInfo, true, false);
+		this->m_writer.MarkLabel(zeroTrip);
+		funcInfo->ReleaseLoc(testNode);
+	}
 
     // emit inverted
     Emit(invertedLoop->pnodeInit, this, funcInfo, false);

--- a/test/loop/loopinversion.js
+++ b/test/loop/loopinversion.js
@@ -73,7 +73,7 @@ g5();
 // Tests that loop inversion does not crash when the outer loop does not have
 // a condition. In order to not stay in an infinite loop, these functions return
 // immediately. The bytecode will still be generated.
-function g6(p){if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g4a(0);
-function g6a(p){"use strict"; if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g4a(0);
+function g6(p){if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g6(0);
+function g6a(p){"use strict"; if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g6a(0);
 
 WScript.Echo("pass");

--- a/test/loop/loopinversion.js
+++ b/test/loop/loopinversion.js
@@ -70,5 +70,10 @@ function g5()
 };
 g5();
 
+// Tests that loop inversion does not crash when the outer loop does not have
+// a condition. In order to not stay in an infinite loop, these functions return
+// immediately. The bytecode will still be generated.
+function g6(p){if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g4a(0);
+function g6a(p){"use strict"; if(!p) return; var a = 0; for (var h = 0;; ++h){ for (var r = 0; r < 1; ++r){ a = r; }}};g4a(0);
 
 WScript.Echo("pass");


### PR DESCRIPTION
Fixes #5532 
Given a nested for loop that qualifies for loop inversion, the lack of a conditional in the outer loop causes a read access violation when the conditional’s ParseNode’s nop is read. The conditional is analyzed to perform a zero trip test which can skip the execution of the loop entirely. In the case where the outer loop lacks a conditional, the zero trip test will not pass. Therefore when the outer loop lacks a conditional skipping the inclusion of a zero trip test is valid and avoids the read access violation.