### PR TITLE
surface oop jit on windows builds of chakracore

### DIFF
--- a/bin/ChakraCore/TestHooks.cpp
+++ b/bin/ChakraCore/TestHooks.cpp
@@ -68,16 +68,6 @@ HRESULT __stdcall SetEnableCheckMemoryLeakOutput(bool flag)
     return S_OK;
 }
 
-#if ENABLE_NATIVE_CODEGEN
-#ifdef _WIN32
-void __stdcall ConnectJITServer(HANDLE processHandle, void* serverSecurityDescriptor, UUID connectionId)
-{
-    JITManager::GetJITManager()->EnableOOPJIT();
-    ThreadContext::SetJITConnectionInfo(processHandle, serverSecurityDescriptor, connectionId);
-}
-#endif
-#endif
-
 void __stdcall NotifyUnhandledException(PEXCEPTION_POINTERS exceptionInfo)
 {
 #ifdef GENERATE_DUMP
@@ -203,9 +193,6 @@ HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
 #undef FLAG_NumberPairSet
 #undef FLAG_NumberTrioSet
 #undef FLAG_NumberRange
-#if ENABLE_NATIVE_CODEGEN && _WIN32
-        ConnectJITServer,
-#endif
         NotifyUnhandledException
     };
     return pfChakraCoreLoaded(testHooks);

--- a/bin/ChakraCore/TestHooks.h
+++ b/bin/ChakraCore/TestHooks.h
@@ -69,13 +69,6 @@ struct TestHooks
 #undef FLAG_NumberTrioSet
 #undef FLAG_NumberRange
 
-#if ENABLE_NATIVE_CODEGEN
-#ifdef _WIN32
-    typedef void(TESTHOOK_CALL * ConnectJITServer)(HANDLE processHandle, void* serverSecurityDescriptor, UUID connectionId);
-    ConnectJITServer pfnConnectJITServer;
-#endif
-#endif
-
     NotifyUnhandledExceptionPtr pfnNotifyUnhandledException;
 };
 

--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -178,6 +178,9 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtTTDGetSnapTimeTopLevelEventMove = (JsAPIHooks::JsrtTTDGetSnapTimeTopLevelEventMovePtr)GetChakraCoreSymbol(library, "JsTTDGetSnapTimeTopLevelEventMove");
     m_jsApiHooks.pfJsrtTTDMoveToTopLevelEvent = (JsAPIHooks::JsrtTTDMoveToTopLevelEventPtr)GetChakraCoreSymbol(library, "JsTTDMoveToTopLevelEvent");
     m_jsApiHooks.pfJsrtTTDReplayExecution = (JsAPIHooks::JsrtTTDReplayExecutionPtr)GetChakraCoreSymbol(library, "JsTTDReplayExecution");
+#ifdef _WIN32
+    m_jsApiHooks.pfJsrtConnectJITProcess = (JsAPIHooks::JsrtConnectJITProcess)GetChakraCoreSymbol(library, "JsConnectJITProcess");
+#endif
 #endif
 
     return true;

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -1298,7 +1298,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
         {
             // TODO: Error checking
             JITProcessManager::StartRpcServer(argc, argv);
-            ChakraRTInterface::ConnectJITServer(JITProcessManager::GetRpcProccessHandle(), nullptr, JITProcessManager::GetRpcConnectionId());
+            ChakraRTInterface::JsConnectJITProcess(JITProcessManager::GetRpcProccessHandle(), nullptr, JITProcessManager::GetRpcConnectionId());
         }
 #endif
         HANDLE threadHandle;

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -67,14 +67,7 @@ JITManager::CreateBinding(
     RPC_BINDING_HANDLE_TEMPLATE_V1 bindingTemplate;
     RPC_BINDING_HANDLE_SECURITY_V1_W bindingSecurity;
 
-#ifndef NTBUILD
-    RPC_SECURITY_QOS_V4 securityQOS;
-    ZeroMemory(&securityQOS, sizeof(RPC_SECURITY_QOS_V4));
-    securityQOS.Capabilities = RPC_C_QOS_CAPABILITIES_DEFAULT;
-    securityQOS.IdentityTracking = RPC_C_QOS_IDENTITY_DYNAMIC;
-    securityQOS.ImpersonationType = RPC_C_IMP_LEVEL_IDENTIFY;
-    securityQOS.Version = 4;
-#else
+#if (NTDDI_VERSION >= NTDDI_WIN8)
     RPC_SECURITY_QOS_V5 securityQOS;
     ZeroMemory(&securityQOS, sizeof(RPC_SECURITY_QOS_V5));
     securityQOS.Capabilities = RPC_C_QOS_CAPABILITIES_DEFAULT;
@@ -82,7 +75,14 @@ JITManager::CreateBinding(
     securityQOS.ImpersonationType = RPC_C_IMP_LEVEL_IDENTIFY;
     securityQOS.Version = 5;
     securityQOS.ServerSecurityDescriptor = serverSecurityDescriptor;
-#endif // NTBUILD
+#else
+    RPC_SECURITY_QOS_V4 securityQOS;
+    ZeroMemory(&securityQOS, sizeof(RPC_SECURITY_QOS_V4));
+    securityQOS.Capabilities = RPC_C_QOS_CAPABILITIES_DEFAULT;
+    securityQOS.IdentityTracking = RPC_C_QOS_IDENTITY_DYNAMIC;
+    securityQOS.ImpersonationType = RPC_C_IMP_LEVEL_IDENTIFY;
+    securityQOS.Version = 4;
+#endif
 
     ZeroMemory(&bindingTemplate, sizeof(bindingTemplate));
     bindingTemplate.Version = 1;

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -27,16 +27,7 @@ HRESULT JsInitializeJITServer(
         return status;
     }
 
-#ifndef NTBUILD
-    status = RpcServerRegisterIf2(
-        ServerIChakraJIT_v0_0_s_ifspec,
-        NULL,
-        NULL,
-        RPC_IF_AUTOLISTEN,
-        RPC_C_LISTEN_MAX_CALLS_DEFAULT,
-        (ULONG)-1,
-        NULL);
-#else
+#if (NTDDI_VERSION >= NTDDI_WIN8)
     status = RpcServerRegisterIf3(
         ServerIChakraJIT_v0_0_s_ifspec,
         NULL,
@@ -46,6 +37,15 @@ HRESULT JsInitializeJITServer(
         (ULONG)-1,
         NULL,
         securityDescriptor);
+#else
+    status = RpcServerRegisterIf2(
+        ServerIChakraJIT_v0_0_s_ifspec,
+        NULL,
+        NULL,
+        RPC_IF_AUTOLISTEN,
+        RPC_C_LISTEN_MAX_CALLS_DEFAULT,
+        (ULONG)-1,
+        NULL);
 #endif
     if (status != RPC_S_OK)
     {

--- a/lib/Jsrt/Chakra.Jsrt.vcxproj
+++ b/lib/Jsrt/Chakra.Jsrt.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
@@ -61,6 +61,7 @@
     <ClInclude Include="ChakraCommon.h" />
     <ClInclude Include="ChakraCommonWindows.h" />
     <ClInclude Include="ChakraCore.h" />
+    <ClInclude Include="ChakraCoreWindows.h" />
     <ClInclude Include="ChakraDebug.h" />
     <ClInclude Include="JsrtContext.h" />
     <ClInclude Include="JsrtDebugManager.h" />

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -1271,5 +1271,10 @@ CHAKRA_API
         _In_ JsValueRef parserState,
         _Out_ JsValueRef * result);
 
+
+#ifdef _WIN32
+#include "ChakraCoreWindows.h"
+#endif // _WIN32
+
 #endif // _CHAKRACOREBUILD
 #endif // _CHAKRACORE_H_

--- a/lib/Jsrt/ChakraCoreWindows.h
+++ b/lib/Jsrt/ChakraCoreWindows.h
@@ -1,0 +1,28 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifdef _MSC_VER
+#pragma once
+#endif // _MSC_VER
+
+#ifndef _CHAKRACOREWINDOWS_H_
+#define _CHAKRACOREWINDOWS_H_
+
+/// <summary>
+///     Enables out-of-process JIT by connecting to a Chakra JIT process that was initialized by calling JsInitializeJITServer
+/// </summary>
+/// <remarks>
+///     Should be called before JS code is executed.
+/// </remarks>
+/// <param name="processHandle">Handle to the JIT process</param>
+/// <param name="serverSecurityDescriptor">Optional pointer to an RPC SECURITY_DESCRIPTOR structure</param>
+/// <param name="connectionId">Same UUID that was passed to JsInitializeJITServer</param>
+/// <returns>
+///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+/// </returns>
+CHAKRA_API
+JsConnectJITProcess(_In_ HANDLE processHandle, _In_opt_ void* serverSecurityDescriptor, _In_ UUID connectionId);
+
+#endif // _CHAKRACOREWINDOWS_H_

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -4176,9 +4176,6 @@ CHAKRA_API JsTTDStart()
 
     Js::ScriptContext* scriptContext = currentContext->GetScriptContext();
     TTDAssert(scriptContext->IsTTDRecordOrReplayModeEnabled(), "Need to create in TTD Record Mode.");
-#if ENABLE_NATIVE_CODEGEN
-    TTDAssert(JITManager::GetJITManager() == nullptr || !JITManager::GetJITManager()->IsOOPJITEnabled(), "TTD cannot run with OOP JIT yet!!!");
-#endif
     return GlobalAPIWrapper_NoRecord([&]() -> JsErrorCode
     {
         if(scriptContext->IsTTDRecordModeEnabled())
@@ -5907,5 +5904,17 @@ JsExecuteBackgroundParse_Experimental(
         return JsErrorFatal;
     }
 }
+
+#ifdef _WIN32
+CHAKRA_API
+JsConnectJITProcess(_In_ HANDLE processHandle, _In_opt_ void* serverSecurityDescriptor, _In_ UUID connectionId)
+{
+#ifdef ENABLE_OOP_NATIVE_CODEGEN
+    JITManager::GetJITManager()->EnableOOPJIT();
+    ThreadContext::SetJITConnectionInfo(processHandle, serverSecurityDescriptor, connectionId);
+#endif
+    return JsNoError;
+}
+#endif
 
 #endif // _CHAKRACOREBUILD

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -114,6 +114,7 @@
     JsParseSerialized
     JsRunSerialized
     JsCreatePropertyId
+    JsConnectJITProcess
     JsCopyPropertyId
     JsCreatePromise
     JsCreateWeakReference


### PR DESCRIPTION
Resolves #5793

To use this, you will need to create a process to use as the JIT process and in it do the following:

````
UUID connectionId;
UuidCreate(&connectionId);
void* securityDescriptor = nullptr; // initialize security descriptor (only applicable on win8+)
void* alpcSecurityDescriptor = nullptr; // initialize alpc security descriptor
JsInitializeJITServer(connectionId, securityDescriptor, alpcSecurityDescriptor);
````

You will need to pass the `connectionId` and a process handle of the JIT process to your JS runtime process, and call the following:
````
void* securityDescriptor = nullptr; // initialize security descriptor (only applicable on win8+)
JsConnectJITProcess(jitProcessHandle, connectionId, securityDescriptor)
````

Notes:
`JsConnectJITProcess` should be called before executing any script, and should only be called once per JS runtime process.
The host should ensure that the JS runtime process does not hold any handles to the JIT process once script execution begins.
The host must enable ACG on the JS runtime process in order to get a security benefit from out-of-process JIT.
You can connect any number of JS runtime processes to a single JIT process.
