### PR TITLE
Remove superfluous const from return types

### DIFF
--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -119,11 +119,11 @@ public:
         Js::RegSlot returnValueRegSlot = Js::Constants::NoRegister, const bool isInlinedConstructor = false,
         Js::ProfileId callSiteIdInParentFunc = UINT16_MAX, bool isGetterSetter = false);
 public:
-    void * const GetCodeGenAllocators()
+    void * GetCodeGenAllocators()
     {
         return this->GetTopFunc()->m_codeGenAllocators;
     }
-    InProcCodeGenAllocators * const GetInProcCodeGenAllocators()
+    InProcCodeGenAllocators * GetInProcCodeGenAllocators()
     {
         Assert(!JITManager::GetJITManager()->IsJITServer());
         return reinterpret_cast<InProcCodeGenAllocators*>(this->GetTopFunc()->m_codeGenAllocators);
@@ -274,7 +274,7 @@ public:
         return &m_output;
     }
 
-    const JITTimeFunctionBody * const GetJITFunctionBody() const
+    const JITTimeFunctionBody * GetJITFunctionBody() const
     {
         return m_workItem->GetJITFunctionBody();
     }

--- a/lib/Backend/GlobOptBlockData.h
+++ b/lib/Backend/GlobOptBlockData.h
@@ -20,7 +20,7 @@ public:
     }
 
 private:
-    static const uint32 BitMask(const uint index)
+    static uint32 BitMask(const uint index)
     {
         return 1u << index;
     }

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -626,7 +626,7 @@ private:
     bool            GenerateFastArgumentsLdElemI(IR::Instr* ldElem, IR::LabelInstr *labelFallThru);
     bool            GenerateFastRealStackArgumentsLdLen(IR::Instr *ldLen);
     bool            GenerateFastArgumentsLdLen(IR::Instr *ldLen, IR::LabelInstr* labelFallThru);
-    static const uint16  GetFormalParamOffset() { /*formal start after frame pointer, return address, function object, callInfo*/ return 4;};
+    static uint16   GetFormalParamOffset() { /*formal start after frame pointer, return address, function object, callInfo*/ return 4;};
 
     IR::RegOpnd*    GenerateFunctionTypeFromFixedFunctionObject(IR::Instr *callInstr, IR::Opnd* functionObjOpnd);
 

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -1293,7 +1293,7 @@ void LowererMD::ChangeToIMul(IR::Instr *const instr, bool hasOverflowCheck)
         EmitInt4Instr(instr); // IMUL2
 }
 
-const uint16
+uint16
 LowererMD::GetFormalParamOffset()
 {
     //In x86\x64 formal params were offset from EBP by the EBP chain, return address, and the 2 non-user params

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -63,7 +63,7 @@ public:
     static void             ChangeToSub(IR::Instr *const instr, const bool needFlags);
     static void             ChangeToShift(IR::Instr *const instr, const bool needFlags);
     static void             ChangeToIMul(IR::Instr *const instr, const bool hasOverflowCheck = false);
-    static const uint16     GetFormalParamOffset();
+    static uint16           GetFormalParamOffset();
     static const Js::OpCode MDUncondBranchOpcode;
     static const Js::OpCode MDMultiBranchOpcode;
     static const Js::OpCode MDExtend32Opcode;

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -103,7 +103,7 @@ EncoderMD::Init(Encoder *encoder)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetOpcodeByte2(IR::Instr *instr)
 {
     return OpcodeByte2[instr->m_opcode - (Js::OpCode::MDStart+1)];
@@ -161,13 +161,13 @@ EncoderMD::GetOpbyte(IR::Instr *instr)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(IR::RegOpnd *regOpnd)
 {
     return this->GetRegEncode(regOpnd->GetReg());
 }
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(RegNum reg)
 {
     AssertMsg(reg != RegNOREG, "should have valid reg in encoder");
@@ -189,7 +189,7 @@ EncoderMD::GetRegEncode(RegNum reg)
 ///
 ///----------------------------------------------------------------------------
 
-const uint32
+uint32
 EncoderMD::GetOpdope(IR::Instr *instr)
 {
     return Opdope[instr->m_opcode - (Js::OpCode::MDStart+1)];
@@ -203,7 +203,7 @@ EncoderMD::GetOpdope(IR::Instr *instr)
 ///
 ///----------------------------------------------------------------------------
 
-const uint32
+uint32
 EncoderMD::GetLeadIn(IR::Instr * instr)
 {
     return OpcodeLeadIn[instr->m_opcode - (Js::OpCode::MDStart+1)];

--- a/lib/Backend/amd64/EncoderMD.h
+++ b/lib/Backend/amd64/EncoderMD.h
@@ -202,14 +202,14 @@ public:
     void            AddLabelReloc(BYTE* relocAddress);
 
 private:
-    const BYTE      GetOpcodeByte2(IR::Instr *instr);
+    BYTE            GetOpcodeByte2(IR::Instr *instr);
     static Forms    GetInstrForm(IR::Instr *instr);
     const BYTE *    GetFormTemplate(IR::Instr *instr);
     const BYTE *    GetOpbyte(IR::Instr *instr);
-    const BYTE      GetRegEncode(IR::RegOpnd *regOpnd);
-    const BYTE      GetRegEncode(RegNum reg);
-    static const uint32 GetOpdope(IR::Instr *instr);
-    const uint32    GetLeadIn(IR::Instr * instr);
+    BYTE            GetRegEncode(IR::RegOpnd *regOpnd);
+    BYTE            GetRegEncode(RegNum reg);
+    static uint32   GetOpdope(IR::Instr *instr);
+    uint32          GetLeadIn(IR::Instr * instr);
     BYTE            EmitModRM(IR::Instr * instr, IR::Opnd *opnd, BYTE reg1);
     void            EmitConst(size_t val, int size, bool allowImm64 = false);
     BYTE            EmitImmed(IR::Opnd * opnd, int opSize, int sbit, bool allowImm64 = false);

--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -34,19 +34,19 @@ EncoderMD::Init(Encoder *encoder)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(IR::RegOpnd *regOpnd)
 {
     return GetRegEncode(regOpnd->GetReg());
 }
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(RegNum reg)
 {
     return RegEncode[reg];
 }
 
-const BYTE
+BYTE
 EncoderMD::GetFloatRegEncode(IR::RegOpnd *regOpnd)
 {
     //Each double register holds two single precision registers.

--- a/lib/Backend/arm/EncoderMD.h
+++ b/lib/Backend/arm/EncoderMD.h
@@ -58,9 +58,9 @@ public:
     void            ApplyRelocs(uint32 codeBufferAddress, size_t codeSize, uint* bufferCRC, BOOL isBrShorteningSucceeded, bool isFinalBufferValidation = false);
     static bool     TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd);
     static bool     TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd);
-    const BYTE      GetRegEncode(IR::RegOpnd *regOpnd);
-    const BYTE      GetFloatRegEncode(IR::RegOpnd *regOpnd);
-    static const BYTE GetRegEncode(RegNum reg);
+    BYTE            GetRegEncode(IR::RegOpnd *regOpnd);
+    BYTE            GetFloatRegEncode(IR::RegOpnd *regOpnd);
+    static BYTE     GetRegEncode(RegNum reg);
     static uint32   GetOpdope(IR::Instr *instr);
     static uint32   GetOpdope(Js::OpCode op);
 

--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -44,19 +44,19 @@ EncoderMD::Init(Encoder *encoder)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(IR::RegOpnd *regOpnd)
 {
     return GetRegEncode(regOpnd->GetReg());
 }
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(RegNum reg)
 {
     return RegEncode[reg];
 }
 
-const BYTE
+BYTE
 EncoderMD::GetFloatRegEncode(IR::RegOpnd *regOpnd)
 {
     BYTE regEncode = GetRegEncode(regOpnd->GetReg());

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -161,9 +161,9 @@ public:
     void            ApplyRelocs(size_t codeBufferAddress, size_t codeSize, uint* bufferCRC, BOOL isBrShorteningSucceeded, bool isFinalBufferValidation = false);
     static bool     TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd);
     static bool     TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd);
-    const BYTE      GetRegEncode(IR::RegOpnd *regOpnd);
-    const BYTE      GetFloatRegEncode(IR::RegOpnd *regOpnd);
-    static const BYTE GetRegEncode(RegNum reg);
+    BYTE            GetRegEncode(IR::RegOpnd *regOpnd);
+    BYTE            GetFloatRegEncode(IR::RegOpnd *regOpnd);
+    static BYTE     GetRegEncode(RegNum reg);
     static uint32   GetOpdope(IR::Instr *instr);
     static uint32   GetOpdope(Js::OpCode op);
 

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -105,7 +105,7 @@ EncoderMD::Init(Encoder *encoder)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetOpcodeByte2(IR::Instr *instr)
 {
     return OpcodeByte2[instr->m_opcode - (Js::OpCode::MDStart+1)];
@@ -154,7 +154,7 @@ EncoderMD::GetOpbyte(IR::Instr *instr)
 ///
 ///----------------------------------------------------------------------------
 
-const BYTE
+BYTE
 EncoderMD::GetRegEncode(IR::RegOpnd *regOpnd)
 {
     AssertMsg(regOpnd->GetReg() != RegNOREG, "RegOpnd should have valid reg in encoder");
@@ -171,7 +171,7 @@ EncoderMD::GetRegEncode(IR::RegOpnd *regOpnd)
 ///
 ///----------------------------------------------------------------------------
 
-const uint32
+uint32
 EncoderMD::GetOpdope(IR::Instr *instr)
 {
     return Opdope[instr->m_opcode - (Js::OpCode::MDStart+1)];
@@ -185,7 +185,7 @@ EncoderMD::GetOpdope(IR::Instr *instr)
 ///
 ///----------------------------------------------------------------------------
 
-const uint32
+uint32
 EncoderMD::GetLeadIn(IR::Instr * instr)
 {
     return OpcodeLeadIn[instr->m_opcode - (Js::OpCode::MDStart+1)];

--- a/lib/Backend/i386/EncoderMD.h
+++ b/lib/Backend/i386/EncoderMD.h
@@ -229,13 +229,13 @@ public:
     BYTE *          GetRelocBufferAddress(EncodeRelocAndLabels * reloc);
 
 private:
-    const BYTE      GetOpcodeByte2(IR::Instr *instr);
+    BYTE            GetOpcodeByte2(IR::Instr *instr);
     const BYTE *    GetFormTemplate(IR::Instr *instr);
     static Forms    GetInstrForm(IR::Instr *instr);
     const BYTE *    GetOpbyte(IR::Instr *instr);
-    const BYTE      GetRegEncode(IR::RegOpnd *regOpnd);
-    const uint32    GetLeadIn(IR::Instr * instr);
-    static const uint32 GetOpdope(IR::Instr *instr);
+    BYTE            GetRegEncode(IR::RegOpnd *regOpnd);
+    uint32          GetLeadIn(IR::Instr * instr);
+    static uint32   GetOpdope(IR::Instr *instr);
     void            EmitModRM(IR::Instr * instr, IR::Opnd *opnd, BYTE reg1);
     void            EmitConst(size_t val, int size);
     int             EmitImmed(IR::Opnd * opnd, int opSize, int sbit);

--- a/lib/Common/Common/Jobs.h
+++ b/lib/Common/Common/Jobs.h
@@ -442,7 +442,7 @@ namespace JsUtil
 
         ParallelThreadData(AllocationPolicyManager* policyManager);
 
-        PageAllocator* const GetPageAllocator() { return &backgroundPageAllocator; }
+        PageAllocator* GetPageAllocator() { return &backgroundPageAllocator; }
         bool CanDecommit() const { return canDecommit; }
     };
 

--- a/lib/Common/DataStructures/BaseDictionary.h
+++ b/lib/Common/DataStructures/BaseDictionary.h
@@ -238,7 +238,7 @@ namespace JsUtil
             return entries[i].Value();
         }
 
-        const TValue Item(const TKey& key) const
+        TValue Item(const TKey& key) const
         {
             int i = FindEntry(key);
             Assert(i >= 0);

--- a/lib/Common/DataStructures/KeyValuePair.h
+++ b/lib/Common/DataStructures/KeyValuePair.h
@@ -28,10 +28,10 @@ namespace JsUtil
         {}
 
         TKey Key() { return key; }
-        const TKey Key() const { return key; }
+        TKey Key() const { return key; }
 
         TValue Value() { return value; }
-        const TValue Value() const { return value; }
+        TValue Value() const { return value; }
     };
 
 }

--- a/lib/Common/DataStructures/WeakReferenceDictionary.h
+++ b/lib/Common/DataStructures/WeakReferenceDictionary.h
@@ -232,7 +232,7 @@ namespace JsUtil
             return values[i];
         }
 
-        const TBValue Item(const TBKey& key) const
+        TBValue Item(const TBKey& key) const
         {
             int i = FindEntry(key);
             Assert(i >= 0);

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -387,7 +387,7 @@ public:
         Assert(GetHeapBlockType() <= HeapBlock::HeapBlockType::BlockTypeCount);
     }
 
-    HeapBlockType const GetHeapBlockType() const
+    HeapBlockType GetHeapBlockType() const
     {
         return (heapBlockType);
     }

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -73,7 +73,7 @@ public:
     template <typename TBlockAttributes>
     bool IsPageHeapEnabledForBlock(const size_t objectSize);
 #else
-    const bool IsPageHeapEnabled() const{ return false; }
+    bool IsPageHeapEnabled() const{ return false; }
 #endif
 
 #if ENABLE_MEM_STATS

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -811,7 +811,7 @@ private:
     inline bool ShouldCapturePageHeapAllocStack() const { return capturePageHeapAllocStack; }
     void VerifyPageHeapFillAfterAlloc(char* memBlock, size_t size, ObjectInfoBits attributes);
 #else
-    inline const bool IsPageHeapEnabled() const { return false; }
+    inline bool IsPageHeapEnabled() const { return false; }
     inline bool ShouldCapturePageHeapAllocStack() const { return false; }
 #endif
 

--- a/lib/Parser/CharClassifier.h
+++ b/lib/Parser/CharClassifier.h
@@ -179,7 +179,7 @@ namespace Js
             return FBigChar(ch) ? IsIdContinueFast<true>(ch) : IsIdContinueFast<false>(ch);
         }
 
-        const size_t SkipBiDirectionalChars(_In_z_bytecount_(2 * length) LPCOLESTR psz, _In_ size_t startIndex, _In_ size_t length) const
+        size_t SkipBiDirectionalChars(_In_z_bytecount_(2 * length) LPCOLESTR psz, _In_ size_t startIndex, _In_ size_t length) const
         {
             size_t count = 0;
             while (startIndex < length)
@@ -195,7 +195,7 @@ namespace Js
             return count;
         }
 
-        const char16 SkipBiDirectionalChars(_In_z_ char16* &pszRef) const
+        char16 SkipBiDirectionalChars(_In_z_ char16* &pszRef) const
         {
             while (*pszRef != '\0')
             {
@@ -249,7 +249,7 @@ namespace Js
             return skipIdentifierFunc(psz, this);
         }
 
-        const LPCUTF8 SkipIdentifier(LPCUTF8 psz, LPCUTF8 end) const
+        LPCUTF8 SkipIdentifier(LPCUTF8 psz, LPCUTF8 end) const
         {
             return skipIdentifierStartEndFunc(psz, end, this);
         }

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -776,11 +776,11 @@ private:
         throw ParseExceptionObject(hr);
     }
 
-    const EncodedCharPtr PchBase(void) const
+    EncodedCharPtr PchBase(void) const
     {
         return m_pchBase;
     }
-    const EncodedCharPtr PchMinTok(void)
+    EncodedCharPtr PchMinTok(void)
     {
         return m_pchMinTok;
     }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -637,7 +637,7 @@ namespace Js
         virtual void Expire() override;
         virtual void EnterExpirableCollectMode() override;
         virtual void ResetOnNativeCodeInstallFailure() override;
-        static const uint8 GetDecrCallCountPerBailout()
+        static uint8 GetDecrCallCountPerBailout()
         {
             return (uint8)CONFIG_FLAG(CallsToBailoutsRatioForRejit) + 1;
         }
@@ -675,7 +675,7 @@ namespace Js
 
 #if ENABLE_NATIVE_CODEGEN
         virtual void ResetOnNativeCodeInstallFailure() override;
-        static const uint8 GetDecrLoopCountPerBailout()
+        static uint8 GetDecrLoopCountPerBailout()
         {
             return (uint8)CONFIG_FLAG(LoopIterationsToBailoutsRatioForRejit) + 1;
         }
@@ -730,8 +730,8 @@ namespace Js
 #endif
         static const uint NoLoop = (uint)-1;
 
-        static const uint GetOffsetOfProfiledLoopCounter() { return offsetof(LoopHeader, profiledLoopCounter); }
-        static const uint GetOffsetOfInterpretCount() { return offsetof(LoopHeader, interpretCount); }
+        static uint GetOffsetOfProfiledLoopCounter() { return offsetof(LoopHeader, profiledLoopCounter); }
+        static uint GetOffsetOfInterpretCount() { return offsetof(LoopHeader, interpretCount); }
 
         bool Contains(Js::LoopHeader * loopHeader) const
         {
@@ -981,7 +981,7 @@ namespace Js
 
         virtual void Mark(Recycler *recycler) override { AssertMsg(false, "Mark called on object that isn't TrackableObject"); }
 
-        static const uint GetOffsetOfFunctionInfo() { return offsetof(FunctionProxy, functionInfo); }
+        static uint GetOffsetOfFunctionInfo() { return offsetof(FunctionProxy, functionInfo); }
         FunctionInfo * GetFunctionInfo() const
         {
             return this->functionInfo;
@@ -2380,7 +2380,7 @@ namespace Js
         }
 #endif
 
-        const bool GetIsAsmJsFunction() const
+        bool GetIsAsmJsFunction() const
         {
             return m_isAsmJsFunction;
         }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -841,12 +841,12 @@ private:
         DateTime::Utility dateTimeUtility;
 
 public:
-        inline const WCHAR *const GetStandardName(size_t *nameLength, DateTime::YMD *ymd = NULL)
+        inline const WCHAR *GetStandardName(size_t *nameLength, DateTime::YMD *ymd = NULL)
         {
             return dateTimeUtility.GetStandardName(nameLength, ymd);
         }
 
-        inline const WCHAR *const GetDaylightName(size_t *nameLength, DateTime::YMD *ymd = NULL)
+        inline const WCHAR *GetDaylightName(size_t *nameLength, DateTime::YMD *ymd = NULL)
         {
             return dateTimeUtility.GetDaylightName(nameLength, ymd);
         }

--- a/lib/Runtime/ByteCode/ByteBlock.cpp
+++ b/lib/Runtime/ByteCode/ByteBlock.cpp
@@ -21,7 +21,7 @@ namespace Js
         return m_content;
     }
 
-    const byte ByteBlock::operator[](uint itemIndex) const
+    byte ByteBlock::operator[](uint itemIndex) const
     {
         AssertMsg(itemIndex < m_contentSize, "Ensure valid offset");
 

--- a/lib/Runtime/ByteCode/ByteBlock.h
+++ b/lib/Runtime/ByteCode/ByteBlock.h
@@ -46,7 +46,7 @@ namespace Js
         uint GetLength() const;
         byte* GetBuffer();
         const byte* GetBuffer() const;
-        const byte operator[](uint itemIndex) const;
+        byte operator[](uint itemIndex) const;
         byte& operator[] (uint itemIndex);
     };
 } // namespace Js

--- a/lib/Runtime/ByteCode/OpCodeUtil.h
+++ b/lib/Runtime/ByteCode/OpCodeUtil.h
@@ -32,11 +32,11 @@ public:
     static bool IsValidByteCodeOpcode(OpCode op);
     static bool IsValidOpcode(OpCode op);
     static bool IsPrefixOpcode(OpCode op);
-    static const bool IsSmallEncodedOpcode(OpCode op)
+    static bool IsSmallEncodedOpcode(OpCode op)
     {
         return op <= Js::OpCode::MaxByteSizedOpcodes;
     }
-    static const uint EncodedSize(OpCode op, LayoutSize layoutSize)
+    static uint EncodedSize(OpCode op, LayoutSize layoutSize)
     {
         // Simple case, only 1 byte
         // Small OpCode with Medium or Large layout: 1 extra byte for the prefix

--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -196,7 +196,7 @@ namespace Js
         Arguments(const Arguments& other) : Info(other.Info), Values(other.Values) {}
 
         Var operator [](int idxArg) { return const_cast<Var>(static_cast<const Arguments&>(*this)[idxArg]); }
-        const Var operator [](int idxArg) const
+        Var operator [](int idxArg) const
         {
             AssertMsg((idxArg < (int)Info.Count) && (idxArg >= 0), "Ensure a valid argument index");
             return Values[idxArg];

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -390,7 +390,7 @@ namespace Js
         // Constructor
         AsmJsModuleArg(PropertyName name, ArgType type) : AsmJsSymbol(name, symbolType), mArgType(type) { }
         // Accessor
-        inline const ArgType GetArgType()const { return mArgType; }
+        inline ArgType GetArgType()const { return mArgType; }
 
         // AsmJsSymbol interface
     public:

--- a/lib/Runtime/Language/ConstructorCache.h
+++ b/lib/Runtime/Language/ConstructorCache.h
@@ -67,8 +67,8 @@ namespace Js
         ConstructorCache();
         ConstructorCache(ConstructorCache const * other);
 
-        static size_t const GetOffsetOfGuardValue() { return PropertyGuard::GetOffsetOfValue(); }
-        static size_t const GetSizeOfGuardValue() { return PropertyGuard::GetSizeOfValue(); }
+        static size_t GetOffsetOfGuardValue() { return PropertyGuard::GetOffsetOfValue(); }
+        static size_t GetSizeOfGuardValue() { return PropertyGuard::GetSizeOfValue(); }
 
         void Populate(DynamicType* type, ScriptContext* scriptContext, bool ctorHasNoExplicitReturnValue, bool updateAfterCtor);
         void PopulateForSkipDefaultNewObject(ScriptContext* scriptContext);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1776,7 +1776,7 @@ skipThunk:
 #pragma optimize("", on)
 #endif
 
-    const bool InterpreterStackFrame::ShouldDoProfile(FunctionBody* executeFunction)
+    bool InterpreterStackFrame::ShouldDoProfile(FunctionBody* executeFunction)
     {
 #if ENABLE_PROFILE_INFO
         const bool doProfile = executeFunction->GetInterpreterExecutionMode(false) == ExecutionMode::ProfilingInterpreter ||

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -361,7 +361,7 @@ namespace Js
         _NOINLINE static Var InterpreterThunk(RecyclableObject* function, CallInfo callInfo, ...);
 #endif
         static Var InterpreterHelper(ScriptFunction* function, ArgumentReader args, void* returnAddress, void* addressOfReturnAddress, AsmJsReturnStruct* asmReturn = nullptr);
-        static const bool ShouldDoProfile(FunctionBody* executeFunction);
+        static bool ShouldDoProfile(FunctionBody* executeFunction);
         static InterpreterStackFrame* CreateInterpreterStackFrameForGenerator(ScriptFunction* function, FunctionBody* executeFunction, JavascriptGenerator* generator, bool doProfile);
 
         void InitializeClosures();

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -82,7 +82,7 @@ namespace Js
     }
 
 
-    void* const JavascriptCallStackLayout::ToFramePointer(JavascriptCallStackLayout* callstackLayout)
+    void* JavascriptCallStackLayout::ToFramePointer(JavascriptCallStackLayout* callstackLayout)
     {
         return
             reinterpret_cast<void * const>(
@@ -1484,12 +1484,12 @@ namespace Js
         return GetFrameAtIndex(frameCount - 1)->function;
     }
 
-    InlinedFrameWalker::InlinedFrame *const InlinedFrameWalker::GetCurrentFrame() const
+    InlinedFrameWalker::InlinedFrame *InlinedFrameWalker::GetCurrentFrame() const
     {
         return GetFrameAtIndex(currentIndex);
     }
 
-    InlinedFrameWalker::InlinedFrame *const InlinedFrameWalker::GetFrameAtIndex(signed index) const
+    InlinedFrameWalker::InlinedFrame *InlinedFrameWalker::GetFrameAtIndex(signed index) const
     {
         Assert(frames);
         Assert(frameCount);

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -57,7 +57,7 @@ namespace Js
         ForInObjectEnumerator * GetForInObjectEnumeratorArrayAtOffset(int offset) const;
 
         static JavascriptCallStackLayout *FromFramePointer(void *const framePointer);
-        static void* const ToFramePointer(JavascriptCallStackLayout* callstackLayout);
+        static void* ToFramePointer(JavascriptCallStackLayout* callstackLayout);
     private:
         JavascriptCallStackLayout() : callInfo(0) {};
     };
@@ -137,12 +137,12 @@ namespace Js
         };
 
     public:
-        InlinedFrame *const     GetFrameAtIndex(signed index) const;
+        InlinedFrame *GetFrameAtIndex(signed index) const;
 
     private:
         void Initialize(int32 frameCount, __in_ecount(frameCount) InlinedFrame **frames, Js::ScriptFunction *parent);
         void MoveNext();
-        InlinedFrame *const GetCurrentFrame() const;
+        InlinedFrame *GetCurrentFrame() const;
 
         Js::ScriptFunction *parentFunction;
         InlinedFrame          **frames;

--- a/lib/Runtime/Language/PropertyGuard.h
+++ b/lib/Runtime/Language/PropertyGuard.h
@@ -44,8 +44,8 @@ public:
         Assert(this->value != GuardValue::Invalidated && this->value != GuardValue::Invalidated_DuringSweep);
     }
 
-    inline static size_t const GetSizeOfValue() { return sizeof(((PropertyGuard*)0)->value); }
-    inline static size_t const GetOffsetOfValue() { return offsetof(PropertyGuard, value); }
+    inline static size_t GetSizeOfValue() { return sizeof(((PropertyGuard*)0)->value); }
+    inline static size_t GetOffsetOfValue() { return offsetof(PropertyGuard, value); }
 
     intptr_t GetValue() const { return this->value; }
     bool IsValid()

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -119,7 +119,7 @@ namespace Js
         }
 
         ES5HeapArgumentsObject* ConvertToUnmappedArgumentsObject(bool overwriteArgsUsingFrameObject = true);
-        const ActivationObject* const GetFrameObject() { return frameObject; }
+        const ActivationObject* GetFrameObject() { return frameObject; }
         void SetFrameObject(ActivationObject * value)
         {
             AssertMsg(frameObject == nullptr, "Setting the frame object again?");

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -329,7 +329,7 @@ bool WasmBinaryReader::IsCurrentFunctionCompleted() const
 }
 
 
-const uint32 WasmBinaryReader::EstimateCurrentFunctionBytecodeSize() const
+uint32 WasmBinaryReader::EstimateCurrentFunctionBytecodeSize() const
 {
     if (m_readerState != READER_STATE_FUNCTION)
     {

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -54,7 +54,7 @@ namespace Wasm
         WasmOp ReadOpCode();
         virtual WasmOp ReadExpr() override;
         virtual void FunctionEnd() override;
-        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const override;
+        virtual uint32 EstimateCurrentFunctionBytecodeSize() const override;
 #if DBG_DUMP
         void PrintOps();
 #endif

--- a/lib/WasmReader/WasmCustomReader.cpp
+++ b/lib/WasmReader/WasmCustomReader.cpp
@@ -44,7 +44,7 @@ void WasmCustomReader::AddNode(WasmNode node)
     m_nodes.Add(node);
 }
 
-const uint32 WasmCustomReader::EstimateCurrentFunctionBytecodeSize() const
+uint32 WasmCustomReader::EstimateCurrentFunctionBytecodeSize() const
 {
     uint32 count = min((uint32)m_nodes.Count(), (uint32)AutoSystemInfo::PageSize);
     // On average each node takes between 3 - 7 bytes to encode

--- a/lib/WasmReader/WasmCustomReader.h
+++ b/lib/WasmReader/WasmCustomReader.h
@@ -15,7 +15,7 @@ namespace Wasm
         virtual bool IsCurrentFunctionCompleted() const override;
         virtual WasmOp ReadExpr() override;
         virtual void FunctionEnd() override;
-        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const override;
+        virtual uint32 EstimateCurrentFunctionBytecodeSize() const override;
 
         void AddNode(WasmNode node);
     private:

--- a/lib/WasmReader/WasmReaderBase.h
+++ b/lib/WasmReader/WasmReaderBase.h
@@ -14,7 +14,7 @@ namespace Wasm
         virtual bool IsCurrentFunctionCompleted() const = 0;
         virtual WasmOp ReadExpr() = 0;
         virtual void FunctionEnd() = 0;
-        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const = 0;
+        virtual uint32 EstimateCurrentFunctionBytecodeSize() const = 0;
         WasmNode m_currentNode;
     };
 } // namespace Wasm


### PR DESCRIPTION
cf. https://isocpp.org/blog/2013/06/quick-q-should-i-return-a-const-value-stackoverflow