### PR TITLE
Do not lose property string in ToPropertyKey

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -285,6 +285,10 @@ CommonNumber:
             // For all other types, convert the key into a string and use that as the property name
             JavascriptString * propName = JavascriptConversion::ToString(key, scriptContext);
             propName->GetPropertyRecord(propertyRecord);
+            if (PropertyString::Is(propName))
+            {
+                propertyString = PropertyString::UnsafeFromVar(propName);
+            }
         }
 
         if (propString)


### PR DESCRIPTION
Looks like the intent of the method is to set propString to a property string if the argument happen to be one. It does not do that now. Possibly due to a typo.

In particular, methods such as HasOwnProperty check if propString is returned and would use its inline caches, but since the property string is not returned, the optimization cannot work.
