### PR TITLE
Fixes #5477 - Forces computed property names within classes to be executed in strict mode

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1923,9 +1923,9 @@ Scope * ByteCodeGenerator::FindScopeForSym(Scope *symScope, Scope *scope, Js::Pr
 }
 
 /* static */
-Js::OpCode ByteCodeGenerator::GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit)
+Js::OpCode ByteCodeGenerator::GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit, bool forceStrictModeForClassComputedPropertyName)
 {
-    return GetStFldOpCode(funcInfo->GetIsStrictMode(), isRoot, isLetDecl, isConstDecl, isClassMemberInit);
+    return GetStFldOpCode(funcInfo->GetIsStrictMode() || forceStrictModeForClassComputedPropertyName, isRoot, isLetDecl, isConstDecl, isClassMemberInit);
 }
 
 /* static */

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -65,6 +65,13 @@ public:
     static const unsigned int MinArgumentsForCallOptimization = 16;
     bool forceNoNative;
 
+    // A flag that when set will force bytecode opcodes to be emitted in strict mode when avaliable.
+    // This flag is set outside of emit calls under the condition that the bytecode being emitted
+    // corresponds to computed property names within classes. This fixes a bug where computed property
+    // names would not enforce strict mode when inside a class even though the spec requires that
+    // all code within a class must be strict.
+    bool forceStrictModeForClassComputedPropertyName = false;
+
     ByteCodeGenerator(Js::ScriptContext* scriptContext, Js::ScopeInfo* parentScopeInfo);
 
 #if DBG_DUMP
@@ -326,7 +333,7 @@ public:
             isStrictMode ? (isRoot ? Js::OpCode::StRootFldStrict : Js::OpCode::StFldStrict) :
             isRoot ? Js::OpCode::StRootFld : Js::OpCode::StFld;
     }
-    static Js::OpCode GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit);
+    static Js::OpCode GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit, bool forceStrictModeForClassComputedPropertyName = false);
     static Js::OpCode GetScopedStFldOpCode(bool isStrictMode, bool isConsoleScope = false)
     {
         return isStrictMode ? 

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -1301,7 +1301,7 @@ namespace Js
         return false;
     }
 
-    void ByteCodeWriter::Element(OpCode op, RegSlot Value, RegSlot Instance, RegSlot Element, bool instanceAtReturnRegOK)
+    void ByteCodeWriter::Element(OpCode op, RegSlot Value, RegSlot Instance, RegSlot Element, bool instanceAtReturnRegOK, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementI);
@@ -1311,7 +1311,7 @@ namespace Js
         Instance = ConsumeReg(Instance);
         Element = ConsumeReg(Element);
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::DeleteElemI_A)
             {
@@ -1401,7 +1401,7 @@ StoreCommon:
         return false;
     }
 
-    void ByteCodeWriter::ScopedProperty(OpCode op, RegSlot value, PropertyIdIndexType propertyIdIndex)
+    void ByteCodeWriter::ScopedProperty(OpCode op, RegSlot value, PropertyIdIndexType propertyIdIndex, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementScopedC);
@@ -1424,7 +1424,7 @@ StoreCommon:
         }
 #endif
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::ScopedDeleteFld)
             {
@@ -1448,7 +1448,7 @@ StoreCommon:
         return false;
     }
 
-    void ByteCodeWriter::Property(OpCode op, RegSlot value, RegSlot instance, PropertyIdIndexType propertyIdIndex)
+    void ByteCodeWriter::Property(OpCode op, RegSlot value, RegSlot instance, PropertyIdIndexType propertyIdIndex, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementC);
@@ -1477,7 +1477,7 @@ StoreCommon:
         }
 #endif
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::DeleteFld)
             {

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -269,10 +269,10 @@ namespace Js
         void CallI(OpCode op, RegSlot returnValueRegister, RegSlot functionRegister, ArgSlot givenArgCount, ProfileId callSiteId, CallFlags callFlags = CallFlags_None);
         void CallIExtended(OpCode op, RegSlot returnValueRegister, RegSlot functionRegister, ArgSlot givenArgCount, CallIExtendedOptions options, const void *buffer, uint byteCount, ProfileId callSiteId, CallFlags callFlags = CallFlags_None);
         void RemoveEntryForRegSlotFromCacheIdMap(RegSlot functionRegister);
-        void Element(OpCode op, RegSlot value, RegSlot instance, RegSlot element, bool instanceAtReturnRegOK = false);
+        void Element(OpCode op, RegSlot value, RegSlot instance, RegSlot element, bool instanceAtReturnRegOK = false, bool forceStrictMode = false);
         void ElementUnsigned1(OpCode op, RegSlot value, RegSlot instance, uint32 element);
-        void Property(OpCode op, RegSlot Value, RegSlot Instance, PropertyIdIndexType propertyIdIndex);
-        void ScopedProperty(OpCode op, RegSlot Value, PropertyIdIndexType propertyIdIndex);
+        void Property(OpCode op, RegSlot Value, RegSlot Instance, PropertyIdIndexType propertyIdIndex, bool forceStrictMode = false);
+        void ScopedProperty(OpCode op, RegSlot Value, PropertyIdIndexType propertyIdIndex, bool forceStrictMode = false);
         void Slot(OpCode op, RegSlot value, RegSlot instance, uint32 slotId);
         void Slot(OpCode op, RegSlot value, RegSlot instance, uint32 slotId, ProfileId profileId);
         void SlotI1(OpCode op, RegSlot value, uint32 slotId1);

--- a/test/strict/classComputedPropertyName.js
+++ b/test/strict/classComputedPropertyName.js
@@ -1,0 +1,245 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Assigning an undeclared variable in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    class C {
+                        [f = 5]() { }
+                    }                
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+            assert.throws(
+                function () {
+                    class C {
+                        static [f = 5]() { }
+                    }
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+            assert.throws(
+                function () {
+                    "use strict";
+                    class C {
+                        [f = 5]() { }
+                    }
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a non writable object property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, 'b', { value: 5, writable: false });
+                    class C {
+                        [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a non writable property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, 'b', { value: 5, writable: false });
+                    class C {
+                        static [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a non writable property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a getter-only object property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = { get b() { return 5; } };
+                    class C {
+                        [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a getter-only property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = { get b() { return 5; } };
+                    class C {
+                        static [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a getter-only property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a property of a non-extensible object in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        [a.b = 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a property of a non-extensible object should throw a TypeError in strict mode",
+                "Cannot create property for a non-extensible object"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        static [a.b = 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a property of a non-extensible object should throw a TypeError in strict mode",
+                "Cannot create property for a non-extensible object"
+            );
+        }
+    },
+    {
+        name: "Calling delete on an undeletable property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    class C {
+                        [delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    class C {
+                        static [delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = 5;
+                    class C {
+                        [a < 6 ? delete Object.prototype : 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = 5;
+                    class C {
+                        static [a < 6 ? delete Object.prototype : 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        [a && delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        static [a && delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, "x", { value: 5, configurable: false });
+                    class C {
+                        [delete a["x"]]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'x' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, "x", { value: 5, configurable: false });
+                    class C {
+                        static [delete a["x"]]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'x' is not allowed in strict mode"
+            );
+        }
+    },
+
+]
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/strict/rlexe.xml
+++ b/test/strict/rlexe.xml
@@ -716,4 +716,10 @@
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>classComputedPropertyName.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Forces computed property names within classes to be executed in strict mode.
The ECMA spec requires that a class definition is always strict mode code, this includes computed property names within classes. A flag, forceStrictModeForClassComputedPropertyName, is added into ByteCodeGenerator.h. When set, this flag will force bytecode opcodes to be emitted in strict mode when avaliable. This flag is set outside of emit calls under the condition that the bytecode being emitted corresponds to computed property names within classes.
