### PR TITLE
Implement export * as ns from module syntax

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -673,6 +673,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES7ValuesEntries        (true)
 #define DEFAULT_CONFIG_ESObjectGetOwnPropertyDescriptors (true)
 #define DEFAULT_CONFIG_ESDynamicImport         (false)
+#define DEFAULT_CONFIG_ESExportNsAs            (true)
 
 #define DEFAULT_CONFIG_ESSharedArrayBuffer     (false)
 
@@ -1149,6 +1150,7 @@ FLAGPR           (Boolean, ES6, ES6UnicodeVerbose      , "Enable ES6 Unicode 6.0
 FLAGPR           (Boolean, ES6, ES6Unscopables         , "Enable ES6 With Statement Unscopables"                    , DEFAULT_CONFIG_ES6Unscopables)
 FLAGPR           (Boolean, ES6, ES6RegExSticky         , "Enable ES6 RegEx sticky flag"                             , DEFAULT_CONFIG_ES6RegExSticky)
 FLAGPR           (Boolean, ES6, ES2018RegExDotAll      , "Enable ES2018 RegEx dotAll flag"                          , DEFAULT_CONFIG_ES2018RegExDotAll)
+FLAGPR           (Boolean, ES6, ESExportNsAs           , "Enable ES experimental export * as name"                  , DEFAULT_CONFIG_ESExportNsAs)
 
 #ifndef COMPILE_DISABLE_ES6RegExPrototypeProperties
     #define COMPILE_DISABLE_ES6RegExPrototypeProperties 0

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -645,6 +645,7 @@ protected:
     ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, IdentPtr importName, IdentPtr localName, IdentPtr exportName, IdentPtr moduleRequest);
     ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, ModuleImportOrExportEntry* importOrExportEntry);
     void AddModuleLocalExportEntry(ParseNodePtr varDeclNode);
+    void CheckForDuplicateExportEntry(IdentPtr exportName);
     void CheckForDuplicateExportEntry(ModuleImportOrExportEntryList* exportEntryList, IdentPtr exportName);
 
     ParseNodeVar * CreateModuleImportDeclNode(IdentPtr localName);
@@ -1087,11 +1088,11 @@ private:
     void AddToNodeList(ParseNode ** ppnodeList, ParseNode *** pppnodeLast, ParseNode * pnodeAdd);
     void AddToNodeListEscapedUse(ParseNode ** ppnodeList, ParseNode *** pppnodeLast, ParseNode * pnodeAdd);
 
-    void ChkCurTokNoScan(int tk, int wErr)
+    void ChkCurTokNoScan(int tk, int wErr, LPCWSTR stringOne = _u(""), LPCWSTR stringTwo = _u(""))
     {
         if (m_token.tk != tk)
         {
-            Error(wErr);
+            Error(wErr, stringOne, stringTwo);
         }
     }
 

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -110,6 +110,7 @@ LSC_ERROR_MSG(1094, ERRLabelFollowedByEOF, "Unexpected end of script after a lab
 LSC_ERROR_MSG(1095, ERRFunctionAfterLabelInStrict, "Function declarations not allowed after a label in strict mode.")
 LSC_ERROR_MSG(1096, ERRAwaitAsLabelInAsync, "Use of 'await' as label in async function is not allowed.")
 LSC_ERROR_MSG(1097, ERRExperimental, "Use of disabled experimental feature")
+LSC_ERROR_MSG(1098, ERRDuplicateExport, "Duplicate export of name '%s'")
 //1098-1199 available for future use
 
 // Generic errors intended to be re-usable

--- a/lib/Runtime/Base/ThreadConfigFlagsList.h
+++ b/lib/Runtime/Base/ThreadConfigFlagsList.h
@@ -48,6 +48,7 @@ FLAG_RELEASE(IsESObjectGetOwnPropertyDescriptorsEnabled, ESObjectGetOwnPropertyD
 FLAG_RELEASE(IsESSharedArrayBufferEnabled, ESSharedArrayBuffer)
 FLAG_RELEASE(IsESDynamicImportEnabled, ESDynamicImport)
 FLAG_RELEASE(IsESBigIntEnabled, ESBigInt)
+FLAG_RELEASE(IsESExportNsAsEnabled, ESExportNsAs)
 #ifdef ENABLE_PROJECTION
 FLAG(AreWinRTDelegatesInterfaces, WinRTDelegateInterfaces)
 FLAG_RELEASE(IsWinRTAdaptiveAppsEnabled, WinRTAdaptiveApps)

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -272,6 +272,12 @@ namespace Js
             // TODO: maybe we can cache the slot address & offset, instead of looking up everytime? We do need to look up the reference everytime.
             if (unambiguousNonLocalExports->TryGetValue(propertyId, &moduleNameRecord))
             {
+                // special case for export * as ns
+                if (moduleNameRecord.bindingName == Js::PropertyIds::star_)
+                {
+                    *value = static_cast<Var>(moduleNameRecord.module->GetNamespace());
+                    return PropertyQueryFlags::Property_Found;
+                }
                 return JavascriptConversion::BooleanToPropertyQueryFlags(moduleNameRecord.module->GetNamespace()->GetProperty(originalInstance, moduleNameRecord.bindingName, value, info, requestContext));
             }
         }

--- a/test/es6module/bug_issue_5777.js
+++ b/test/es6module/bug_issue_5777.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Bug Issue 5777 https://github.com/Microsoft/ChakraCore/issues/5777
+// Duplicate export names should cause an early syntax error
+
+WScript.RegisterModuleSource("a.js",
+    `export const boo = 4;
+    export {bar as boo} from "b.js";
+    print ("Should not be printed")`);
+WScript.RegisterModuleSource("b.js","export const bar = 5;");
+
+import("a.js").then(()=>{
+    print("Failed - expected SyntaxError but no error thrown")
+}).catch ((e)=>{
+    if (e instanceof SyntaxError) {
+        print("pass");
+    } else {
+        print (`Failed - threw ${e.constructor.toString()} but should have thrown SyntaxError`);
+    }
+});

--- a/test/es6module/export_namespace_as.js
+++ b/test/es6module/export_namespace_as.js
@@ -1,0 +1,134 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+
+const tests = [
+    {
+        name: "Basic usage of export * as ns",
+        body() {
+            WScript.RegisterModuleSource("basicExport", 'export * as basic from "ModuleSimpleExport.js"');
+
+            testRunner.LoadModule(
+                `import {basic} from "basicExport";
+                assert.areEqual(basic.ModuleSimpleExport_foo(), 'ModuleSimpleExport');`);
+        }
+    },
+    {
+        name: "Various valid exports via export * as ns",
+        body() {
+            WScript.RegisterModuleSource("variousExports", `
+                export * as basic from "ModuleSimpleExport.js";
+                export * as valid from "ValidExportStatements.js";
+                export * as validReExports from "ValidReExportStatements.js";
+                export * as complexReExports from "ModuleComplexReexports.js";
+                `);
+            
+                testRunner.LoadModule(`
+                function verifyPropertyDesc(obj, prop, desc, propName) {
+                    var actualDesc = Object.getOwnPropertyDescriptor(obj, prop);
+                    if (typeof propName === "undefined") { propName = prop; }
+                    assert.areEqual(desc.configurable, actualDesc.configurable, propName+"'s attribute: configurable");
+                    assert.areEqual(desc.enumerable, actualDesc.enumerable, propName+"'s attribute: enumerable");
+                    assert.areEqual(desc.writable, actualDesc.writable, propName+"'s attribute: writable");
+                }
+
+                import {basic, valid as foo, validReExports as foo1} from "variousExports";
+
+                assert.areEqual(basic.ModuleSimpleExport_foo(), 'ModuleSimpleExport');
+
+                assert.areEqual("Module", foo[Symbol.toStringTag], "@@toStringTag is the String value'Module'");
+                verifyPropertyDesc(foo, Symbol.toStringTag, {configurable:false, enumerable: false, writable: false}, "Symbol.toStringTag");
+                verifyPropertyDesc(foo, "default", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var7", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var6", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var4", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var3", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "var1", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "foo4", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "bar2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "foobar", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "foo3", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "baz2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "foo2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "baz", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "bar", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "foo", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "const6", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "const5", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "const4", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "const3", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "const2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let7", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let6", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let5", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let4", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "let1", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "cl2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "cl1", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "gn2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "gn1", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "fn2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo, "fn1", {configurable:false, enumerable: true, writable: true});
+    
+                verifyPropertyDesc(foo1, "foo", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo1, "bar", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo1, "baz", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo1, "foo2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo1, "bar2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo1, "foo3", {configurable:false, enumerable: true, writable: true});
+    
+                import {complexReExports as foo2} from "variousExports";
+                verifyPropertyDesc(foo2, "ModuleComplexReexports_foo", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "bar2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "localfoo2", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "bar", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "localfoo", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "baz", {configurable:false, enumerable: true, writable: true});
+                verifyPropertyDesc(foo2, "foo", {configurable:false, enumerable: true, writable: true});
+            `);
+        }
+    },
+    {
+        name : "Re-exported namespace",
+        body() {
+            WScript.RegisterModuleSource("one",`
+                export function foo () { return "foo"; }
+                export function bar () { return "bar"; }
+                export const boo = 5;
+                `);
+            WScript.RegisterModuleSource("two", `
+                export const boo = 6;
+                export function foo() { return "far"; }
+                `);
+            WScript.RegisterModuleSource("three", `
+                export * as ns from "two";
+                export * as default from "one";
+                `);
+            WScript.RegisterModuleSource("four", `
+                export * from "three";
+            `);
+            testRunner.LoadModule(`
+                import main from "three";
+                import {ns} from "three";
+                import * as Boo from "four";
+
+                assert.areEqual(main.foo(), "foo");
+                assert.areEqual(main.bar(), "bar");
+                assert.areEqual(main.boo, 5);
+
+                assert.areEqual(ns.foo(), "far");
+                assert.areEqual(ns.boo, 6);
+                assert.areEqual(Boo.ns, ns);
+                assert.isUndefined(Boo.default);
+            `);
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -106,13 +106,6 @@
   </test>
   <test>
     <default>
-      <files>exportBindingLoader.js</files>
-      <compile-flags>-ES6Module -args summary -endargs</compile-flags>
-      <tags>exclude_dynapogo,exclude_sanitize_address</tags>
-    </default>
-  </test>
-  <test>
-    <default>
       <files>test_bug_2645.js</files>
       <compile-flags>-ES6Module</compile-flags>
       <tags>exclude_sanitize_address</tags>
@@ -144,6 +137,20 @@
       <files>bug_issue_3257.js</files>
       <compile-flags>-ESDynamicImport</compile-flags>
       <baseline>bug_issue_3257.baseline</baseline>
+      <tags>exclude_sanitize_address</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>bug_issue_5777.js</files>
+      <compile-flags>-ESDynamicImport -MuteHostErrorMsg</compile-flags>
+      <tags>exclude_sanitize_address</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>export_namespace_as.js</files>
+      <compile-flags>-ESExportNsAs -MuteHostErrorMsg -args summary -endargs</compile-flags>
       <tags>exclude_sanitize_address</tags>
     </default>
   </test>


### PR DESCRIPTION
This PR does the following:
1. implements support for `export * as ns from "module"` syntax a normative change PR to ecma262 which has tc39 consensus
See spec diff: https://spectranaut.github.io/proposal-export-ns-from/
See normative PR here: https://github.com/tc39/ecma262/pull/1174#issuecomment-425120082
This is placed behind a flag but set to default enabled
2. Adds some relevant tests
3. Fixes a bug where duplicate exports weren't always a syntax error (implementing this feature correctly without fixing this bug would have been awkward)
4. Some drive by syntax error message improvement for duplicate exports and alias'd exports
    - "Syntax error: Syntax error" -> "Syntax error: Duplicate export of name '%s'"
    - "Syntax error: Syntax error" -> "Syntax error: 'as' is only valid if followed by an identifier."

There are unfortunately some remaining related test262 failures due to #5778 and #5501

closes #5759 
fixes #5777 