### PR TITLE
fixes #5681 avoid c2440 error lose const qualifier

### DIFF
--- a/bin/NativeTests/BigUIntTest.cpp
+++ b/bin/NativeTests/BigUIntTest.cpp
@@ -226,7 +226,7 @@ namespace BigUIntTest
     TEST_CASE("Init_From_Char_Of_Digits", "[BigUIntTest]")
     {
         BigUInt biDec;
-        char *charDigit;
+        const char *charDigit;
         bool result;
         int charDigitLength;
 


### PR DESCRIPTION
When /Zc:strictStrings is enable, encounter this error https://msdn.microsoft.com/en-us/library/dn449508.aspx since we cast literal string to non-const char pointer.