### PR TITLE
Reference error for assignment to import()

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -965,7 +965,7 @@ private:
     bool IsImportOrExportStatementValidHere();
     bool IsTopLevelModuleFunc();
 
-    template<bool buildAST> ParseNodePtr ParseImport();
+    template<bool buildAST> ParseNodePtr ParseImport(BOOL *pfCanAssign);
     template<bool buildAST> void ParseImportClause(ModuleImportOrExportEntryList* importEntryList, bool parsingAfterComma = false);
     template<bool buildAST> ParseNodePtr ParseImportCall();
 

--- a/test/es6module/dynamic-module-import-specifier.js
+++ b/test/es6module/dynamic-module-import-specifier.js
@@ -96,6 +96,26 @@ var tests = [
         }
     },
     {
+        name: "Reference errors for assignments to import() call",
+        body: function () {
+                let functionBody =
+                    `
+                    assert.throws(function () { eval("import('') ++"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') += 5"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') -= 5"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') --"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') = 2"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') <<= 2"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') >>= 2"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') >>>= 2"); }, ReferenceError);
+                    assert.throws(function () { eval("import('') **= 2"); }, ReferenceError);
+                    `;
+
+                testScript(functionBody, "Test reference errors for assignment to import()");
+                testModuleScript(functionBody, "Test reference errors for assignment to import()");
+        }
+    },
+    {
         name: "Module specifier that are not string",
         body: function () {
             var testNonStringSpecifier = function (specifier, expectedType, expectedErrMsg, message) {

--- a/test/es6module/module-syntax.js
+++ b/test/es6module/module-syntax.js
@@ -164,6 +164,8 @@ var tests = [
             testModuleScript(`do import { default } from "module"
                                 while (false);`, 'Syntax error export in while', true);
             testModuleScript('function () { import { default } from "module"; }', 'Syntax error export in function', true);
+            testModuleScript('import { default } from "module" ++ }', 'Syntax error assignment to import statement', true);
+            testModuleScript('import "module" ++ }', 'Syntax error assignment to import statement', true);
         }
     },
     {


### PR DESCRIPTION
This is hopefully a sufficiently neat fix to show the correct error type for assignments to import()

Note all of the cases this catches currently throw a syntax error but per spec should be throwing a reference error.

This has 17 test262 tests, the first 17 in this folder: https://github.com/tc39/test262/tree/master/test/language/expressions/dynamic-import/syntax/invalid

Fix: #5798