### PR TITLE
Syntax error for module exporting undeclared name

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -317,7 +317,7 @@ protected:
     __declspec(noreturn) void Error(HRESULT hr, LPCWSTR stringOne = _u(""), LPCWSTR stringTwo = _u(""));
 private:
     __declspec(noreturn) void Error(HRESULT hr, ParseNodePtr pnode);
-    __declspec(noreturn) void Error(HRESULT hr, charcount_t ichMin, charcount_t ichLim);
+    __declspec(noreturn) void Error(HRESULT hr, charcount_t ichMin, charcount_t ichLim, LPCWSTR stringOne = _u(""), LPCWSTR stringTwo = _u(""));
     __declspec(noreturn) static void OutOfMemory();
 
     void EnsureStackAvailable();
@@ -641,11 +641,12 @@ protected:
     ModuleImportOrExportEntryList* EnsureModuleStarExportEntryList();
 
     void AddModuleSpecifier(IdentPtr moduleRequest);
-    ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, IdentPtr importName, IdentPtr localName, IdentPtr exportName, IdentPtr moduleRequest);
+    ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, IdentPtr importName, IdentPtr localName, IdentPtr exportName, IdentPtr moduleRequest, charcount_t offsetForError = 0);
     ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, ModuleImportOrExportEntry* importOrExportEntry);
     void AddModuleLocalExportEntry(ParseNodePtr varDeclNode);
     void CheckForDuplicateExportEntry(IdentPtr exportName);
     void CheckForDuplicateExportEntry(ModuleImportOrExportEntryList* exportEntryList, IdentPtr exportName);
+    void VerifyModuleLocalExportEntries();
 
     ParseNodeVar * CreateModuleImportDeclNode(IdentPtr localName);
 

--- a/lib/Parser/ParserCommon.h
+++ b/lib/Parser/ParserCommon.h
@@ -39,14 +39,17 @@ class ParseNodeFnc;
 typedef ParseNode *ParseNodePtr;
 
 struct Ident;
+struct PidRefStack;
 typedef Ident *IdentPtr;
 
 struct ModuleImportOrExportEntry
 {
-    IdentPtr moduleRequest;
-    IdentPtr importName;
-    IdentPtr localName;
-    IdentPtr exportName;
+    IdentPtr     moduleRequest;
+    IdentPtr     importName;
+    IdentPtr     localName;
+    IdentPtr     exportName;
+    PidRefStack* pidRefStack;
+    charcount_t  offset;
 };
 
 typedef SList<ModuleImportOrExportEntry, ArenaAllocator> ModuleImportOrExportEntryList;

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -112,6 +112,7 @@ LSC_ERROR_MSG(1096, ERRAwaitAsLabelInAsync, "Use of 'await' as label in async fu
 LSC_ERROR_MSG(1097, ERRExperimental, "Use of disabled experimental feature")
 LSC_ERROR_MSG(1098, ERRDuplicateExport, "Duplicate export of name '%s'")
 LSC_ERROR_MSG(1099, ERRStmtOfWithIsLabelledFunc, "The statement of a 'with' statement cannot be a labelled function.")
+LSC_ERROR_MSG(1100, ERRUndeclaredExportName, "Export of name '%s' which has no local definition.")
 //1100-1199 available for future use
 
 // Generic errors intended to be re-usable

--- a/test/es6module/module-syntax.js
+++ b/test/es6module/module-syntax.js
@@ -115,6 +115,8 @@ var tests = [
             testModuleScript(`do export default null
                                 while (false);`, 'Syntax error export in while', true);
             testModuleScript('function () { export default null; }', 'Syntax error export in function', true);
+            testModuleScript('export {foo}', 'Syntax error undefined export', true);
+            testModuleScript('export {Array}', 'Syntax error exporting a global name with no local definition', true);
         }
     },
     {


### PR DESCRIPTION
This PR causes CC to throw a syntax error when a module is parsed that exports a name with no local definition, this is per point 4 of https://tc39.github.io/ecma262/#sec-module-semantics-static-semantics-early-errors

@boingoing @pleath Thanks for the help with how to do this, please could one of you review?

fix: #5778