### PR TITLE
OSG#19011798: GlobOpt::UpdateObjPtrValueType can't distinguish typed array from virtual typed array

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1967,6 +1967,12 @@ GlobOpt::UpdateObjPtrValueType(IR::Opnd * opnd, IR::Instr * instr)
     AnalysisAssert(type != nullptr);
     Js::TypeId typeId = type->GetTypeId();
 
+    if (Js::TypedArrayBase::Is(typeId))
+    {
+        // Type ID does not allow us to distinguish between virtual and non-virtual typed array.
+        return;
+    }
+
     // Passing false for useVirtual as we would never have a virtual typed array hitting this code path
     ValueType newValueType = ValueType::FromTypeId(typeId, false);
 

--- a/test/typedarray/definitetypedarray.js
+++ b/test/typedarray/definitetypedarray.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let xxx = new Uint32Array(0x10000);
+
+xxx.slice = Array.prototype.slice;
+
+function jit(arr, index){
+	let ut = arr.slice(0,0);   //become definite Uint32Array but |arr| is a VirtualUint32Array
+	for(let i = 0; i < 0x30; i++){
+		arr[i] = 0;   //will be crash at |Op_memset|
+	}
+}
+
+for(let i = 0;i < 0x10000; i++){
+	jit(xxx, 2);
+}
+
+if (xxx[0] === 0)
+{
+    WScript.Echo('pass');
+}
+

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -423,4 +423,9 @@ Below test fails with difference in space. Investigate the cause and re-enable t
       <files>bug18321215.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>definitetypedarray.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Do not attempt to optimize the ValueType in case of typed array.