### PR TITLE
Do not skip FromPropertyDescriptor in Proxy DefineOwnProperty

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8643,7 +8643,10 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
             {
                 JavascriptOperators::InitProperty(object, PropertyIds::value, descriptor.GetValue());
             }
-            JavascriptOperators::InitProperty(object, PropertyIds::writable, JavascriptBoolean::ToVar(descriptor.IsWritable(),scriptContext));
+            if (descriptor.WritableSpecified())
+            {
+                JavascriptOperators::InitProperty(object, PropertyIds::writable, JavascriptBoolean::ToVar(descriptor.IsWritable(), scriptContext));
+            }
         }
         else if (descriptor.IsAccessorDescriptor())
         {

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -495,6 +495,21 @@ var tests = [
             });
             assert.throws(()=> { Object.keys(proxy);}, TypeError, "proxy's ownKeys is returning duplicate keys", "Proxy's ownKeys trap returned duplicate keys");
         }
+    },
+    {
+        name : "Proxy with DefineOwnProperty trap should not get descriptor properties twice",
+        body() {
+            const desc = { };
+            let counter = 0;
+            let handler = {
+                defineProperty : function (oTarget, sKey, oDesc) { 
+                    return Reflect.defineProperty(oTarget, sKey, oDesc); 
+                }
+            };
+            Object.defineProperty(desc, "writable", { get: function () { ++counter; return true; }});
+            Object.defineProperty(new Proxy({}, handler), "test", desc);
+            assert.areEqual(1, counter, "Writable property on descriptor should only be checked once");
+        }
     }
 ];
 


### PR DESCRIPTION
Fix bug in JavascriptProxy::DefineOwnPropertyDescriptor
1. Previously the FromPropertyDescriptor call was skipped if the descriptor came from ToPropertyDescriptor BUT in the case of a descriptor object with a getter this could result in it being called twice

2. Update comments with spec text in this function as they were out of date

3. Add test case for point 1

Fixes: #5680