### PR TITLE
[Backport #5464] update the build script to support LLVM > 9

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -546,7 +546,7 @@ else
 fi
 
 # check clang version (min required 3.7)
-VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]\.[0-9]*" --o)
+VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]*\.[0-9]*" --o)
 VERSION=${VERSION/./}
 
 if [[ $VERSION -lt 37 ]]; then


### PR DESCRIPTION
Backporting #5464 to release/1.11, thanks again to @patrickkettner for the PR.