### PR TITLE
Change Date.parse() to require a time component when using a zone designator or offset.

### DIFF
--- a/lib/Runtime/Library/DateImplementation.cpp
+++ b/lib/Runtime/Library/DateImplementation.cpp
@@ -1118,19 +1118,13 @@ Error:
                     continue;
                 }
                 case '+':
-                {
-                    if (lwNil != lwTime)
-                    {
-                        ss = ssAddOffset;
-                    }
-                    continue;
-                }
                 case '-':
                 {
-                    if (lwNil != lwTime)
+                    if (lwNil == lwTime)
                     {
-                        ss = ssSubOffset;
+                        goto LError;
                     }
+                    ss = (ch == '+') ? ssAddOffset : ssSubOffset;
                     continue;
                 }
             }
@@ -1166,7 +1160,7 @@ Error:
                     // j isn't used
                     // a to m are 1 to 12
                     // n to y are -1 to -12
-                    if (lwNil != lwZone)
+                    if (lwNil != lwZone || lwNil == lwTime)
                     {
                         goto LError;
                     }
@@ -1300,7 +1294,7 @@ Error:
                 {
                     AssertMsg(isNextFieldDateNegativeVersion5 == false, "isNextFieldDateNegativeVersion5 == false");
 
-                    if (lwNil != lwOffset)
+                    if (lwNil != lwOffset || lwNil == lwTime)
                         goto LError;
                     // convert into minutes, e.g. 730 -> 7*60+30
                     lwOffset = lwT < 24 ? lwT * 60 :

--- a/test/Date/DateParse3.js
+++ b/test/Date/DateParse3.js
@@ -24,6 +24,9 @@ runTest("2011-11-08 19:48:43.100", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.1000", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.12345", "2011-11-08T19:48:43.123");
 
+runTest("2011-11-08Z", null); // zone designators (and offsets) must follow a time
+runTest("2011-11-08+01:00", null); // previously the '+' or '-' would be skipped and the offset interpreted as a time
+
 function runTest(dateToTest, isoDate)
 {
     if (isoDate === null) {


### PR DESCRIPTION
NaN is now returned when lacking a time component (and using a zone designator or offset).
Relevant Github issue: https://github.com/Microsoft/ChakraCore/issues/5789
Zone designators are 'Z' for UTC/GMT and the military time zones ('a' .. 'z').
Also fixed a bug where offsets (+12:34) would be parsed as the time component.

Previously the following invalid example inputs to `Date.parse()` would produce values other than NaN:
- `2018-08-21Z`
- `2018-08-21+10:00`