### PR TITLE
Update String.padStart/padEnd to fix #5617

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2090,11 +2090,6 @@ case_2:
             return mainString;
         }
 
-        if (maxLength > JavascriptString::MaxCharLength)
-        {
-            JavascriptError::ThrowRangeError(scriptContext, JSERR_OutOfBoundString);
-        }
-
         JavascriptString * fillerString = nullptr;
         if (args.Info.Count > 2 && !JavascriptOperators::IsUndefinedObject(args[2], scriptContext))
         {
@@ -2107,6 +2102,11 @@ case_2:
             {
                 return mainString;
             }
+        }
+
+        if (maxLength > JavascriptString::MaxCharLength)
+        {
+            JavascriptError::ThrowRangeError(scriptContext, JSERR_OutOfBoundString);
         }
 
         if (fillerString == nullptr)

--- a/test/es7/stringpad.js
+++ b/test/es7/stringpad.js
@@ -63,6 +63,11 @@ var tests = [
         name: "String.prototype.padStart out of bound scenario",
         body: function () {
             assert.throws(() => { 'foo'.padStart(2147483647);}, RangeError, "index is out of bound", "String length is out of bound");
+            assert.throws(() => { 'foo'.padEnd(2147483647);}, RangeError, "index is out of bound", "String length is out of bound");
+            assert.doesNotThrow(() => { 'foo'.padStart(2147483647, '');}, "Out of bounds pad length does not throw when padding with empty string");
+            assert.doesNotThrow(() => { 'foo'.padEnd(2147483647, '');}, "Out of bounds pad length does not throw when padding with empty string");
+            assert.areEqual('foo'.padStart(2147483647, ''), 'foo', "String padded with empty string is returned even if length of padding > max string length");
+            assert.areEqual('foo'.padEnd(2147483647, ''), 'foo', "String padded with empty string is returned even if length of padding > max string length");   
         }
     }
 ];


### PR DESCRIPTION
Early return for empty fillString even if padLength > max string length.

Fixes #5617