### PR TITLE
Various module import fixes

### DIFF
--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -155,7 +155,7 @@ uint ConcatPath(LPCSTR filenameLeft, uint posPathSep, LPCSTR filenameRight, char
     return totalLength;
 }
 
-HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UINT* lengthBytesOut /*= nullptr*/)
+HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UINT* lengthBytesOut /*= nullptr*/, std::string* fullPath /*= nullptr*/)
 {
     static char sHostApplicationPathBuffer[MAX_URI_LENGTH];
     static uint sHostApplicationPathBufferLength = (uint) -1;
@@ -169,7 +169,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UIN
     FILE * file = NULL;
     size_t bufferLength = 0;
 
-    LPCSTR filename = filenameToLoad;
+    LPCSTR filename = fullPath == nullptr ? filenameToLoad : LPCSTR(fullPath->c_str());
     if (sHostApplicationPathBufferLength == (uint)-1)
     {
         // consider incoming filename as the host app and base its' path for others
@@ -188,7 +188,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UIN
         }
         sHostApplicationPathBuffer[sHostApplicationPathBufferLength] = char(0);
     }
-    else if (filename[0] != '/' && filename[0] != '\\') // make sure it's not a full path
+    else if (filename[0] != '/' && filename[0] != '\\' && fullPath == nullptr) // make sure it's not a full path
     {
         // concat host path and filename
         uint len = ConcatPath(sHostApplicationPathBuffer, sHostApplicationPathBufferLength,

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -155,7 +155,7 @@ uint ConcatPath(LPCSTR filenameLeft, uint posPathSep, LPCSTR filenameRight, char
     return totalLength;
 }
 
-HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UINT* lengthBytesOut /*= nullptr*/, std::string* fullPath /*= nullptr*/)
+HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UINT* lengthBytesOut /*= nullptr*/, std::string* fullPath /*= nullptr*/, bool shouldMute /*=false */)
 {
     static char sHostApplicationPathBuffer[MAX_URI_LENGTH];
     static uint sHostApplicationPathBufferLength = (uint) -1;
@@ -216,7 +216,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filenameToLoad, LPCSTR& contents, UIN
         // etc.
         if (fopen_s(&file, filename, "rb") != 0)
         {
-            if (!HostConfigFlags::flags.MuteHostErrorMsgIsEnabled)
+            if (!HostConfigFlags::flags.MuteHostErrorMsgIsEnabled && !shouldMute)
             {
 #ifdef _WIN32
                 DWORD lastError = GetLastError();

--- a/bin/ch/Helpers.h
+++ b/bin/ch/Helpers.h
@@ -7,7 +7,7 @@
 class Helpers
 {
 public :
-    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* lengthBytesOut = nullptr, std::string* fullPath = nullptr);
+    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* lengthBytesOut = nullptr, std::string* fullPath = nullptr, bool shouldMute = false);
     static LPCWSTR JsErrorCodeToString(JsErrorCode jsErrorCode);
     static void LogError(__in __nullterminated const char16 *msg, ...);
     static HRESULT LoadBinaryFile(LPCSTR filename, LPCSTR& contents, UINT& lengthBytes, bool printFileOpenError = true);

--- a/bin/ch/Helpers.h
+++ b/bin/ch/Helpers.h
@@ -7,7 +7,7 @@
 class Helpers
 {
 public :
-    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* lengthBytesOut = nullptr);
+    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* lengthBytesOut = nullptr, std::string* fullPath = nullptr);
     static LPCWSTR JsErrorCodeToString(JsErrorCode jsErrorCode);
     static void LogError(__in __nullterminated const char16 *msg, ...);
     static HRESULT LoadBinaryFile(LPCSTR filename, LPCSTR& contents, UINT& lengthBytes, bool printFileOpenError = true);

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -5,6 +5,13 @@
 #pragma once
 #include <list>
 
+enum ModuleState
+{
+    RootModule,
+    ImportedModule,
+    ErroredModule
+};
+
 class WScriptJsrt
 {
 public:
@@ -141,5 +148,6 @@ private:
     static DWORD_PTR sourceContext;
     static std::map<std::string, JsModuleRecord> moduleRecordMap;
     static std::map<JsModuleRecord, std::string> moduleDirMap;
+    static std::map<JsModuleRecord, ModuleState> moduleErrMap;
     static std::map<DWORD_PTR, std::string> scriptDirMap;
 };

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -36,17 +36,18 @@ public:
     private:
         JsModuleRecord moduleRecord;
         JsValueRef specifier;
+        std::string* fullPath;
 
-        ModuleMessage(JsModuleRecord module, JsValueRef specifier);
+        ModuleMessage(JsModuleRecord module, JsValueRef specifier, std::string* fullPathPtr);
 
     public:
         ~ModuleMessage();
 
         virtual HRESULT Call(LPCSTR fileName) override;
 
-        static ModuleMessage* Create(JsModuleRecord module, JsValueRef specifier)
+        static ModuleMessage* Create(JsModuleRecord module, JsValueRef specifier, std::string* fullPath = nullptr)
         {
-            return new ModuleMessage(module, specifier);
+            return new ModuleMessage(module, specifier, fullPath);
         }
 
     };

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -3624,6 +3624,10 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
     case tkIMPORT:
         if (m_scriptContext->GetConfig()->IsES6ModuleEnabled() && m_scriptContext->GetConfig()->IsESDynamicImportEnabled())
         {
+            if (!fAllowCall)
+            {
+                Error(ERRTokenAfter, _u("import"), _u("new"));
+            }
             this->GetScanner()->Scan();
             ChkCurTokNoScan(tkLParen, ERRnoLparen);
             pnode = ParseImportCall<buildAST>();

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -955,16 +955,6 @@ namespace Js
     {
         OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("ModuleEvaluation(%s)\n"), this->GetSpecifierSz());
 
-#if DBG
-        if (childrenModuleSet != nullptr)
-        {
-            childrenModuleSet->EachValue([=](SourceTextModuleRecord* childModuleRecord)
-            {
-                AssertMsg(childModuleRecord->WasParsed(), "child module needs to have been parsed");
-                AssertMsg(childModuleRecord->WasDeclarationInitialized(), "child module needs to have been initialized.");
-            });
-        }
-#endif
         if (!scriptContext->GetConfig()->IsES6ModuleEnabled() || WasEvaluated())
         {
             return nullptr;
@@ -985,6 +975,17 @@ namespace Js
                 JavascriptExceptionOperators::Throw(errorObject, this->scriptContext);
             }
         }
+
+#if DBG
+        if (childrenModuleSet != nullptr)
+        {
+            childrenModuleSet->EachValue([=](SourceTextModuleRecord* childModuleRecord)
+            {
+                AssertMsg(childModuleRecord->WasParsed(), "child module needs to have been parsed");
+                AssertMsg(childModuleRecord->WasDeclarationInitialized(), "child module needs to have been initialized.");
+            });
+        }
+#endif
 
         Assert(this->errorObject == nullptr);
         SetWasEvaluated();

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -202,7 +202,7 @@ namespace Js
 
             if (this->promise != nullptr)
             {
-                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this);
+                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this, false);
             }
 
             // Notify host if current module is dynamically-loaded module, or is root module and the host hasn't been notified
@@ -307,7 +307,7 @@ namespace Js
                 {
                     // Cleanup in case of error.
                     this->ReleaseParserResources();
-                    SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, scriptContext, this);
+                    SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, scriptContext, this, false);
                 }
                 else
                 {
@@ -342,7 +342,7 @@ namespace Js
             }
         }
 
-        return this->promise;
+        return JavascriptPromise::CreatePassThroughPromise(this->promise, scriptContext);
     }
 
     HRESULT SourceTextModuleRecord::PrepareForModuleDeclarationInitialization()
@@ -401,7 +401,7 @@ namespace Js
 
             if (this->promise != nullptr)
             {
-                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this);
+                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this, false);
             }
 
             if (this->promise != nullptr || (isRootModule && !hadNotifyHostReady))
@@ -967,7 +967,7 @@ namespace Js
 
             if (this->promise != nullptr)
             {
-                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this);
+                SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(false, this->errorObject, this->scriptContext, this, false);
                 return scriptContext->GetLibrary()->GetUndefined();
             }
             else
@@ -1029,7 +1029,7 @@ namespace Js
             this->errorObject = errorObject;
             if (this->promise != nullptr)
             {
-                ResolveOrRejectDynamicImportPromise(false, errorObject, scriptContext, this);
+                ResolveOrRejectDynamicImportPromise(false, errorObject, scriptContext, this, false);
                 return scriptContext->GetLibrary()->GetUndefined();
             }
         }
@@ -1041,7 +1041,7 @@ namespace Js
 
         if (this->promise != nullptr)
         {
-            SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(true, this->GetNamespace(), this->GetScriptContext(), this);
+            SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(true, this->GetNamespace(), this->GetScriptContext(), this, false);
         }
 
         return ret;
@@ -1268,7 +1268,7 @@ namespace Js
     }
 
     // static
-    Var SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(bool isResolve, Var value, ScriptContext *scriptContext, SourceTextModuleRecord *moduleRecord)
+    Var SourceTextModuleRecord::ResolveOrRejectDynamicImportPromise(bool isResolve, Var value, ScriptContext *scriptContext, SourceTextModuleRecord *moduleRecord, bool useReturn)
     {
         bool isScriptActive = scriptContext->GetThreadContext()->IsScriptActive();
         JavascriptPromise *promise = nullptr;
@@ -1297,8 +1297,11 @@ namespace Js
         if (moduleRecord != nullptr)
         {
             moduleRecord->SetPromise(nullptr);
+            if (useReturn)
+            {
+                return JavascriptPromise::CreatePassThroughPromise(promise, scriptContext);
+            }
         }
-
         return promise;
     }
 }

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -108,7 +108,7 @@ namespace Js
 
         void SetParent(SourceTextModuleRecord* parentRecord, LPCOLESTR moduleName);
         Utf8SourceInfo* GetSourceInfo() { return this->pSourceInfo; }
-        static Var ResolveOrRejectDynamicImportPromise(bool isResolve, Var value, ScriptContext *scriptContext, SourceTextModuleRecord *mr = nullptr);
+        static Var ResolveOrRejectDynamicImportPromise(bool isResolve, Var value, ScriptContext *scriptContext, SourceTextModuleRecord *mr = nullptr, bool useReturn = true);
         Var PostProcessDynamicModuleImport();
 
     private:

--- a/test/es6module/bug_issue_3257.js
+++ b/test/es6module/bug_issue_3257.js
@@ -3,28 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-WScript.RegisterModuleSource("mod0.js", `
-    import 'mod1.js';
-    import 'mod2.js';
+// Test that ch handles relative paths for module imports correctly
+// See orriginal issue https://github.com/Microsoft/ChakraCore/issues/3257
+// and repeat (following reversion) https://github.com/Microsoft/ChakraCore/issues/5237
 
-    console.log("mod0");
-`);
-
-WScript.RegisterModuleSource("mod1.js",`
-    import 'mod2.js';
-    console.log("mod1");
-`);
-
-WScript.RegisterModuleSource("mod2.js",`
-    import 'mod0.js';
-    console.log("mod2");
-`);
-
-WScript.RegisterModuleSource("script0.js",`
-    console.log("script0");
-    import('mod1.js');
-    import('mod2.js');
-`);
-
-WScript.LoadScriptFile("mod0.js", "module");
-WScript.LoadScriptFile("script0.js");
+WScript.LoadScriptFile("bug_issue_3257/mod/mod0.js", "module");
+WScript.LoadScriptFile("bug_issue_3257/script/script0.js");

--- a/test/es6module/bug_issue_3257/mod/mod0.js
+++ b/test/es6module/bug_issue_3257/mod/mod0.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// static imports in a module - relative to the module
+
+import '../mod1.js';
+import '../mod2/mod2.js';
+
+// dynamic import in a module - relative to the module
+
+import('../mod1.js').catch(e => print("Should not be printed"));
+
+print("mod0");

--- a/test/es6module/bug_issue_3257/mod1.js
+++ b/test/es6module/bug_issue_3257/mod1.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// static import in a module, relative to the module
+
+import 'mod2/mod2.js';
+print("mod1");

--- a/test/es6module/bug_issue_3257/mod2/mod2.js
+++ b/test/es6module/bug_issue_3257/mod2/mod2.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//static import in a module, relative to module
+
+import '../mod/mod0.js';
+print("mod2");

--- a/test/es6module/bug_issue_3257/script/script0.js
+++ b/test/es6module/bug_issue_3257/script/script0.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Dynamic import from a Script - relative to CWD not the script
+print("script0");
+import('bug_issue_3257/mod1.js').catch(e => print ("Should not be printed"));
+import('bug_issue_3257/mod2/mod2.js').catch(e => print ("Should not be printed"));

--- a/test/es6module/dynamic-module-functionality.js
+++ b/test/es6module/dynamic-module-functionality.js
@@ -406,6 +406,26 @@ var tests = [
         body: function() {
             assert.throws(()=>{eval('new import("ModuleSimpleExport.js")')}, SyntaxError);
         }
+    },
+    {
+        name : "Test that import() always gives different promise objects - Bug Issue #5795",
+        body: function () {
+            WScript.RegisterModuleSource("testModule", "export const a = 5;");
+            let functionBody =
+                `testDynamicImport(function () {
+                    const first = import ('ModuleSimpleExport.js');
+                    const second = import ('ModuleSimpleExport.js');
+                    assert.isTrue(first !== second, 'import() should not return the same promise');
+                    return Promise.all([first, second]).then ((results) => ({first, second, results}));
+                }, function (imports) {
+                    assert.isTrue(imports.first !== imports.second, 'import() should not return the same promise after resolution');
+                    assert.isTrue(imports.results[0] === imports.results[1], 'import() should return the same namespace object');
+                }, function (e) {
+                    print ("Test should not throw, threw " + e);
+                }, _asyncEnter, _asyncExit);`;
+            testScript(functionBody, "Test that import() always gives different promise objects", false, true);
+            testModuleScript(functionBody, "Test that import() always gives different promise objects", false, true);
+        }
     }
 ];
 

--- a/test/es6module/dynamic-module-functionality.js
+++ b/test/es6module/dynamic-module-functionality.js
@@ -400,7 +400,13 @@ var tests = [
 			//note exclusion of testScript case intentional - running the code from a script loads the module
 			//then the test from Module uses the one loaded by the script - do not add testScript here
         }
-	},
+    },
+    {
+        name : "Test 'new import()' throws - Bug Issue 5797",
+        body: function() {
+            assert.throws(()=>{eval('new import("ModuleSimpleExport.js")')}, SyntaxError);
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6module/dynamic_import_promises_5796.js
+++ b/test/es6module/dynamic_import_promises_5796.js
@@ -1,0 +1,66 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Dynamic import should always resolve or reject a promise
+// and it should never throw an unhandled exception
+// https://github.com/Microsoft/ChakraCore/issues/5796
+
+const promises = [];
+
+function testDynamicImport(testCase, shouldThrow = false, errorType = URIError)
+{
+    if (shouldThrow) {
+        promises.push(testCase
+            .then(() => print("Promise should be rejected"))
+            .catch (e => {if (!(e instanceof errorType)) throw new Error("fail");})
+            .catch (() => print("Wrong error type"))
+            );
+    } else {
+       promises.push(testCase.then(() => true).catch(e => print ("Test case failed")));
+    }
+}
+
+// Invalid specifiers, these produce promises rejected with URIErros
+testDynamicImport(import(undefined), true);
+testDynamicImport(import(true), true);
+testDynamicImport(import(false), true);
+testDynamicImport(import({}), true);
+testDynamicImport(import(' '), true);
+
+WScript.RegisterModuleSource("case1", 'this is a syntax error');
+WScript.RegisterModuleSource("case2", 'import "helper1";');
+WScript.RegisterModuleSource("helper1", 'this is a syntax error');
+WScript.RegisterModuleSource("case3", 'import "case1";');
+WScript.RegisterModuleSource("case4", 'throw new TypeError("error");');
+WScript.RegisterModuleSource("case5", 'import "case3";');
+WScript.RegisterModuleSource("case6", 'import "case4";');
+WScript.RegisterModuleSource("helper2", 'throw new TypeError("error");');
+WScript.RegisterModuleSource("case7", 'import "helper2";');
+WScript.RegisterModuleSource("passThrough", 'import "helper3"');
+WScript.RegisterModuleSource("helper3", 'throw new TypeError("error");');
+WScript.RegisterModuleSource("case8", 'import "passThrough";');
+WScript.RegisterModuleSource("case9", 'import "case8";');
+
+// syntax error at first level
+testDynamicImport(import("case1"), true, SyntaxError);
+// syntax error at second level
+testDynamicImport(import("case2"), true, SyntaxError);
+// syntax error at second level from already imported module
+testDynamicImport(import("case3"), true, SyntaxError);
+// Type Error at run time at first level
+testDynamicImport(import("case4"), true, TypeError);
+// Syntax error at 3rd level
+testDynamicImport(import("case5"), true, SyntaxError);
+// Indirectly re-Import the module that threw the type error
+// Promise should be resolved as the child module won't be evaluated twice
+testDynamicImport(import("case6"), true, TypeError);
+// Type Error at run time at second level
+testDynamicImport(import("case7"), true, TypeError);
+// Type Error at run time at third level
+testDynamicImport(import("case8"), true, TypeError);
+// Type Error at run time in a child that has already thrown
+testDynamicImport(import("case9"), true, TypeError);
+
+Promise.all(promises).then(() => print ("pass"));

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -137,7 +137,7 @@
       <files>bug_issue_3257.js</files>
       <compile-flags>-ESDynamicImport</compile-flags>
       <baseline>bug_issue_3257.baseline</baseline>
-      <tags>exclude_sanitize_address</tags>
+      <tags>exclude_sanitize_address,exclude_jshost</tags>
     </default>
   </test>
   <test>

--- a/test/es6module/rlexe.xml
+++ b/test/es6module/rlexe.xml
@@ -71,6 +71,13 @@
   </test>
   <test>
     <default>
+      <files>dynamic_import_promises_5796.js</files>
+      <compile-flags>-ESDynamicImport</compile-flags>
+      <tags>exclude_jshost</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>module-syntax.js</files>
       <compile-flags>-MuteHostErrorMsg -ES6Module -force:deferparse -args summary -endargs</compile-flags>
       <tags>exclude_sanitize_address</tags>


### PR DESCRIPTION
This PR fixes a collection of module related issues - some of these are very small so I thought better to combine them into one PR. I hope this isn't too much at once.

1. Restore the use of relative paths for imports within modules in ch - this was implemented a long time ago and then broken - the functionality was mostly still there just broken in a few places - originally this was issue 3257, it also has a newer issue I opened 5237. As well as restoring the functionality I restored the test case from 3257 which was no longer testing what it had been designed for after a previous edit.

2. Don't print messages about failing to load modules or syntax errors in modules when processing dynamic imports - this was purely a ch issue but was problematic for several test262 cases per issue 5796.

3. Reject the promise from import() if a child module of the dynamically imported module throws a runtime error - there was a bug where this promise was never being resolved - this is also part of 5796.

4. `new import(anything)` should be a syntax error - 5797

5. import() should return a different promise each time even when using the same specifier - fix this by using JavascriptPromise::CreatePassThroughPromise 5795

cc @rwaldron @boingoing 

fix #5796
fix #5795
fix #5797 
fix #5237 
re-fix #3257