### PR TITLE
Keep memory usage under control when running compile_clang

### DIFF
--- a/tools/compile_clang.sh
+++ b/tools/compile_clang.sh
@@ -112,7 +112,7 @@ if [ ! -d ./cc-toolchain/src/llvm/projects/compiler-rt ]; then
     mkdir binutils_compile; cd binutils_compile
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${ROOT}/build/lib/"
     ../binutils/configure --enable-gold --enable-plugins --disable-werror --prefix="${ROOT}/build"
-    make -j
+    make -j4
     make install
     if [ $? != 0 ]; then
         exit 1


### PR DESCRIPTION
"make -j" creates an enormous number of processes and consistently crashes my VM despite having 16 GB of memory available. Let's put a slightly more reasonable limit on the process count.