### PR TITLE
Special symbol var decls can be created in the wrong function

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1741,7 +1741,7 @@ ParseNodeVar * Parser::CreateSpecialVarDeclIfNeeded(ParseNodeFnc * pnodeFnc, Ide
     PidRefStack* ref = pid->GetTopRef();
 
     // If the function has a reference to pid or we set forceCreate, make a special var decl
-    if (forceCreate || (ref && ref->GetScopeId() >= m_currentBlockInfo->pnodeBlock->blockId))
+    if (forceCreate || (ref && (ref->GetScopeId() >= m_currentBlockInfo->pnodeBlock->blockId && ref->GetFuncScopeId() >= pnodeFnc->functionId)))
     {
         return this->CreateSpecialVarDeclNode(pnodeFnc, pid);
     }

--- a/test/Bugs/function_id_destructured_reparse.js
+++ b/test/Bugs/function_id_destructured_reparse.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    ({
+        p: o = ({
+            bar() {
+                (function () {})
+            }
+        },
+        (this))
+    } = 0)
+}
+test0()
+
+console.log('pass');

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -553,6 +553,13 @@
   </test>
   <test>
     <default>
+      <files>function_id_destructured_reparse.js</files>
+      <compile-flags>-useparserstatecache -parserstatecache -force:deferparse</compile-flags>
+      <tags>exclude_jshost</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug_5585.js</files>
       <compile-flags>-esdynamicimport -mutehosterrormsg -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
When we rollback the scanner and reparse a destructured object literal containing a function and the outer funtion has a special symbol reference, it is possible we will incorrectly create a var decl for the special symbol in the nested function.
