### PR TITLE
Change Date.parse() to require a time component when using an offset.

### DIFF
--- a/lib/Runtime/Library/DateImplementation.cpp
+++ b/lib/Runtime/Library/DateImplementation.cpp
@@ -1118,19 +1118,13 @@ Error:
                     continue;
                 }
                 case '+':
-                {
-                    if (lwNil != lwTime)
-                    {
-                        ss = ssAddOffset;
-                    }
-                    continue;
-                }
                 case '-':
                 {
-                    if (lwNil != lwTime)
+                    if (lwNil == lwTime)
                     {
-                        ss = ssSubOffset;
+                        goto LError;
                     }
+                    ss = (ch == '+') ? ssAddOffset : ssSubOffset;
                     continue;
                 }
             }
@@ -1300,7 +1294,7 @@ Error:
                 {
                     AssertMsg(isNextFieldDateNegativeVersion5 == false, "isNextFieldDateNegativeVersion5 == false");
 
-                    if (lwNil != lwOffset)
+                    if (lwNil != lwOffset || lwNil == lwTime)
                         goto LError;
                     // convert into minutes, e.g. 730 -> 7*60+30
                     lwOffset = lwT < 24 ? lwT * 60 :

--- a/test/Date/DateParse3.js
+++ b/test/Date/DateParse3.js
@@ -24,7 +24,9 @@ runTest("2011-11-08 19:48:43.100", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.1000", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.12345", "2011-11-08T19:48:43.123");
 
-runTest("2011-11-08+01:00", null); // previously the '+' or '-' would be skipped and the offset interpreted as a time
+// previously the '+' or '-' would be skipped and the offset interpreted as a time
+runTest("2011-11-08+01:00", null);
+runTest("2011-11-08-01:00", null);
 
 function runTest(dateToTest, isoDate)
 {

--- a/test/Date/DateParse3.js
+++ b/test/Date/DateParse3.js
@@ -24,6 +24,8 @@ runTest("2011-11-08 19:48:43.100", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.1000", "2011-11-08T19:48:43.100");
 runTest("2011-11-08 19:48:43.12345", "2011-11-08T19:48:43.123");
 
+runTest("2011-11-08+01:00", null); // previously the '+' or '-' would be skipped and the offset interpreted as a time
+
 function runTest(dateToTest, isoDate)
 {
     if (isoDate === null) {


### PR DESCRIPTION
Previously an input such as `2018-08-21+10:00` would interpret the offset as a time.
NaN is now returned instead. As a compatibility note, both Chrome and Firefox return NaN.

Previous pull-request: https://github.com/Microsoft/ChakraCore/pull/5791