### PR TITLE
RegExp.lastIndex writeable can be set to false fixes:#238

### DIFF
--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -17,6 +17,7 @@ namespace Js
         static PropertyId const specialPropertyIdsWithoutDotAll[];
         static PropertyId const specialPropertyIdsWithoutDotAllOrUnicode[];
         static const uint defaultSpecialPropertyIdsCount = 6;
+        Field(bool) readOnlyLastIndex = false;
 
         Field(UnifiedRegex::RegexPattern*) pattern;
 
@@ -50,6 +51,7 @@ namespace Js
         bool GetPropertyBuiltIns(PropertyId propertyId, Var* value, BOOL* result);
         bool SetPropertyBuiltIns(PropertyId propertyId, Var value, PropertyOperationFlags flags, BOOL* result);
         bool GetSetterBuiltIns(PropertyId propertyId, PropertyValueInfo* info, DescriptorFlags* result);
+        BOOL SetWritable(PropertyId propertyId, BOOL value);
         inline PropertyId const * GetSpecialPropertyIdsInlined() const;
 
         Var GetOptions();

--- a/test/Regex/bug_issue_238.js
+++ b/test/Regex/bug_issue_238.js
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+const tests = [
+  {
+    name: "Bug Issue 238 - lastIndex can be made not writable",
+    body: function () {
+        const re = /./;
+        re.lastIndex = 2;
+        let desc = Object.getOwnPropertyDescriptor(re, "lastIndex");
+        assert.areEqual(true, desc.writable, "lastIndex property should be created writable");
+        re.lastIndex = 5;
+        assert.areEqual(5, re.lastIndex, "writing to lastIndex should succeed");
+        Object.defineProperty(re, "lastIndex", {writable : false});
+        desc = Object.getOwnPropertyDescriptor(re, "lastIndex");
+        assert.areEqual(false, desc.writable, "making lastIndex not writable should succeed");
+        assert.areEqual(5, re.lastIndex);
+    
+        assert.throws(()=>{"use strict"; re.lastIndex = 10}, TypeError, "TypeError for writing to non-writeable property in strict mode");
+        assert.doesNotThrow(()=>{re.lastIndex = 10}, "No error for writing to non-writable property in sloppy mode");
+        assert.areEqual(5, re.lastIndex, "Writing to non-writable lastIndex property should not succeed");
+        assert.throws(()=>{ Object.defineProperty(re, "lastIndex", {writable : true})}, TypeError, "Attempting to revert writable state of lastIndex should throw");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -237,6 +237,12 @@
   </test>
   <test>
     <default>
+      <files>bug_issue_238.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>characterclass_with_range.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
RegExp instances have the property "lastIndex" which by default is: writeable but not configurable. However it should be possible with Object.defineProperty to change it to not writeable.

This would not previously work as RegExp::IsWriteable was hard coded to return true for the lastIndex property.

This fixes the issue by adding a boolean to track if lastIndex has been set to read only.

fixes:#238

Edit: this hasn't quite worked (it's my own test case for this issue that's failing) - I'll take another look; it passed offline on macOS - and as can be seen below it passes on some variants but not all within the CI.