### PR TITLE
Writing to proto can leave the TypeHandler::protoCachesWereInvalidated set, and writing to proto again with the same type on the RHS object can skip proto cache invalidation

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -720,7 +720,7 @@ BackwardPass::MergeSuccBlocksInfo(BasicBlock * block)
                               this->func->GetDebugNumberSet(debugStringBuffer),
                               block->GetBlockNum(), blockSucc->GetBlockNum());
 
-            auto fixupFrom = [block, blockSucc, this](Bucket<AddPropertyCacheBucket> &bucket)
+            auto fixupFrom = [block, blockSucc, upwardExposedUses, this](Bucket<AddPropertyCacheBucket> &bucket)
             {
                 AddPropertyCacheBucket *fromData = &bucket.element;
                 if (fromData->GetInitialType() == nullptr ||
@@ -729,10 +729,10 @@ BackwardPass::MergeSuccBlocksInfo(BasicBlock * block)
                     return;
                 }
 
-                this->InsertTypeTransitionsAtPriorSuccessors(block, blockSucc, bucket.value, fromData);
+                this->InsertTypeTransitionsAtPriorSuccessors(block, blockSucc, bucket.value, fromData, upwardExposedUses);
             };
 
-            auto fixupTo = [blockSucc, this](Bucket<AddPropertyCacheBucket> &bucket)
+            auto fixupTo = [blockSucc, upwardExposedUses, this](Bucket<AddPropertyCacheBucket> &bucket)
             {
                 AddPropertyCacheBucket *toData = &bucket.element;
                 if (toData->GetInitialType() == nullptr ||
@@ -741,7 +741,7 @@ BackwardPass::MergeSuccBlocksInfo(BasicBlock * block)
                     return;
                 }
 
-                this->InsertTypeTransitionAtBlock(blockSucc, bucket.value, toData);
+                this->InsertTypeTransitionAtBlock(blockSucc, bucket.value, toData, upwardExposedUses);
             };
 
             if (blockSucc->stackSymToFinalType != nullptr)
@@ -4614,7 +4614,7 @@ BackwardPass::ProcessNewScObject(IR::Instr* instr)
                     Assert(pBucket->GetInitialType() == ctorCache->GetType());
                     if (!this->IsPrePass())
                     {
-                        this->InsertTypeTransition(instr->m_next, objSym, pBucket);
+                        this->InsertTypeTransition(instr->m_next, objSym, pBucket, block->upwardExposedUses);
                     }
 #if DBG
                     pBucket->deadStoreUnavailableInitialType = pBucket->GetInitialType();
@@ -5192,7 +5192,7 @@ BackwardPass::ProcessPropertySymOpndUse(IR::PropertySymOpnd * opnd)
                     pBucket->GetFinalType() != nullptr &&
                     pBucket->GetFinalType() != pBucket->GetInitialType())
                 {
-                    this->InsertTypeTransition(this->currentInstr->m_next, baseSym, pBucket);
+                    this->InsertTypeTransition(this->currentInstr->m_next, baseSym, pBucket, block->upwardExposedUses);
                     pBucket->SetFinalType(pBucket->GetInitialType());
                 }
             }
@@ -5211,9 +5211,6 @@ BackwardPass::ProcessPropertySymOpndUse(IR::PropertySymOpnd * opnd)
 void
 BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *block)
 {
-    StackSym *auxSlotPtrSym = nullptr;
-    bool auxSlotPtrUpwardExposed = false;
-
     Assert(tag == Js::DeadStorePhase);
     Assert(opnd->IsTypeCheckSeqCandidate());
 
@@ -5280,7 +5277,6 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
 #endif
 
         bucket->AddToGuardedPropertyOps(opnd->GetObjTypeSpecFldId());
-        auxSlotPtrUpwardExposed = PHASE_ON(Js::ReuseAuxSlotPtrPhase, this->func) && opnd->UsesAuxSlot() && !opnd->IsLoadedFromProto() && opnd->IsTypeChecked();
 
         if (opnd->NeedsMonoCheck())
         {
@@ -5327,12 +5323,6 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
                     bucket->SetGuardedPropertyOps(nullptr);
                     JitAdelete(this->tempAlloc, guardedPropertyOps);
                     block->stackSymToGuardedProperties->Clear(objSym->m_id);
-                    auxSlotPtrSym = opnd->GetAuxSlotPtrSym();
-                    if (auxSlotPtrSym)
-                    {
-                        this->currentBlock->upwardExposedUses->Clear(auxSlotPtrSym->m_id);
-                    }
-                    auxSlotPtrUpwardExposed = false;
                 }
             }
 #if DBG
@@ -5351,11 +5341,25 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
         opnd->SetGuardedPropOp(opnd->GetObjTypeSpecFldId());
     }
 
-    if (auxSlotPtrUpwardExposed)
+    if (opnd->UsesAuxSlot() && opnd->IsTypeCheckSeqParticipant() && !opnd->HasTypeMismatch() && !opnd->IsLoadedFromProto())
     {
-        // This is an upward-exposed use of the aux slot pointer.
-        auxSlotPtrSym = opnd->EnsureAuxSlotPtrSym(this->func);
-        this->currentBlock->upwardExposedUses->Set(auxSlotPtrSym->m_id);
+        bool auxSlotPtrUpwardExposed = false;
+        StackSym *auxSlotPtrSym = opnd->GetAuxSlotPtrSym();
+        if (opnd->IsAuxSlotPtrSymAvailable())
+        {    
+            // This is an upward-exposed use of the aux slot pointer.
+            Assert(auxSlotPtrSym);
+            auxSlotPtrUpwardExposed = this->currentBlock->upwardExposedUses->TestAndSet(auxSlotPtrSym->m_id);
+        }
+        else if (auxSlotPtrSym != nullptr)
+        {
+            // The aux slot pointer is not upward-exposed at this point.
+            auxSlotPtrUpwardExposed = this->currentBlock->upwardExposedUses->TestAndClear(auxSlotPtrSym->m_id);
+        }
+        if (!this->IsPrePass() && auxSlotPtrUpwardExposed)
+        {
+            opnd->SetProducesAuxSlotPtr(true);
+        }
     }
 }
 
@@ -5611,16 +5615,18 @@ BackwardPass::TrackAddPropertyTypes(IR::PropertySymOpnd *opnd, BasicBlock *block
 }
 
 void
-BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, int symId, AddPropertyCacheBucket *data)
+BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses)
 {
     StackSym *objSym = this->func->m_symTable->FindStackSym(symId);
     Assert(objSym);
-    this->InsertTypeTransition(instrInsertBefore, objSym, data);
+    this->InsertTypeTransition(instrInsertBefore, objSym, data, upwardExposedUses);
 }
 
 void
-BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSym, AddPropertyCacheBucket *data)
+BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSym, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses)
 {
+    Assert(!this->IsPrePass());
+
     IR::RegOpnd *baseOpnd = IR::RegOpnd::New(objSym, TyMachReg, this->func);
     baseOpnd->SetIsJITOptimizedReg(true);
 
@@ -5637,7 +5643,7 @@ BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSy
     IR::Instr *adjustTypeInstr =
         IR::Instr::New(Js::OpCode::AdjustObjType, finalTypeOpnd, baseOpnd, initialTypeOpnd, this->func);
 
-    if (this->currentBlock->upwardExposedUses)
+    if (upwardExposedUses)
     {
         // If this type change causes a slot adjustment, the aux slot pointer (if any) will be reloaded here, so take it out of upwardExposedUses.
         int oldCount;
@@ -5651,7 +5657,10 @@ BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSy
             StackSym *auxSlotPtrSym = baseOpnd->m_sym->GetAuxSlotPtrSym();
             if (auxSlotPtrSym)
             {
-                this->currentBlock->upwardExposedUses->Clear(auxSlotPtrSym->m_id);
+                if (upwardExposedUses->Test(auxSlotPtrSym->m_id))
+                {
+                    adjustTypeInstr->m_opcode = Js::OpCode::AdjustObjTypeReloadAuxSlotPtr;
+                }
             }
         }
     }
@@ -5660,7 +5669,7 @@ BackwardPass::InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSy
 }
 
 void
-BackwardPass::InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPropertyCacheBucket *data)
+BackwardPass::InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses)
 {
     if (!this->IsPrePass())
     {
@@ -5669,11 +5678,11 @@ BackwardPass::InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPro
         {
             // The instr with the bailout is something like a branch that may not fall through.
             // Insert the transitions instead at the beginning of each successor block.
-            this->InsertTypeTransitionsAtPriorSuccessors(this->currentBlock, nullptr, symId, data);
+            this->InsertTypeTransitionsAtPriorSuccessors(this->currentBlock, nullptr, symId, data, upwardExposedUses);
         }
         else
         {
-            this->InsertTypeTransition(instr->m_next, symId, data);
+            this->InsertTypeTransition(instr->m_next, symId, data, upwardExposedUses);
         }
     }
     // Note: we could probably clear this entry out of the table, but I don't know
@@ -5682,7 +5691,7 @@ BackwardPass::InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPro
 }
 
 void
-BackwardPass::InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPropertyCacheBucket *data)
+BackwardPass::InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses)
 {
     bool inserted = false;
     FOREACH_INSTR_IN_BLOCK(instr, block)
@@ -5705,7 +5714,7 @@ BackwardPass::InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPrope
             }
             else
             {
-                this->InsertTypeTransition(instr, symId, data);
+                this->InsertTypeTransition(instr, symId, data, upwardExposedUses);
                 inserted = true;
                 break;
             }
@@ -5715,7 +5724,7 @@ BackwardPass::InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPrope
     if (!inserted)
     {
         Assert(block->GetLastInstr()->m_next);
-        this->InsertTypeTransition(block->GetLastInstr()->m_next, symId, data);
+        this->InsertTypeTransition(block->GetLastInstr()->m_next, symId, data, upwardExposedUses);
     }
 }
 
@@ -5724,7 +5733,8 @@ BackwardPass::InsertTypeTransitionsAtPriorSuccessors(
     BasicBlock *block,
     BasicBlock *blockSucc,
     int symId,
-    AddPropertyCacheBucket *data)
+    AddPropertyCacheBucket *data,
+    BVSparse<JitArenaAllocator>* upwardExposedUses)
 {
     // For each successor of block prior to blockSucc, adjust the type.
     FOREACH_SUCCESSOR_BLOCK(blockFix, block)
@@ -5734,7 +5744,7 @@ BackwardPass::InsertTypeTransitionsAtPriorSuccessors(
             return;
         }
 
-        this->InsertTypeTransitionAtBlock(blockFix, symId, data);
+        this->InsertTypeTransitionAtBlock(blockFix, symId, data, upwardExposedUses);
     }
     NEXT_SUCCESSOR_BLOCK;
 }
@@ -5752,7 +5762,7 @@ BackwardPass::InsertTypeTransitionsAtPotentialKills()
         // Also do this for ctor cache updates, to avoid putting a type in the ctor cache that extends past
         // the end of the ctor that the cache covers.
         this->ForEachAddPropertyCacheBucket([&](int symId, AddPropertyCacheBucket *data)->bool {
-            this->InsertTypeTransitionAfterInstr(instr, symId, data);
+            this->InsertTypeTransitionAfterInstr(instr, symId, data, this->currentBlock->upwardExposedUses);
             return false;
         });
     }
@@ -5778,7 +5788,7 @@ BackwardPass::InsertTypeTransitionsAtPotentialKills()
                 if (this->TransitionUndoesObjectHeaderInlining(data))
                 {
                     // We're transitioning from inlined to non-inlined, so we can't push it up any farther.
-                    this->InsertTypeTransitionAfterInstr(instr, symId, data);
+                    this->InsertTypeTransitionAfterInstr(instr, symId, data, this->currentBlock->upwardExposedUses);
                 }
                 return false;
             });

--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -135,11 +135,11 @@ private:
     void TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *block);
     void TrackObjTypeSpecWriteGuards(IR::PropertySymOpnd *opnd, BasicBlock *block);
     void TrackAddPropertyTypes(IR::PropertySymOpnd *opnd, BasicBlock *block);
-    void InsertTypeTransition(IR::Instr *instrInsertBefore, int symId, AddPropertyCacheBucket *data);
-    void InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSym, AddPropertyCacheBucket *data);
-    void InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPropertyCacheBucket *data);
-    void InsertTypeTransitionsAtPriorSuccessors(BasicBlock *block, BasicBlock *blockSucc, int symId, AddPropertyCacheBucket *data);
-    void InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPropertyCacheBucket *data);
+    void InsertTypeTransition(IR::Instr *instrInsertBefore, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses);
+    void InsertTypeTransition(IR::Instr *instrInsertBefore, StackSym *objSym, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses);
+    void InsertTypeTransitionAtBlock(BasicBlock *block, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses);
+    void InsertTypeTransitionsAtPriorSuccessors(BasicBlock *block, BasicBlock *blockSucc, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses);
+    void InsertTypeTransitionAfterInstr(IR::Instr *instr, int symId, AddPropertyCacheBucket *data, BVSparse<JitArenaAllocator>* upwardExposedUses);
     void InsertTypeTransitionsAtPotentialKills();
     bool TransitionUndoesObjectHeaderInlining(AddPropertyCacheBucket *data) const;
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -87,6 +87,7 @@ GlobOpt::GlobOpt(Func * func)
     updateInductionVariableValueNumber(false),
     isPerformingLoopBackEdgeCompensation(false),
     currentRegion(nullptr),
+    auxSlotPtrSyms(nullptr),
     changedSymsAfterIncBailoutCandidate(nullptr),
     doTypeSpec(
         !IsTypeSpecPhaseOff(func)),
@@ -350,6 +351,8 @@ GlobOpt::ForwardPass()
     // changedSymsAfterIncBailoutCandidate helps track building incremental bailout in ForwardPass
     this->changedSymsAfterIncBailoutCandidate = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
 
+    this->auxSlotPtrSyms = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
+
 #if DBG
     this->byteCodeUsesBeforeOpt = JitAnew(this->alloc, BVSparse<JitArenaAllocator>, this->alloc);
     if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::FieldCopyPropPhase) && this->DoFunctionFieldCopyProp())
@@ -431,6 +434,7 @@ GlobOpt::ForwardPass()
 
     // this->alloc will be freed right after return, no need to free it here
     this->changedSymsAfterIncBailoutCandidate = nullptr;
+    this->auxSlotPtrSyms = nullptr;
 
     END_CODEGEN_PHASE(this->func, Js::ForwardPhase);
 }

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -459,6 +459,8 @@ private:
 
     BVSparse<JitArenaAllocator> *   changedSymsAfterIncBailoutCandidate;
 
+    BVSparse<JitArenaAllocator> *   auxSlotPtrSyms;
+
     JitArenaAllocator *             alloc;
     JitArenaAllocator *             tempAlloc;
 
@@ -933,6 +935,8 @@ private:
     bool                    CheckIfInstrInTypeCheckSeqEmitsTypeCheck(IR::Instr* instr, IR::PropertySymOpnd *opnd);
     template<bool makeChanges>
     bool                    ProcessPropOpInTypeCheckSeq(IR::Instr* instr, IR::PropertySymOpnd *opnd, BasicBlock* block, bool updateExistingValue, bool* emitsTypeCheckOut = nullptr, bool* changesTypeValueOut = nullptr, bool *isObjTypeChecked = nullptr);
+    StackSym *              EnsureAuxSlotPtrSym(IR::PropertySymOpnd *opnd);
+    void                    KillAuxSlotPtrSyms(IR::PropertySymOpnd *opnd, BasicBlock *block, bool isObjTypeSpecialized);
     void                    KillObjectHeaderInlinedTypeSyms(BasicBlock *block, bool isObjTypeSpecialized, SymID symId = SymID_Invalid);
     bool                    HasLiveObjectHeaderInlinedTypeSym(BasicBlock *block, bool isObjTypeSpecialized, SymID symId = SymID_Invalid);
     template<class Fn>

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -636,6 +636,7 @@ private:
     void GenerateSetObjectTypeFromInlineCache(IR::Instr * instrToInsertBefore, IR::RegOpnd * opndBase, IR::RegOpnd * opndInlineCache, bool isTypeTagged);
     bool GenerateFastStFld(IR::Instr * const instrStFld, IR::JnHelperMethod helperMethod, IR::JnHelperMethod polymorphicHelperMethod,
         IR::LabelInstr ** labelBailOut, IR::RegOpnd* typeOpnd, bool* pIsHelper, IR::LabelInstr** pLabelHelper, bool withPutFlags = false, Js::PropertyOperationFlags flags = Js::PropertyOperation_None);
+    void            GenerateAuxSlotPtrLoad(IR::PropertySymOpnd *propertySymOpnd, IR::Instr *insertInstr);
 
     bool            GenerateFastStFldForCustomProperty(IR::Instr *const instr, IR::LabelInstr * *const labelHelperRef);
 
@@ -750,7 +751,7 @@ private:
     static IR::RegOpnd *    LoadGeneratorArgsPtr(IR::Instr *instrInsert);
     static IR::Instr *      LoadGeneratorObject(IR::Instr *instrInsert);
 
-    IR::Opnd *      LoadSlotArrayWithCachedLocalType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd, bool canReuseAuxSlotPtr);
+    IR::Opnd *      LoadSlotArrayWithCachedLocalType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd);
     IR::Opnd *      LoadSlotArrayWithCachedProtoType(IR::Instr * instrInsert, IR::PropertySymOpnd *propertySymOpnd);
     IR::Instr *     LowerLdAsmJsEnv(IR::Instr *instr);
     IR::Instr *     LowerLdEnv(IR::Instr *instr);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -1056,24 +1056,6 @@ bool PropertySymOpnd::HasFinalType() const
     return this->finalType != nullptr;
 }
 
-bool PropertySymOpnd::NeedsAuxSlotPtrSymLoad() const
-{
-    // Consider: reload based on guarded prop ops' use of aux slots
-    return this->GetAuxSlotPtrSym() != nullptr;
-}
-
-void PropertySymOpnd::GenerateAuxSlotPtrSymLoad(IR::Instr * instrInsert)
-{
-    StackSym * auxSlotPtrSym = GetAuxSlotPtrSym();
-    Assert(auxSlotPtrSym);
-    Func * func = instrInsert->m_func;
-
-    IR::Opnd *opndIndir = IR::IndirOpnd::New(this->CreatePropertyOwnerOpnd(func), Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, func);
-    IR::RegOpnd *regOpnd = IR::RegOpnd::New(auxSlotPtrSym, TyMachReg, func);
-    regOpnd->SetIsJITOptimizedReg(true);
-    Lowerer::InsertMove(regOpnd, opndIndir, instrInsert);
-}
-
 PropertySymOpnd *
 PropertySymOpnd::CloneDefInternalSub(Func *func)
 {

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -636,6 +636,8 @@ public:
             // Note that even usesFixedValue cannot live on ObjTypeSpecFldInfo, because we may share a cache between
             // e.g. Object.prototype and new Object(), and only the latter actually uses the fixed value, even though both have it.
             bool usesFixedValue: 1;
+            bool auxSlotPtrSymAvailable:1;
+            bool producesAuxSlotPtr:1;
 
             union
             {
@@ -964,6 +966,28 @@ public:
         this->typeDead = value;
     }
 
+    bool IsAuxSlotPtrSymAvailable() const
+    {
+        return this->auxSlotPtrSymAvailable;
+    }
+
+    void SetAuxSlotPtrSymAvailable(bool value)
+    {
+        Assert(IsTypeCheckSeqCandidate());
+        this->auxSlotPtrSymAvailable = value;
+    }
+
+    bool ProducesAuxSlotPtr() const
+    {
+        return this->producesAuxSlotPtr;
+    }
+
+    void SetProducesAuxSlotPtr(bool value)
+    {
+        Assert(IsTypeCheckSeqCandidate());
+        this->producesAuxSlotPtr = value;
+    }
+
     void SetTypeDeadIfTypeCheckSeqCandidate(bool value)
     {
         if (IsTypeCheckSeqCandidate())
@@ -1167,9 +1191,6 @@ public:
     {
         this->finalType = JITTypeHolder(nullptr);
     }
-
-    bool NeedsAuxSlotPtrSymLoad() const;
-    void GenerateAuxSlotPtrSymLoad(IR::Instr * instrInsert);
 
     BVSparse<JitArenaAllocator>* GetGuardedPropOps()
     {

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1923,9 +1923,9 @@ Scope * ByteCodeGenerator::FindScopeForSym(Scope *symScope, Scope *scope, Js::Pr
 }
 
 /* static */
-Js::OpCode ByteCodeGenerator::GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit)
+Js::OpCode ByteCodeGenerator::GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit, bool forceStrictModeForClassComputedPropertyName)
 {
-    return GetStFldOpCode(funcInfo->GetIsStrictMode(), isRoot, isLetDecl, isConstDecl, isClassMemberInit);
+    return GetStFldOpCode(funcInfo->GetIsStrictMode() || forceStrictModeForClassComputedPropertyName, isRoot, isLetDecl, isConstDecl, isClassMemberInit);
 }
 
 /* static */

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -65,6 +65,13 @@ public:
     static const unsigned int MinArgumentsForCallOptimization = 16;
     bool forceNoNative;
 
+    // A flag that when set will force bytecode opcodes to be emitted in strict mode when avaliable.
+    // This flag is set outside of emit calls under the condition that the bytecode being emitted
+    // corresponds to computed property names within classes. This fixes a bug where computed property
+    // names would not enforce strict mode when inside a class even though the spec requires that
+    // all code within a class must be strict.
+    bool forceStrictModeForClassComputedPropertyName = false;
+
     ByteCodeGenerator(Js::ScriptContext* scriptContext, Js::ScopeInfo* parentScopeInfo);
 
 #if DBG_DUMP
@@ -326,7 +333,7 @@ public:
             isStrictMode ? (isRoot ? Js::OpCode::StRootFldStrict : Js::OpCode::StFldStrict) :
             isRoot ? Js::OpCode::StRootFld : Js::OpCode::StFld;
     }
-    static Js::OpCode GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit);
+    static Js::OpCode GetStFldOpCode(FuncInfo* funcInfo, bool isRoot, bool isLetDecl, bool isConstDecl, bool isClassMemberInit, bool forceStrictModeForClassComputedPropertyName = false);
     static Js::OpCode GetScopedStFldOpCode(bool isStrictMode, bool isConsoleScope = false)
     {
         return isStrictMode ? 

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -1301,7 +1301,7 @@ namespace Js
         return false;
     }
 
-    void ByteCodeWriter::Element(OpCode op, RegSlot Value, RegSlot Instance, RegSlot Element, bool instanceAtReturnRegOK)
+    void ByteCodeWriter::Element(OpCode op, RegSlot Value, RegSlot Instance, RegSlot Element, bool instanceAtReturnRegOK, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementI);
@@ -1311,7 +1311,7 @@ namespace Js
         Instance = ConsumeReg(Instance);
         Element = ConsumeReg(Element);
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::DeleteElemI_A)
             {
@@ -1401,7 +1401,7 @@ StoreCommon:
         return false;
     }
 
-    void ByteCodeWriter::ScopedProperty(OpCode op, RegSlot value, PropertyIdIndexType propertyIdIndex)
+    void ByteCodeWriter::ScopedProperty(OpCode op, RegSlot value, PropertyIdIndexType propertyIdIndex, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementScopedC);
@@ -1424,7 +1424,7 @@ StoreCommon:
         }
 #endif
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::ScopedDeleteFld)
             {
@@ -1448,7 +1448,7 @@ StoreCommon:
         return false;
     }
 
-    void ByteCodeWriter::Property(OpCode op, RegSlot value, RegSlot instance, PropertyIdIndexType propertyIdIndex)
+    void ByteCodeWriter::Property(OpCode op, RegSlot value, RegSlot instance, PropertyIdIndexType propertyIdIndex, bool forceStrictMode)
     {
         CheckOpen();
         CheckOp(op, OpLayoutType::ElementC);
@@ -1477,7 +1477,7 @@ StoreCommon:
         }
 #endif
 
-        if (this->m_functionWrite->GetIsStrictMode())
+        if (this->m_functionWrite->GetIsStrictMode() || forceStrictMode)
         {
             if (op == OpCode::DeleteFld)
             {

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -269,10 +269,10 @@ namespace Js
         void CallI(OpCode op, RegSlot returnValueRegister, RegSlot functionRegister, ArgSlot givenArgCount, ProfileId callSiteId, CallFlags callFlags = CallFlags_None);
         void CallIExtended(OpCode op, RegSlot returnValueRegister, RegSlot functionRegister, ArgSlot givenArgCount, CallIExtendedOptions options, const void *buffer, uint byteCount, ProfileId callSiteId, CallFlags callFlags = CallFlags_None);
         void RemoveEntryForRegSlotFromCacheIdMap(RegSlot functionRegister);
-        void Element(OpCode op, RegSlot value, RegSlot instance, RegSlot element, bool instanceAtReturnRegOK = false);
+        void Element(OpCode op, RegSlot value, RegSlot instance, RegSlot element, bool instanceAtReturnRegOK = false, bool forceStrictMode = false);
         void ElementUnsigned1(OpCode op, RegSlot value, RegSlot instance, uint32 element);
-        void Property(OpCode op, RegSlot Value, RegSlot Instance, PropertyIdIndexType propertyIdIndex);
-        void ScopedProperty(OpCode op, RegSlot Value, PropertyIdIndexType propertyIdIndex);
+        void Property(OpCode op, RegSlot Value, RegSlot Instance, PropertyIdIndexType propertyIdIndex, bool forceStrictMode = false);
+        void ScopedProperty(OpCode op, RegSlot Value, PropertyIdIndexType propertyIdIndex, bool forceStrictMode = false);
         void Slot(OpCode op, RegSlot value, RegSlot instance, uint32 slotId);
         void Slot(OpCode op, RegSlot value, RegSlot instance, uint32 slotId, ProfileId profileId);
         void SlotI1(OpCode op, RegSlot value, uint32 slotId1);

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -773,6 +773,7 @@ MACRO_BACKEND_ONLY(     CheckFixedFld,       Empty,          OpFastFldInstr|OpTe
 MACRO_BACKEND_ONLY(     CheckPropertyGuardAndLoadType,  Empty,          OpFastFldInstr|OpTempObjectSources|OpDoNotTransfer)
 MACRO_BACKEND_ONLY(     CheckObjType,        Empty,          OpFastFldInstr|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     AdjustObjType,       Empty,          OpSideEffect)
+MACRO_BACKEND_ONLY(     AdjustObjTypeReloadAuxSlotPtr,       Empty,          OpSideEffect)
 
                                                                                                             // Edge inline built-ins
 #ifdef ENABLE_DOM_FAST_PATH

--- a/lib/Runtime/Library/EngineInterfaceObject.cpp
+++ b/lib/Runtime/Library/EngineInterfaceObject.cpp
@@ -425,7 +425,7 @@ namespace Js
     {
         EngineInterfaceObject_CommonFunctionProlog(function, callInfo);
 
-        if (callInfo.Count < 3 || !JavascriptConversion::IsCallable(args.Values[1]) || !RecyclableObject::Is(args.Values[2]))
+        if (callInfo.Count < 3 || !JavascriptConversion::IsCallable(args.Values[1]))
         {
             return scriptContext->GetLibrary()->GetUndefined();
         }

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -194,7 +194,7 @@ BOOL JavascriptObject::ChangePrototype(RecyclableObject* object, RecyclableObjec
     //      ii. Let nextp be the result of calling the [[GetInheritance]] internal method of p with no arguments.
     //      iii.    ReturnIfAbrupt(nextp).
     //      iv. Let  p be nextp.
-        if (IsPrototypeOfStopAtProxy(object, newPrototype, scriptContext)) // Reject cycle
+    if (IsPrototypeOfStopAtProxy(object, newPrototype, scriptContext)) // Reject cycle
     {
         if (shouldThrow)
         {
@@ -228,6 +228,11 @@ BOOL JavascriptObject::ChangePrototype(RecyclableObject* object, RecyclableObjec
     if (isInvalidationOfInlineCacheNeeded)
     {
         bool allProtoCachesInvalidated = false;
+
+        JavascriptOperators::MapObjectAndPrototypes<true>(newPrototype, [&](RecyclableObject* obj)
+        {
+            obj->ClearProtoCachesWereInvalidated();
+        });
 
         // Notify old prototypes that they are being removed from a prototype chain. This triggers invalidating protocache, etc.
         JavascriptOperators::MapObjectAndPrototypesUntil<true>(object->GetPrototype(), [&](RecyclableObject* obj)->bool

--- a/test/InlineCaches/MissingProtoInval.js
+++ b/test/InlineCaches/MissingProtoInval.js
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function f1() {
+    var o1 = {},o2 = {};
+    var proto1 = {a:'a',b:'b'},proto2 = {a:'a'};
+    o1.__proto__ = proto1;
+    o2.__proto__ = proto2;
+
+    function a(o) { return o.a; }
+    function b(o) { return o.b; }
+
+    a(o1);
+    a(o2);
+    b(o1);
+    b(o2);
+    proto2.__proto__ = {b:'b'};
+    if (b(o2) !== 'b') {
+        WScript.Echo('fail');
+    }
+}
+
+f1()
+f1();
+
+function f2() {
+    var o1 = {b:'b'},o2 = {b:'b'};
+    var proto1 = {a:'a',b:'b'},proto2 = {a:'a'};
+    o1.__proto__ = proto1;
+    o2.__proto__ = proto2;
+
+    function a(o) { return o.a; }
+    function b(o) { return o.b; }
+
+    a(o1);
+    a(o2);
+
+    delete o1.b;
+    delete o2.b;
+
+    b(o1);
+    b(o2);
+    proto2.__proto__ = {b:'b'};
+    if (b(o2) !== 'b') {
+        WScript.Echo('fail');
+    }
+}
+
+f2();
+f2();
+
+WScript.Echo('pass');

--- a/test/InlineCaches/rlexe.xml
+++ b/test/InlineCaches/rlexe.xml
@@ -122,6 +122,11 @@
   </test>
   <test>
     <default>
+      <files>MissingProtoInval.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>instanceOfCacheCrossRegistration.js</files>
       <baseline>instanceOfCacheCrossRegistration.baseline</baseline>
     </default>

--- a/test/strict/classComputedPropertyName.js
+++ b/test/strict/classComputedPropertyName.js
@@ -1,0 +1,245 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Assigning an undeclared variable in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    class C {
+                        [f = 5]() { }
+                    }                
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+            assert.throws(
+                function () {
+                    class C {
+                        static [f = 5]() { }
+                    }
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+            assert.throws(
+                function () {
+                    "use strict";
+                    class C {
+                        [f = 5]() { }
+                    }
+                },
+                ReferenceError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus a variable assignment to an undeclared variable should throw a ReferenceError in strict mode",
+                "Variable undefined in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a non writable object property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, 'b', { value: 5, writable: false });
+                    class C {
+                        [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a non writable property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, 'b', { value: 5, writable: false });
+                    class C {
+                        static [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a non writable property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a getter-only object property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = { get b() { return 5; } };
+                    class C {
+                        [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a getter-only property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = { get b() { return 5; } };
+                    class C {
+                        static [a.b = 6]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a getter-only property should throw a TypeError in strict mode",
+                "Assignment to read-only properties is not allowed in strict mode"
+            );
+        }
+    },
+    {
+        name: "Writing to a property of a non-extensible object in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        [a.b = 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a property of a non-extensible object should throw a TypeError in strict mode",
+                "Cannot create property for a non-extensible object"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        static [a.b = 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus assigning a value to a property of a non-extensible object should throw a TypeError in strict mode",
+                "Cannot create property for a non-extensible object"
+            );
+        }
+    },
+    {
+        name: "Calling delete on an undeletable property in a class' computed property name",
+        body: function () {
+            assert.throws(
+                function () {
+                    class C {
+                        [delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    class C {
+                        static [delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode,\
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = 5;
+                    class C {
+                        [a < 6 ? delete Object.prototype : 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = 5;
+                    class C {
+                        static [a < 6 ? delete Object.prototype : 5]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        [a && delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.preventExtensions(a);
+                    class C {
+                        static [a && delete Object.prototype]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'prototype' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, "x", { value: 5, configurable: false });
+                    class C {
+                        [delete a["x"]]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'x' is not allowed in strict mode"
+            );
+            assert.throws(
+                function () {
+                    var a = {};
+                    Object.defineProperty(a, "x", { value: 5, configurable: false });
+                    class C {
+                        static [delete a["x"]]() { }
+                    }
+                },
+                TypeError,
+                "Computed property names inside classes are specified to execute in strict mode, \
+thus calling delete on an undeletable property of object should throw a TypeError in strict mode",
+                "Calling delete on 'x' is not allowed in strict mode"
+            );
+        }
+    },
+
+]
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/strict/rlexe.xml
+++ b/test/strict/rlexe.xml
@@ -716,4 +716,10 @@
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>classComputedPropertyName.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Clear the flag on objects in the new prototype chain on entry to the ChangePrototype method so that invalidation happens based on the current state of those objects.