### PR TITLE
fix CallInstanceFunction with non-RecycableObject thisArgs

### DIFF
--- a/lib/Runtime/Library/EngineInterfaceObject.cpp
+++ b/lib/Runtime/Library/EngineInterfaceObject.cpp
@@ -425,7 +425,7 @@ namespace Js
     {
         EngineInterfaceObject_CommonFunctionProlog(function, callInfo);
 
-        if (callInfo.Count < 3 || !JavascriptConversion::IsCallable(args.Values[1]) || !RecyclableObject::Is(args.Values[2]))
+        if (callInfo.Count < 3 || !JavascriptConversion::IsCallable(args.Values[1]))
         {
             return scriptContext->GetLibrary()->GetUndefined();
         }


### PR DESCRIPTION
The conditions checked in the beginning of this function were originally setup for more limited use cases. Since it is now used to call user callbacks with a user-provided thisArg, we need to allow any arguments to be passed as thisArg.
