### PR TITLE
Force same src/dst for SQRTSD

### DIFF
--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7711,12 +7711,24 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
     switch (instr->m_opcode)
     {
     case Js::OpCode::InlineMathSqrt:
-        // Sqrt maps directly to the SSE2 instruction.
-        // src and dst should already be XMM registers, all we need is just change the opcode.
-        Assert(helperMethod == (IR::JnHelperMethod)0);
-        Assert(instr->GetSrc2() == nullptr);
-        instr->m_opcode = instr->GetSrc1()->IsFloat64() ? Js::OpCode::SQRTSD : Js::OpCode::SQRTSS;
-        break;
+		{
+			// Sqrt maps directly to the SSE2 instruction.
+			// src and dst should already be XMM registers, all we need is just change the opcode.
+			Assert(helperMethod == (IR::JnHelperMethod)0);
+			Assert(instr->GetSrc2() == nullptr);
+			instr->m_opcode = instr->GetSrc1()->IsFloat64() ? Js::OpCode::SQRTSD : Js::OpCode::SQRTSS;
+
+			IR::Opnd *src = instr->GetSrc1();
+			IR::Opnd *dst = instr->GetDst();
+			if (!src->IsEqual(dst))
+			{
+				// Force source to be the same as destination to break false dependency on the register
+				Lowerer::InsertMove(dst, src, instr, true /* generateWriteBarrier */);
+				instr->ReplaceSrc1(dst);
+			}
+
+			break;
+		}
 
     case Js::OpCode::InlineMathAbs:
         Assert(helperMethod == (IR::JnHelperMethod)0);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7722,8 +7722,9 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
 			IR::Opnd *dst = instr->GetDst();
 			if (!src->IsEqual(dst))
 			{
+				Assert(src->IsRegOpnd() && dst->IsRegOpnd());
 				// Force source to be the same as destination to break false dependency on the register
-				Lowerer::InsertMove(dst, src, instr, true /* generateWriteBarrier */);
+				Lowerer::InsertMove(dst, src, instr, false /* generateWriteBarrier */);
 				instr->ReplaceSrc1(dst);
 			}
 

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7711,25 +7711,25 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
     switch (instr->m_opcode)
     {
     case Js::OpCode::InlineMathSqrt:
-		{
-			// Sqrt maps directly to the SSE2 instruction.
-			// src and dst should already be XMM registers, all we need is just change the opcode.
-			Assert(helperMethod == (IR::JnHelperMethod)0);
-			Assert(instr->GetSrc2() == nullptr);
-			instr->m_opcode = instr->GetSrc1()->IsFloat64() ? Js::OpCode::SQRTSD : Js::OpCode::SQRTSS;
+        {
+            // Sqrt maps directly to the SSE2 instruction.
+            // src and dst should already be XMM registers, all we need is just change the opcode.
+            Assert(helperMethod == (IR::JnHelperMethod)0);
+            Assert(instr->GetSrc2() == nullptr);
+            instr->m_opcode = instr->GetSrc1()->IsFloat64() ? Js::OpCode::SQRTSD : Js::OpCode::SQRTSS;
 
-			IR::Opnd *src = instr->GetSrc1();
-			IR::Opnd *dst = instr->GetDst();
-			if (!src->IsEqual(dst))
-			{
-				Assert(src->IsRegOpnd() && dst->IsRegOpnd());
-				// Force source to be the same as destination to break false dependency on the register
-				Lowerer::InsertMove(dst, src, instr, false /* generateWriteBarrier */);
-				instr->ReplaceSrc1(dst);
-			}
+            IR::Opnd *src = instr->GetSrc1();
+            IR::Opnd *dst = instr->GetDst();
+            if (!src->IsEqual(dst))
+            {
+                Assert(src->IsRegOpnd() && dst->IsRegOpnd());
+                // Force source to be the same as destination to break false dependency on the register
+                Lowerer::InsertMove(dst, src, instr, false /* generateWriteBarrier */);
+                instr->ReplaceSrc1(dst);
+            }
 
-			break;
-		}
+            break;
+        }
 
     case Js::OpCode::InlineMathAbs:
         Assert(helperMethod == (IR::JnHelperMethod)0);


### PR DESCRIPTION
 Force source to be the same as destination to break false dependency on the register; this fixes the slowdown for `sqrtsd`