### PR TITLE
Throw a syntax error when the statement of a with statement is a labeled function.

### DIFF
--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -111,7 +111,8 @@ LSC_ERROR_MSG(1095, ERRFunctionAfterLabelInStrict, "Function declarations not al
 LSC_ERROR_MSG(1096, ERRAwaitAsLabelInAsync, "Use of 'await' as label in async function is not allowed.")
 LSC_ERROR_MSG(1097, ERRExperimental, "Use of disabled experimental feature")
 LSC_ERROR_MSG(1098, ERRDuplicateExport, "Duplicate export of name '%s'")
-//1098-1199 available for future use
+LSC_ERROR_MSG(1099, ERRStmtOfWithIsLabelledFunc, "The statement of a 'with' statement cannot be a labelled function.")
+//1100-1199 available for future use
 
 // Generic errors intended to be re-usable
 LSC_ERROR_MSG(1200, ERRKeywordAfter, "Unexpected keyword '%s' after '%s'")

--- a/test/Function/LabelFuncAsWithStmt.baseline
+++ b/test/Function/LabelFuncAsWithStmt.baseline
@@ -1,0 +1,2 @@
+SyntaxError: The statement of a 'with' statement cannot be a labelled function.
+	at code (LabelFuncAsWithStmt.js:7:1)

--- a/test/Function/LabelFuncAsWithStmt.js
+++ b/test/Function/LabelFuncAsWithStmt.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+with ({}) L: function f() { }

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -2,6 +2,12 @@
 <regress-exe>
   <test>
     <default>
+      <files>LabelFuncAsWithStmt.js</files>
+      <baseline>LabelFuncAsWithStmt.baseline</baseline>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>apply.js</files>
       <baseline>apply.baseline</baseline>
     </default>


### PR DESCRIPTION
Repro:
cmd: ch bug.js

`with ({}) L: function f(){}`

Should output a syntax error as the[ statement of a WithStatement is not allowed to be a LabelledFunction](https://tc39.github.io/ecma262/#sec-with-statement-static-semantics-early-errors), but instead Chakra does not output a syntax error. 