### PR TITLE
BigInt: reallocate space, digit_t, increment, decrement

### DIFF
--- a/bin/ChakraCore/TestHooks.cpp
+++ b/bin/ChakraCore/TestHooks.cpp
@@ -19,6 +19,13 @@ int LogicalStringCompareImpl(const char16* p1, int p1size, const char16* p2, int
 }
 }
 
+namespace Js
+{
+    static digit_t AddDigit(digit_t a, digit_t b, digit_t * carry);
+    static digit_t SubtractDigit(digit_t a, digit_t b, digit_t * borrow);
+    static digit_t MulDigit(digit_t a, digit_t b, digit_t * high);
+}
+
 #ifdef ENABLE_TEST_HOOKS
 
 HRESULT __stdcall SetConfigFlags(__in int argc, __in_ecount(argc) LPWSTR argv[], ICustomConfigFlags* customConfigFlags)
@@ -167,6 +174,11 @@ HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
         SetAssertToConsoleFlag,
         SetEnableCheckMemoryLeakOutput,
         PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl,
+
+        //BigInt hooks
+        Js::JavascriptBigInt::AddDigit,
+        Js::JavascriptBigInt::SubDigit,
+        Js::JavascriptBigInt::MulDigit,
 
 #define FLAG(type, name, description, defaultValue, ...) FLAG_##type##(name)
 #define FLAGINCLUDE(name) \

--- a/bin/ChakraCore/TestHooks.h
+++ b/bin/ChakraCore/TestHooks.h
@@ -31,6 +31,14 @@ struct TestHooks
     SetEnableCheckMemoryLeakOutputPtr pfSetEnableCheckMemoryLeakOutput;
     LogicalStringCompareImpl pfLogicalCompareStringImpl;
 
+    // Javasscript Bigint hooks
+    typedef digit_t(TESTHOOK_CALL *AddDigit)(digit_t a, digit_t b, digit_t* carry);
+    typedef digit_t(TESTHOOK_CALL *SubDigit)(digit_t a, digit_t b, digit_t* borrow);
+    typedef digit_t(TESTHOOK_CALL *MulDigit)(digit_t a, digit_t b, digit_t* high);
+    AddDigit pfAddDigit;
+    SubDigit pfSubDigit;
+    MulDigit pfMulDigit;
+
 #define FLAG(type, name, description, defaultValue, ...) FLAG_##type##(name)
 #define FLAG_String(name) \
     bool (TESTHOOK_CALL *pfIsEnabled##name##Flag)(); \

--- a/bin/NativeTests/JavascriptBigIntTests.cpp
+++ b/bin/NativeTests/JavascriptBigIntTests.cpp
@@ -1,0 +1,84 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "stdafx.h"
+#pragma warning(disable:26434) // Function definition hides non-virtual function in base class
+#pragma warning(disable:26439) // Implicit noexcept
+#pragma warning(disable:26451) // Arithmetic overflow
+#pragma warning(disable:26495) // Uninitialized member variable
+#include "catch.hpp"
+
+#pragma warning(disable:4100) // unreferenced formal parameter
+#pragma warning(disable:6387) // suppressing preFAST which raises warning for passing null to the JsRT APIs
+#pragma warning(disable:6262) // CATCH is using stack variables to report errors, suppressing the preFAST warning.
+
+namespace JavascriptBigIntTests
+{
+    void Test_AddDigit(digit_t digit1, digit_t digit2, digit_t * carry, digit_t expectedResult, digit_t expectedCarry)
+    {
+        REQUIRE(g_testHooksLoaded);
+
+        digit_t res = g_testHooks.pfAddDigit(digit1, digit2, carry);
+
+        //test to check that the result from call to AddDigit is the expected value
+        REQUIRE(res == expectedResult);
+        REQUIRE(expectedCarry == *carry);
+    }
+
+    void Test_SubDigit(digit_t digit1, digit_t digit2, digit_t * borrow, digit_t expectedResult, digit_t expectedBorrow)
+    {
+        REQUIRE(g_testHooksLoaded);
+
+        digit_t res = g_testHooks.pfSubDigit(digit1, digit2, borrow);
+
+        //test to check that the result from call to SubtractDigit is the expected value
+        REQUIRE(res == expectedResult);
+        REQUIRE(*borrow == expectedBorrow);
+    }
+
+    void Test_MulDigit(digit_t digit1, digit_t digit2, digit_t * high, digit_t expectedResult, digit_t expectedHigh)
+    {
+        REQUIRE(g_testHooksLoaded);
+
+        digit_t res = g_testHooks.pfMulDigit(digit1, digit2, high);
+
+        //test to check that the result from call to SubtractDigit is the expected value
+        REQUIRE(res == expectedResult);
+        REQUIRE(*high == expectedHigh);
+    }
+
+    TEST_CASE("AddDigit", "[JavascriptBigIntTests]")
+    {
+        digit_t carry = 0;
+        Test_AddDigit(1, 2, &carry, 3, 0);
+
+        digit_t d1 = UINTPTR_MAX;
+        digit_t d2 = UINTPTR_MAX;
+        carry = 0;
+        Test_AddDigit(d1, d2, &carry, UINTPTR_MAX-1, 1);
+    }
+
+    TEST_CASE("SubDigit", "[JavascriptBigIntTests]")
+    {
+        digit_t borrow = 0;
+        Test_SubDigit(3, 2, &borrow, 1, 0);
+
+        digit_t d1 = 0;
+        digit_t d2 = 1;
+        borrow = 0;
+        Test_SubDigit(d1, d2, &borrow, UINTPTR_MAX, 1);
+    }
+
+    TEST_CASE("MulDigit", "[JavascriptBigIntTests]")
+    {
+        digit_t high = 0;
+        Test_MulDigit(3, 2, &high, 6, 0);
+
+        digit_t d1 = UINTPTR_MAX;
+        digit_t d2 = 2;
+        high = 0;
+        Test_MulDigit(d1, d2, &high, UINTPTR_MAX-1, 1);
+    }
+}

--- a/bin/NativeTests/NativeTests.vcxproj
+++ b/bin/NativeTests/NativeTests.vcxproj
@@ -48,6 +48,7 @@
     <ClInclude Include="stdafx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="JavascriptBigIntTests.cpp" />
     <ClCompile Include="BigUIntTest.cpp" />
     <ClCompile Include="CodexAssert.cpp" />
     <ClCompile Include="CodexTests.cpp" />

--- a/lib/Common/Core/CommonTypedefs.h
+++ b/lib/Common/Core/CommonTypedefs.h
@@ -61,3 +61,6 @@ namespace Js
 {
     typedef uint32 LocalFunctionId;
 };
+
+// digit_t represents a digit in bigint underline
+typedef uintptr_t digit_t;

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -62,6 +62,10 @@ using namespace Js;
             {
                 return TaggedInt::Increment(aRight, scriptContext);
             }
+            if (VarIs<JavascriptBigInt>(aRight))
+            {
+                return JavascriptBigInt::Increment(aRight);
+            }
 
             double inc = Increment_Helper(aRight, scriptContext);
             return JavascriptNumber::InPlaceNew(inc, scriptContext, result);
@@ -74,6 +78,10 @@ using namespace Js;
             if (TaggedInt::Is(aRight))
             {
                 return TaggedInt::Increment(aRight, scriptContext);
+            }
+            if (VarIs<JavascriptBigInt>(aRight))
+            {
+                return JavascriptBigInt::Increment(aRight);
             }
 
             double inc = Increment_Helper(aRight, scriptContext);
@@ -89,6 +97,10 @@ using namespace Js;
             {
                 return TaggedInt::Decrement(aRight, scriptContext);
             }
+            if (VarIs<JavascriptBigInt>(aRight))
+            {
+                return JavascriptBigInt::Decrement(aRight);
+            }
 
             double dec = Decrement_Helper(aRight,scriptContext);
             return JavascriptNumber::InPlaceNew(dec, scriptContext, result);
@@ -101,6 +113,10 @@ using namespace Js;
             if (TaggedInt::Is(aRight))
             {
                 return TaggedInt::Decrement(aRight, scriptContext);
+            }
+            if (VarIs<JavascriptBigInt>(aRight))
+            {
+                return JavascriptBigInt::Decrement(aRight);
             }
 
             double dec = Decrement_Helper(aRight,scriptContext);

--- a/test/BigInt/assign_by_value.js
+++ b/test/BigInt/assign_by_value.js
@@ -1,0 +1,46 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "Assign BigInt literal",
+        body: function () {
+            var x = 123n;
+            var y = x;
+            assert.isTrue(x == 123n);
+            assert.isTrue(y == 123n);
+            x++;
+            assert.isTrue(x == 124n);
+            assert.isTrue(y == 123n);
+            y = x;
+            ++x;
+            assert.isTrue(x == 125n);
+            assert.isTrue(y == 124n);
+        }
+    },
+    {
+        name: "Assign BigInt object",
+        body: function () {
+            var x = BigInt(123n);
+            var y = x;
+            assert.isTrue(x == 123n);
+            assert.isTrue(y == 123n);
+            x++;
+            assert.isTrue(x == 124n);
+            assert.isTrue(y == 123n);
+            y = x;
+            ++x;
+            assert.isTrue(x == 125n);
+            assert.isTrue(y == 124n);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/BigInt/comparison.js
+++ b/test/BigInt/comparison.js
@@ -72,6 +72,32 @@ var tests = [
             assert.isFalse(x > y);
         }
     },
+    {
+        name: "Out of 64 bit range",
+        body: function () {
+            var x = 1234567890123456789012345678901234567890n;
+            var y = BigInt(1234567890123456789012345678901234567891n);
+            assert.isFalse(x == y);
+            assert.isTrue(x < y);
+            assert.isTrue(x <= y);
+            assert.isTrue(x == x);
+            assert.isFalse(x >= y);
+            assert.isFalse(x > y);
+        }
+    },
+    {
+        name: "Very big BigInt, test resize",
+        body: function () {
+            var x = eval('1234567890'.repeat(20) + 'n');
+            var y = eval('1234567891'.repeat(20) + 'n');
+            assert.isFalse(x == y);
+            assert.isTrue(x < y);
+            assert.isTrue(x <= y);
+            assert.isTrue(x == x);
+            assert.isFalse(x >= y);
+            assert.isFalse(x > y);
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/BigInt/decrement.js
+++ b/test/BigInt/decrement.js
@@ -1,0 +1,89 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "Decrement BigInt literal",
+        body: function () {
+            var x = 123n;
+            assert.isTrue(x == 123n);
+            x--;
+            assert.isTrue(x == 122n);
+            --x;
+            assert.isTrue(x == 121n);
+        }
+    },
+    {
+        name: "Decrement negative BigInt literal",
+        body: function () {
+            var x = -123n;
+            assert.isTrue(x == -123n);
+            x--;
+            assert.isTrue(x == -124n);
+            --x;
+            assert.isTrue(x == -125n);
+        }
+    },   
+    {
+        name: "Decrement 0n",
+        body: function () {
+            var x = 0n;
+            assert.isTrue(x == 0n);
+            x--;
+            assert.isTrue(x == -1n);
+            --x;
+            assert.isTrue(x == -2n);
+        }
+    },
+    {
+        name: "Decrement to change length",
+        body: function () {
+            var x = 4294967296n;
+            assert.isTrue(x == 4294967296n);
+            x--;
+            assert.isTrue(x == 4294967295n);
+            --x;
+            assert.isTrue(x == 4294967294n);
+            var y = -4294967295n;
+            assert.isTrue(y == -4294967295n);
+            y--;
+            assert.isTrue(y == -4294967296n);
+            --y;
+            assert.isTrue(y == -4294967297n);
+        }
+    },
+    {
+        name: "Decrement BigInt Object",
+        body: function () {
+            var x = BigInt(12345678901234567890n);
+            var y = BigInt(12345678901234567891n);
+            assert.isTrue(x < y);
+            --y;
+            assert.isTrue(x == y);
+            y--;
+            assert.isTrue(x >= y);
+        }
+    },
+    {
+        name: "Out of 64 bit range",
+        body: function () {
+            var x = 1234567890123456789012345678901234567890n;
+            var y = BigInt(1234567890123456789012345678901234567891n);
+            assert.isFalse(x == y);
+            x--;
+            --y;
+            assert.isTrue(x < y);
+            --y;
+            assert.isTrue(x == y);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/BigInt/increment.js
+++ b/test/BigInt/increment.js
@@ -1,0 +1,89 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+if (this.WScript && this.WScript.LoadScriptFile) { // Check for running in ch
+    this.WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+}
+
+var tests = [
+    {
+        name: "Increment BigInt literal",
+        body: function () {
+            var x = 123n;
+            assert.isTrue(x == 123n);
+            x++;
+            assert.isTrue(x == 124n);
+            ++x;
+            assert.isTrue(x == 125n);
+        }
+    },
+    {
+        name: "Increment negative BigInt literal",
+        body: function () {
+            var x = -123n;
+            assert.isTrue(x == -123n);
+            x++;
+            assert.isTrue(x == -122n);
+            ++x;
+            assert.isTrue(x == -121n);
+        }
+    },   
+    {
+        name: "Increment -1n",
+        body: function () {
+            var x = -1n;
+            assert.isTrue(x == -1n);
+            x++;
+            assert.isTrue(x == 0n);
+            ++x;
+            assert.isTrue(x == 1n);
+        }
+    },
+    {
+        name: "Increment to change length",
+        body: function () {
+            var x = 4294967295n;
+            assert.isTrue(x == 4294967295n);
+            x++;
+            assert.isTrue(x == 4294967296n);
+            ++x;
+            assert.isTrue(x == 4294967297n);
+            var y = -4294967297n;
+            assert.isTrue(y == -4294967297n);
+            y++;
+            assert.isTrue(y == -4294967296n);
+            ++y;
+            assert.isTrue(y == -4294967295n);
+        }
+    },
+    {
+        name: "Increment BigInt Object",
+        body: function () {
+            var x = BigInt(12345678901234567890n);
+            var y = BigInt(12345678901234567891n);
+            assert.isTrue(x < y);
+            ++x;
+            assert.isTrue(x == y);
+            x++;
+            assert.isTrue(x >= y);
+        }
+    },
+    {
+        name: "Out of 64 bit range",
+        body: function () {
+            var x = 1234567890123456789012345678901234567890n;
+            var y = BigInt(1234567890123456789012345678901234567891n);
+            assert.isFalse(x == y);
+            x++;
+            ++y;
+            assert.isTrue(x < y);
+            ++x;
+            assert.isTrue(x == y);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/BigInt/rlexe.xml
+++ b/test/BigInt/rlexe.xml
@@ -12,4 +12,22 @@
       <compile-flags>-args summary -endargs -ESBigInt</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>increment.js</files>
+      <compile-flags>-args summary -endargs -ESBigInt</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>decrement.js</files>
+      <compile-flags>-args summary -endargs -ESBigInt</compile-flags>
+    </default>
+  </test>
+    <test>
+    <default>
+      <files>assign_by_value.js</files>
+      <compile-flags>-args summary -endargs -ESBigInt</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In this PR, we implement
- reallocate space for BigInt if necessary -> make it arbitrarily-precision.
- make use of configuration with digit_t
- implement increment/decrement operators
- native tests for methods in Javascript BigInt class

I defer "assign along with inc/dec" `y=x++` and `y=++x` to a future PR