### PR TITLE
removed last param `&NvContext` from RtlVirtualUnwind function call

### DIFF
--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -150,7 +150,7 @@ namespace Js
             else
             {
                 RtlVirtualUnwind(UNW_FLAG_NHANDLER, ImageBase, Context.Rip, RuntimeFunction,
-                    &Context, &HandlerData, &EstablisherFrame, &NvContext);
+                    &Context, &HandlerData, &EstablisherFrame);
             }
 
             if (!Context.Rip)


### PR DESCRIPTION
resolving issue #5314 
