### PR TITLE
Fix module-namespace indirect exports

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2908,8 +2908,7 @@ ParseNodePtr Parser::ParseDefaultExportClause()
     }
 
     IdentPtr exportName = wellKnownPropertyPids._default;
-    IdentPtr localName = wellKnownPropertyPids._starDefaultStar;
-    AddModuleImportOrExportEntry(EnsureModuleLocalExportEntryList(), nullptr, localName, exportName, nullptr);
+    AddModuleImportOrExportEntry(EnsureModuleLocalExportEntryList(), nullptr, exportName, exportName, nullptr);
 
     return pnode;
 }
@@ -11544,7 +11543,6 @@ void Parser::InitPids()
     wellKnownPropertyPids.as = this->GetHashTbl()->PidHashNameLen(_u("as"), sizeof("as") - 1);
     wellKnownPropertyPids.from = this->GetHashTbl()->PidHashNameLen(_u("from"), sizeof("from") - 1);
     wellKnownPropertyPids._default = this->GetHashTbl()->PidHashNameLen(_u("default"), sizeof("default") - 1);
-    wellKnownPropertyPids._starDefaultStar = this->GetHashTbl()->PidHashNameLen(_u("*default*"), sizeof("*default*") - 1);
     wellKnownPropertyPids._star = this->GetHashTbl()->PidHashNameLen(_u("*"), sizeof("*") - 1);
     wellKnownPropertyPids._this = this->GetHashTbl()->PidHashNameLen(_u("*this*"), sizeof("*this*") - 1);
     wellKnownPropertyPids._newTarget = this->GetHashTbl()->PidHashNameLen(_u("*new.target*"), sizeof("*new.target*") - 1);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -483,7 +483,6 @@ private:
         IdentPtr as;
         IdentPtr _default;
         IdentPtr _star; // Special '*' identifier for modules
-        IdentPtr _starDefaultStar; // Special '*default*' identifier for modules
         IdentPtr _this; // Special 'this' identifier
         IdentPtr _newTarget; // Special new.target identifier
         IdentPtr _super; // Special super identifier

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -109,12 +109,16 @@ namespace Js
                 if (moduleNameRecord->module == moduleRecord)
                 {
                     // skip local exports as they are covered in the localExportSlots.
+                    // have to check the property map to avoid filtering out aliased local re-exports
+                    // which are not covered in localExportSlots
+                    if (propertyMap->ContainsKey(scriptContext->GetThreadContext()->GetPropertyName(propertyId)))
+                    {
 #if DBG
-                    localExportCount++;
+                        localExportCount++;
 #endif
-                    return;
+                        return;
+                    }
                 }
-                Assert(moduleNameRecord->module != moduleRecord);
                 this->AddUnambiguousNonLocalExport(propertyId, moduleNameRecord);
             });
         }

--- a/test/es6module/module-bugfixes.js
+++ b/test/es6module/module-bugfixes.js
@@ -93,6 +93,33 @@ var tests = [
             const start = 'import "b.js"; import "a.js"; import "c.js";';
             testRunner.LoadModule(start);
         }
+    },
+    {
+        // https://github.com/Microsoft/ChakraCore/issues/5501
+        name : "Issue 5501: Indirect exports excluded from namespace object - POC 1",
+        body()
+        {
+            WScript.RegisterModuleSource("test5501Part1", `
+                export {bar as foo} from "test5501Part1";
+                export const bar = 5;
+                import * as stuff from "test5501Part1";
+                assert.areEqual(stuff.bar, stuff.foo);
+            `);
+            testRunner.LoadModule("import 'test5501Part1'");
+        }
+    },
+    {
+        name : "Issue 5501: Indirect exports excluded from namespace object - POC 2",
+        body()
+        {
+            WScript.RegisterModuleSource("test5501Part2a", "export default function () { return true; }");
+            WScript.RegisterModuleSource("test5501Part2b", "export {default as aliasName} from 'test5501Part2a'");
+
+            testRunner.LoadModule(`
+                import {aliasName} from 'test5501Part2b';
+                assert.isTrue(aliasName());
+            `);
+        }
     }
 ];
 


### PR DESCRIPTION
Saw the solution to this whilst working on #5779 

@digitalinfinity conscious the issue for this (5501) was assigned to you, was intending to leave but saw the fix whilst looking at the code for something else. Let me know if this PR is unwanted and I will close it.

This fixes two cases where a module-namespace object could have undefined indirect exports:
1. `export {a as b} from "thisModule";` - due to it not being in the localExports list but then being marked as a local export when processing the indirectExports
2. `export {default as otherName} from "anyModule";` - due to seemingly unnecessary special handling of `default`

Test262 note, this fix introduces passes for 6 es6 module tests, it is also necessary for several Dynamic Import tests to pass - and for some `export * as ns` tests. The 6 es6 tests that this fixes are:
test/language/module-code/namespace/internals/get-own-property-str-found-init.js
test/language/module-code/namespace/internals/get-str-initialize.js
test/language/module-code/namespace/internals/get-str-found-init.js
test/language/module-code/namespace/internals/get-str-update.js
test/language/module-code/namespace/internals/has-property-str-found-uninit.js
test/language/module-code/namespace/internals/has-property-str-found-init.js

fix #5501 