### PR TITLE
Force new type check when object ptr copy prop creates a mismatch

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1851,7 +1851,13 @@ GlobOpt::CopyPropPropertySymObj(IR::SymOpnd *symOpnd, IR::Instr *instr)
                         bool shouldOptimize = CompareCurrentTypesWithExpectedTypes(newValueInfo, propertySymOpnd);
                         if (!shouldOptimize)
                         {
-                            propertySymOpnd->SetTypeCheckSeqCandidate(false);
+                            // Force a new type check here. We used to disable optimization for this symbol, but that's
+                            // no longer necessary now that inline caches are not shared.
+                            BVSparse<JitArenaAllocator> *liveFields = this->currentBlock->globOptData.liveFields;
+                            if (liveFields)
+                            {
+                                liveFields->Clear(newTypeSym->m_id);
+                            }
                         }
                     }
 


### PR DESCRIPTION
We used to disable objtypespec altogether for the given object pointer in such a case, but that's no longer necessary now that we don't share inline caches. Failure to objtypespec was exposed by a cross-site function type-sharing unit test.