### PR TITLE
Word-choice context update of THIRD-PARTY-NOTICES.txt

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1591,7 +1591,7 @@ for the Source Code where You describe recipients' rights or ownership rights
 relating to Covered Code. You may choose to offer, and to charge a fee for, warranty,
 support, indemnity or liability obligations to one or more recipients of Covered Code.
 However, You may do so only on Your own behalf, and not on behalf of the Initial
-Developer or any Contributor. You must make it absolutely clear than any such warranty,
+Developer or any Contributor. You must make it absolutely clear that any such warranty,
 support, indemnity or liability obligation is offered by You alone, and You hereby
 agree to indemnify the Initial Developer and every Contributor for any liability
 incurred by the Initial Developer or such Contributor as a result of warranty,


### PR DESCRIPTION
Changed "than" to "that" in the sentence, "Developer or any Contributor. You must make it absolutely clear than any such warranty, support, indemnity or liability obligation is offered by You alone, and You hereby..." Under section 3.5. of this agreement.