### PR TITLE
Change `usedCapturedValues` in `BailOutInfo` to a pointer for consistency

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -1763,19 +1763,19 @@ BackwardPass::ProcessBailOutArgObj(BailOutInfo * bailOutInfo, BVSparse<JitArenaA
         {
             if (byteCodeUpwardExposedUsed->TestAndClear(symId))
             {
-                if (bailOutInfo->usedCapturedValues.argObjSyms == nullptr)
+                if (bailOutInfo->usedCapturedValues->argObjSyms == nullptr)
                 {
-                    bailOutInfo->usedCapturedValues.argObjSyms = JitAnew(this->func->m_alloc,
+                    bailOutInfo->usedCapturedValues->argObjSyms = JitAnew(this->func->m_alloc,
                         BVSparse<JitArenaAllocator>, this->func->m_alloc);
                 }
-                bailOutInfo->usedCapturedValues.argObjSyms->Set(symId);
+                bailOutInfo->usedCapturedValues->argObjSyms->Set(symId);
             }
         }
         NEXT_BITSET_IN_SPARSEBV;
     }
-    if (bailOutInfo->usedCapturedValues.argObjSyms)
+    if (bailOutInfo->usedCapturedValues->argObjSyms)
     {
-        byteCodeUpwardExposedUsed->Minus(bailOutInfo->usedCapturedValues.argObjSyms);
+        byteCodeUpwardExposedUsed->Minus(bailOutInfo->usedCapturedValues->argObjSyms);
     }
 }
 
@@ -1785,7 +1785,7 @@ BackwardPass::ProcessBailOutConstants(BailOutInfo * bailOutInfo, BVSparse<JitAre
     Assert(this->tag != Js::BackwardPhase);
 
     // Remove constants that we are already going to restore
-    SListBase<ConstantStackSymValue> * usedConstantValues = &bailOutInfo->usedCapturedValues.constantValues;
+    SListBase<ConstantStackSymValue> * usedConstantValues = &bailOutInfo->usedCapturedValues->constantValues;
     FOREACH_SLISTBASE_ENTRY(ConstantStackSymValue, value, usedConstantValues)
     {
         byteCodeUpwardExposedUsed->Clear(value.Key()->m_id);
@@ -1817,7 +1817,7 @@ BackwardPass::ProcessBailOutCopyProps(BailOutInfo * bailOutInfo, BVSparse<JitAre
     Assert(!this->func->GetJITFunctionBody()->IsAsmJsMode());
 
     // Remove copy prop that we were already going to restore
-    SListBase<CopyPropSyms> * usedCopyPropSyms = &bailOutInfo->usedCapturedValues.copyPropSyms;
+    SListBase<CopyPropSyms> * usedCopyPropSyms = &bailOutInfo->usedCapturedValues->copyPropSyms;
     FOREACH_SLISTBASE_ENTRY(CopyPropSyms, copyPropSyms, usedCopyPropSyms)
     {
         byteCodeUpwardExposedUsed->Clear(copyPropSyms.Key()->m_id);
@@ -2596,7 +2596,7 @@ BackwardPass::ProcessBailOutInfo(IR::Instr * instr, BailOutInfo * bailOutInfo)
             tempBv->And(this->func->m_nonTempLocalVars, bailOutInfo->liveVarSyms);
 
             // Remove syms that are restored in other ways than byteCodeUpwardExposedUsed.
-            FOREACH_SLIST_ENTRY(ConstantStackSymValue, value, &bailOutInfo->usedCapturedValues.constantValues)
+            FOREACH_SLIST_ENTRY(ConstantStackSymValue, value, &bailOutInfo->usedCapturedValues->constantValues)
             {
                 Assert(value.Key()->HasByteCodeRegSlot() || value.Key()->GetInstrDef()->m_opcode == Js::OpCode::BytecodeArgOutCapture);
                 if (value.Key()->HasByteCodeRegSlot())
@@ -2605,7 +2605,7 @@ BackwardPass::ProcessBailOutInfo(IR::Instr * instr, BailOutInfo * bailOutInfo)
                 }
             }
             NEXT_SLIST_ENTRY;
-            FOREACH_SLIST_ENTRY(CopyPropSyms, value, &bailOutInfo->usedCapturedValues.copyPropSyms)
+            FOREACH_SLIST_ENTRY(CopyPropSyms, value, &bailOutInfo->usedCapturedValues->copyPropSyms)
             {
                 Assert(value.Key()->HasByteCodeRegSlot() || value.Key()->GetInstrDef()->m_opcode == Js::OpCode::BytecodeArgOutCapture);
                 if (value.Key()->HasByteCodeRegSlot())
@@ -2614,9 +2614,9 @@ BackwardPass::ProcessBailOutInfo(IR::Instr * instr, BailOutInfo * bailOutInfo)
                 }
             }
             NEXT_SLIST_ENTRY;
-            if (bailOutInfo->usedCapturedValues.argObjSyms)
+            if (bailOutInfo->usedCapturedValues->argObjSyms)
             {
-                tempBv->Minus(bailOutInfo->usedCapturedValues.argObjSyms);
+                tempBv->Minus(bailOutInfo->usedCapturedValues->argObjSyms);
             }
 
             byteCodeUpwardExposedUsed->Or(tempBv);
@@ -8226,7 +8226,7 @@ BackwardPass::ReverseCopyProp(IR::Instr *instr)
             FOREACH_SLISTBASE_ENTRY(
                 CopyPropSyms,
                 usedCopyPropSym,
-                &instrPrev->GetBailOutInfo()->usedCapturedValues.copyPropSyms)
+                &instrPrev->GetBailOutInfo()->usedCapturedValues->copyPropSyms)
             {
                 if(dstSym == usedCopyPropSym.Value())
                 {

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -24,8 +24,21 @@ BailOutInfo::Clear(JitArenaAllocator * allocator)
         this->capturedValues->copyPropSyms.Clear(allocator);
         JitAdelete(allocator, this->capturedValues);
     }
-    this->usedCapturedValues.constantValues.Clear(allocator);
-    this->usedCapturedValues.copyPropSyms.Clear(allocator);
+
+    if (this->usedCapturedValues)
+    {
+        Assert(this->usedCapturedValues->refCount == 0);
+        this->usedCapturedValues->constantValues.Clear(allocator);
+        this->usedCapturedValues->copyPropSyms.Clear(allocator);
+
+        if (this->usedCapturedValues->argObjSyms)
+        {
+            JitAdelete(allocator, this->usedCapturedValues->argObjSyms);
+        }
+
+        JitAdelete(allocator, this->usedCapturedValues);
+    }
+
     if (byteCodeUpwardExposedUsed)
     {
         JitAdelete(allocator, byteCodeUpwardExposedUsed);

--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -41,7 +41,9 @@ public:
 #endif
         this->capturedValues = JitAnew(bailOutFunc->m_alloc, CapturedValues);
         this->capturedValues->refCount = 1;
-        this->usedCapturedValues.argObjSyms = nullptr;
+
+        this->usedCapturedValues = JitAnew(bailOutFunc->m_alloc, CapturedValues);
+        this->usedCapturedValues->argObjSyms = nullptr;
     }
     void Clear(JitArenaAllocator * allocator);
 
@@ -77,9 +79,9 @@ public:
 #endif
     uint32 bailOutOffset;
     BailOutRecord * bailOutRecord;
-    CapturedValues* capturedValues;                                      // Values we know about after forward pass
-    CapturedValues usedCapturedValues;                                  // Values that need to be restored in the bail out
-    BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed;            // Non-constant stack syms that needs to be restored in the bail out
+    CapturedValues * capturedValues;                                      // Values we know about after forward pass
+    CapturedValues * usedCapturedValues;                                  // Values that need to be restored in the bail out
+    BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed;              // Non-constant stack syms that needs to be restored in the bail out
     uint polymorphicCacheIndex;
     uint startCallCount;
     uint totalOutParamCount;

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -1417,7 +1417,7 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
     memset(state.registerSaveSyms, 0, sizeof(state.registerSaveSyms));
 
     // Fill in the constants
-    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, value, &bailOutInfo->usedCapturedValues.constantValues, constantValuesIterator)
+    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, value, &bailOutInfo->usedCapturedValues->constantValues, constantValuesIterator)
     {
         AssertMsg(bailOutInfo->bailOutRecord->bailOutKind != IR::BailOutForGeneratorYield, "constant prop syms unexpected for bail-in for generator yield");
         StackSym * stackSym = value.Key();
@@ -1460,7 +1460,7 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
     NEXT_SLISTBASE_ENTRY_EDITING;
 
     // Fill in the copy prop syms
-    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSyms, &bailOutInfo->usedCapturedValues.copyPropSyms, copyPropSymsIter)
+    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSyms, &bailOutInfo->usedCapturedValues->copyPropSyms, copyPropSymsIter)
     {
         AssertMsg(bailOutInfo->bailOutRecord->bailOutKind != IR::BailOutForGeneratorYield, "copy prop syms unexpected for bail-in for generator yield");
         StackSym * stackSym = copyPropSyms.Key();
@@ -1513,9 +1513,9 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
     }
     NEXT_BITSET_IN_SPARSEBV;
 
-    if (bailOutInfo->usedCapturedValues.argObjSyms)
+    if (bailOutInfo->usedCapturedValues->argObjSyms)
     {
-        FOREACH_BITSET_IN_SPARSEBV(id, bailOutInfo->usedCapturedValues.argObjSyms)
+        FOREACH_BITSET_IN_SPARSEBV(id, bailOutInfo->usedCapturedValues->argObjSyms)
         {
             StackSym * stackSym = this->func->m_symTable->FindStackSym(id);
             Assert(stackSym != nullptr);
@@ -1705,7 +1705,7 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
                 uint outParamOffsetIndex = outParamStart + argSlot;
                 if (!sym->m_isBailOutReferenced && !sym->IsArgSlotSym())
                 {
-                    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, constantValue, &bailOutInfo->usedCapturedValues.constantValues, iterator)
+                    FOREACH_SLISTBASE_ENTRY_EDITING(ConstantStackSymValue, constantValue, &bailOutInfo->usedCapturedValues->constantValues, iterator)
                     {
                         if (constantValue.Key()->m_id == sym->m_id)
                         {
@@ -1731,13 +1731,13 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
                         continue;
                     }
 
-                    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSym, &bailOutInfo->usedCapturedValues.copyPropSyms, iter)
+                    FOREACH_SLISTBASE_ENTRY_EDITING(CopyPropSyms, copyPropSym, &bailOutInfo->usedCapturedValues->copyPropSyms, iter)
                     {
                         if (copyPropSym.Key()->m_id == sym->m_id)
                         {
                             StackSym * copyStackSym = copyPropSym.Value();
 
-                            BVSparse<JitArenaAllocator>* argObjSyms = bailOutInfo->usedCapturedValues.argObjSyms;
+                            BVSparse<JitArenaAllocator>* argObjSyms = bailOutInfo->usedCapturedValues->argObjSyms;
                             if (argObjSyms && argObjSyms->Test(copyStackSym->m_id))
                             {
                                 outParamOffsets[outParamOffsetIndex] = BailOutRecord::GetArgumentsObjectOffset();
@@ -1845,7 +1845,7 @@ LinearScan::FillBailOutRecord(IR::Instr * instr)
                                     Assert(LowererMD::IsAssign(instrDef));
                                 }
 
-                                if (bailOutInfo->usedCapturedValues.argObjSyms && bailOutInfo->usedCapturedValues.argObjSyms->Test(sym->m_id))
+                                if (bailOutInfo->usedCapturedValues->argObjSyms && bailOutInfo->usedCapturedValues->argObjSyms->Test(sym->m_id))
                                 {
                                     //foo.apply(this,arguments) case and we bailout when the apply is overridden. We need to restore the arguments object.
                                     outParamOffsets[outParamOffsetIndex] = BailOutRecord::GetArgumentsObjectOffset();

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -463,7 +463,7 @@ SCCLiveness::ProcessBailOutUses(IR::Instr * instr)
     }
     NEXT_BITSET_IN_SPARSEBV;
 
-    FOREACH_SLISTBASE_ENTRY(CopyPropSyms, copyPropSyms, &bailOutInfo->usedCapturedValues.copyPropSyms)
+    FOREACH_SLISTBASE_ENTRY(CopyPropSyms, copyPropSyms, &bailOutInfo->usedCapturedValues->copyPropSyms)
     {
         ProcessStackSymUse(copyPropSyms.Value(), instr);
     }


### PR DESCRIPTION
As part of `LazyBailOut`, we want to perform a *shallow* copy of a `BailOutInfo` which includes sharing all field pointers. However, `usedCapturedValues` is the only field in `BailOutInfo` that is not a pointer and is initialized together with `CapturedValues`, which makes it more complicated to do so as we have to perform manual copy of each field inside `CapturedValues`. With this change, we are more consistent with what we already have and also make it easier for future `LazyBailOut` work.
