### PR TITLE
Implement Symbol.prototype.description

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -655,6 +655,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6RegExSticky          (true)
 #define DEFAULT_CONFIG_ES2018RegExDotAll          (true)
 #define DEFAULT_CONFIG_ESBigInt          (false)
+#define DEFAULT_CONFIG_ESSymbolDescription     (true)
 #ifdef COMPILE_DISABLE_ES6RegExPrototypeProperties
     // If ES6RegExPrototypeProperties needs to be disabled by compile flag, DEFAULT_CONFIG_ES6RegExPrototypeProperties should be false
     #define DEFAULT_CONFIG_ES6RegExPrototypeProperties (false)
@@ -1188,6 +1189,9 @@ FLAGR(Boolean, WinRTAdaptiveApps        , "Enable the adaptive apps feature, all
 
 // ES BigInt flag
 FLAGR(Boolean, ESBigInt, "Enable ESBigInt flag", DEFAULT_CONFIG_ESBigInt)
+
+// ES Symbol.prototype.description flag
+FLAGR(Boolean, ESSymbolDescription, "Enable Symbol.prototype.description", DEFAULT_CONFIG_ESSymbolDescription)
 
 // This flag to be removed once JITing generator functions is stable
 FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", false)

--- a/lib/Runtime/Base/ThreadConfigFlagsList.h
+++ b/lib/Runtime/Base/ThreadConfigFlagsList.h
@@ -49,6 +49,7 @@ FLAG_RELEASE(IsESSharedArrayBufferEnabled, ESSharedArrayBuffer)
 FLAG_RELEASE(IsESDynamicImportEnabled, ESDynamicImport)
 FLAG_RELEASE(IsESBigIntEnabled, ESBigInt)
 FLAG_RELEASE(IsESExportNsAsEnabled, ESExportNsAs)
+FLAG_RELEASE(IsESSymbolDescriptionEnabled, ESSymbolDescription)
 #ifdef ENABLE_PROJECTION
 FLAG(AreWinRTDelegatesInterfaces, WinRTDelegateInterfaces)
 FLAG_RELEASE(IsWinRTAdaptiveAppsEnabled, WinRTAdaptiveApps)

--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -277,6 +277,7 @@ BUILTIN(JavascriptSymbol, ToString, EntryToString, FunctionInfo::ErrorOnNew | Fu
 BUILTIN(JavascriptSymbol, For, EntryFor, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptSymbol, KeyFor, EntryKeyFor, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptSymbol, SymbolToPrimitive, EntrySymbolToPrimitive, FunctionInfo::ErrorOnNew)
+BUILTIN(JavascriptSymbol, Description, EntryDescription, FunctionInfo::ErrorOnNew | FunctionInfo::HasNoSideEffect | FunctionInfo::CanBeHoisted)
 BUILTIN(JavascriptProxy, Revocable, EntryRevocable, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptProxy, Revoke, EntryRevoke, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptProxy, NewInstance, NewInstance, FunctionInfo::SkipDefaultNewObject)

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -2399,7 +2399,7 @@ namespace Js
 
     bool JavascriptLibrary::InitializeSymbolPrototype(DynamicObject* symbolPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
     {
-        typeHandler->Convert(symbolPrototype, mode, 5);
+        typeHandler->Convert(symbolPrototype, mode, 6);
         // Note: Any new function addition/deletion/modification should also be updated in JavascriptLibrary::ProfilerRegisterSymbol
         // so that the update is in sync with profiler
         JavascriptLibrary* library = symbolPrototype->GetLibrary();
@@ -2423,6 +2423,12 @@ namespace Js
                 &JavascriptSymbol::EntryInfo::SymbolToPrimitive, 1));
             symbolPrototype->SetWritable(PropertyIds::_symbolToPrimitive, false);
         }
+
+        if (scriptContext->GetConfig()->IsESSymbolDescriptionEnabled())
+        {
+            library->AddAccessorsToLibraryObject(symbolPrototype, PropertyIds::description, &JavascriptSymbol::EntryInfo::Description, nullptr);
+        }
+
         symbolPrototype->SetHasNoEnumerableProperties(true);
 
         return true;
@@ -7441,6 +7447,7 @@ namespace Js
         REG_OBJECTS_LIB_FUNC(toString, JavascriptSymbol::EntryToString);
         REG_OBJECTS_LIB_FUNC2(for_, _u("for"), JavascriptSymbol::EntryFor);
         REG_OBJECTS_LIB_FUNC(keyFor, JavascriptSymbol::EntryKeyFor);
+        REG_OBJECTS_LIB_FUNC(description, JavascriptSymbol::EntryDescription);
 
         return hr;
     }

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -202,6 +202,35 @@ namespace Js
         }
     }
 
+    // Symbol.prototype.description
+    Var JavascriptSymbol::EntryDescription(RecyclableObject* function, CallInfo callInfo, ...)
+    {
+        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+
+        ARGUMENTS(args, callInfo);
+        AssertMsg(args.Info.Count, "Should always have implicit 'this'.");
+        ScriptContext* scriptContext = function->GetScriptContext();
+
+        Assert(!(callInfo.Flags & CallFlags_New));
+
+        const PropertyRecord* val;
+        Var aValue = args[0];
+        if (VarIs<JavascriptSymbol>(aValue))
+        {
+            val = VarTo<JavascriptSymbol>(aValue)->GetValue();
+        }
+        else if (VarIs<JavascriptSymbolObject>(aValue))
+        {
+            val = VarTo<JavascriptSymbolObject>(aValue)->GetValue();
+        }
+        else
+        {
+            return TryInvokeRemotelyOrThrow(EntryDescription, scriptContext, args, JSERR_This_NeedSymbol, _u("Symbol.prototype.description"));
+        }
+
+        return scriptContext->GetPropertyString(val->GetPropertyId());
+    }
+
     RecyclableObject * JavascriptSymbol::CloneToScriptContext(ScriptContext* requestContext)
     {
         // PropertyRecords are per-ThreadContext so we can just create a new primitive wrapper

--- a/lib/Runtime/Library/JavascriptSymbol.h
+++ b/lib/Runtime/Library/JavascriptSymbol.h
@@ -36,6 +36,7 @@ namespace Js
             static FunctionInfo ToString;
             static FunctionInfo For;
             static FunctionInfo KeyFor;
+            static FunctionInfo Description;
 
             static FunctionInfo SymbolToPrimitive;
         };
@@ -46,6 +47,7 @@ namespace Js
         static Var EntryFor(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryKeyFor(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntrySymbolToPrimitive(RecyclableObject* function, CallInfo callInfo, ...);
+        static Var EntryDescription(RecyclableObject* function, CallInfo callInfo, ...);
 
         virtual BOOL Equals(Var other, BOOL* value, ScriptContext * requestContext) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;

--- a/test/DebuggerCommon/symbols.js.dbg.baseline
+++ b/test/DebuggerCommon/symbols.js.dbg.baseline
@@ -108,7 +108,8 @@
                 "Symbol.toStringTag": "string Symbol",
                 "valueOf": "function <large string>",
                 "toString": "function <large string>",
-                "Symbol.toPrimitive": "function <large string>"
+                "Symbol.toPrimitive": "function <large string>",
+                "description": "Error <large string>"
               },
               "name": "string Symbol",
               "hasInstance": "symbol <large string>",
@@ -180,7 +181,8 @@
               },
               "length": "number 1",
               "name": "string <large string>"
-            }
+            },
+            "description": "string symobject"
           }
         },
         "short symbol name": "symbol Symbol(s)",

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -95,4 +95,10 @@
       <tags>exclude_jshost</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>symboldescription.js</files>
+      <compile-flags>-ESSymbolDescription -args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/es7/symboldescription.js
+++ b/test/es7/symboldescription.js
@@ -1,0 +1,38 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Symbol.prototype.description API shape",
+        body: function () {
+            assert.isTrue(Symbol.prototype.hasOwnProperty('description'), "Symbol.prototype has a 'description' property");
+            
+            var descriptor = Object.getOwnPropertyDescriptor(Symbol.prototype, 'description');
+            assert.areEqual(undefined, descriptor.writable, "writable(description) isn't set");
+            assert.isFalse(descriptor.enumerable, "enumerable(description) must be false");
+            assert.isTrue(descriptor.configurable, "configurable(description) must be true");
+            
+            assert.areEqual('function', typeof descriptor.get, "Symbol.prototype.description is an accessor with a getter");
+            assert.areEqual(0, descriptor.get.length, "Symbol.prototype.description getter has length 0");
+            assert.areEqual("get description", descriptor.get.name, "Symbol.prototype.description getter has name 'get description'");
+            assert.areEqual(undefined, descriptor.set, "Symbol.prototype.description has no setter");
+        }
+    },
+    {
+        name: "Symbol.prototype.description functionality",
+        body: function () {
+            assert.areEqual('foo', Symbol('foo').description);
+            assert.areEqual('', Symbol('').description);
+            assert.areEqual('null', Symbol(null).description);
+            
+            assert.areEqual('', Symbol().description);
+            assert.areEqual('', Symbol(undefined).description);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es7/symboldescription.js
+++ b/test/es7/symboldescription.js
@@ -29,6 +29,9 @@ var tests = [
             assert.areEqual('', Symbol('').description);
             assert.areEqual('null', Symbol(null).description);
             
+            // Symbol().description === undefined;
+            // Should be true but we have a limitation in ChakraCore right now.
+            // See ##5833
             assert.areEqual('', Symbol().description);
             assert.areEqual('', Symbol(undefined).description);
         }


### PR DESCRIPTION
The proposal is stage 3 and shipping in Chrome, Firefox, and Safari stable.

Include a flag (-ESSymbolDescription) enabled by default.

See spec:
https://tc39.github.io/proposal-Symbol-description/

Fixes #5825
