### PR TITLE
CheckIsFuncObj and CheckFuncInfo - Non fixed field bailout hoisting

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -4443,35 +4443,14 @@ Inline::SplitConstructorCallCommon(
 }
 
 void
-Inline::InsertObjectCheck(IR::RegOpnd * funcOpnd, IR::Instr* insertBeforeInstr, IR::Instr*bailOutIfNotObject)
+Inline::InsertFunctionObjectCheck(IR::RegOpnd * funcOpnd, IR::Instr *insertBeforeInstr, IR::Instr *bailOutInstr, const FunctionJITTimeInfo *funcInfo)
 {
-    // Bailout if 'functionRegOpnd' is not an object.
-    bailOutIfNotObject->SetSrc1(funcOpnd);
-    bailOutIfNotObject->SetByteCodeOffset(insertBeforeInstr);
-    insertBeforeInstr->InsertBefore(bailOutIfNotObject);
-}
+    Js::BuiltinFunction index = Js::JavascriptLibrary::GetBuiltInForFuncInfo(funcInfo->GetLocalFunctionId());
+    AssertMsg(index < Js::BuiltinFunction::Count, "Invalid built-in index on a call target marked as built-in");
 
-void
-Inline::InsertFunctionTypeIdCheck(IR::RegOpnd * funcOpnd, IR::Instr* insertBeforeInstr, IR::Instr* bailOutIfNotJsFunction)
-{
-    // functionTypeRegOpnd = Ld functionRegOpnd->type
-    IR::IndirOpnd *functionTypeIndirOpnd = IR::IndirOpnd::New(funcOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachPtr, insertBeforeInstr->m_func);
-    IR::RegOpnd *functionTypeRegOpnd = IR::RegOpnd::New(TyVar, this->topFunc);
-    IR::Instr *instr = IR::Instr::New(Js::OpCode::Ld_A, functionTypeRegOpnd, functionTypeIndirOpnd, insertBeforeInstr->m_func);
-    if(instr->m_func->HasByteCodeOffset())
-    {
-        instr->SetByteCodeOffset(insertBeforeInstr);
-    }
-    insertBeforeInstr->InsertBefore(instr);
-
-    CompileAssert(sizeof(Js::TypeId) == sizeof(int32));
-    // if (functionTypeRegOpnd->typeId != TypeIds_Function) goto $noInlineLabel
-    // BrNeq_I4 $noInlineLabel, functionTypeRegOpnd->typeId, TypeIds_Function
-    IR::IndirOpnd *functionTypeIdIndirOpnd = IR::IndirOpnd::New(functionTypeRegOpnd, Js::Type::GetOffsetOfTypeId(), TyInt32, insertBeforeInstr->m_func);
-    IR::IntConstOpnd *typeIdFunctionConstOpnd = IR::IntConstOpnd::New(Js::TypeIds_Function, TyInt32, insertBeforeInstr->m_func);
-    bailOutIfNotJsFunction->SetSrc1(functionTypeIdIndirOpnd);
-    bailOutIfNotJsFunction->SetSrc2(typeIdFunctionConstOpnd);
-    insertBeforeInstr->InsertBefore(bailOutIfNotJsFunction);
+    bailOutInstr->SetSrc1(funcOpnd);
+    bailOutInstr->SetSrc2(IR::IntConstOpnd::New(index, TyInt32, insertBeforeInstr->m_func));
+    insertBeforeInstr->InsertBefore(bailOutInstr);
 }
 
 void
@@ -4480,44 +4459,15 @@ Inline::InsertJsFunctionCheck(IR::Instr * callInstr, IR::Instr *insertBeforeInst
     // This function only inserts bailout for tagged int & TypeIds_Function.
     // As of now this is only used for polymorphic inlining.
     Assert(bailOutKind == IR::BailOutOnPolymorphicInlineFunction);
-
     Assert(insertBeforeInstr);
     Assert(insertBeforeInstr->m_func == callInstr->m_func);
 
-    IR::RegOpnd * funcOpnd = callInstr->GetSrc1()->AsRegOpnd();
-
-    // bailOutIfNotFunction is primary bailout instruction
-    IR::Instr* bailOutIfNotFunction = IR::BailOutInstr::New(Js::OpCode::BailOnNotEqual, bailOutKind, insertBeforeInstr, callInstr->m_func);
-
-    IR::Instr *bailOutIfNotObject = IR::BailOutInstr::New(Js::OpCode::BailOnNotObject, bailOutKind, bailOutIfNotFunction->GetBailOutInfo(), callInstr->m_func);
-    InsertObjectCheck(funcOpnd, insertBeforeInstr, bailOutIfNotObject);
-
-    InsertFunctionTypeIdCheck(funcOpnd, insertBeforeInstr, bailOutIfNotFunction);
-
-}
-
-void
-Inline::InsertFunctionInfoCheck(IR::RegOpnd * funcOpnd, IR::Instr *insertBeforeInstr, IR::Instr* bailoutInstr, const FunctionJITTimeInfo *funcInfo)
-{
-    // if (VarTo<JavascriptFunction>(r1)->functionInfo != funcInfo) goto noInlineLabel
-    // BrNeq_I4 noInlineLabel, r1->functionInfo, funcInfo
-    IR::IndirOpnd* opndFuncInfo = IR::IndirOpnd::New(funcOpnd, Js::JavascriptFunction::GetOffsetOfFunctionInfo(), TyMachPtr, insertBeforeInstr->m_func);
-    IR::AddrOpnd* inlinedFuncInfo = IR::AddrOpnd::New(funcInfo->GetFunctionInfoAddr(), IR::AddrOpndKindDynamicFunctionInfo, insertBeforeInstr->m_func);
-    bailoutInstr->SetSrc1(opndFuncInfo);
-    bailoutInstr->SetSrc2(inlinedFuncInfo);
-
-    insertBeforeInstr->InsertBefore(bailoutInstr);
-}
-
-void
-Inline::InsertFunctionObjectCheck(IR::RegOpnd * funcOpnd, IR::Instr *insertBeforeInstr, IR::Instr *bailOutInstr, const FunctionJITTimeInfo *funcInfo)
-{
-     Js::BuiltinFunction index = Js::JavascriptLibrary::GetBuiltInForFuncInfo(funcInfo->GetLocalFunctionId());
-    AssertMsg(index < Js::BuiltinFunction::Count, "Invalid built-in index on a call target marked as built-in");
-
-    bailOutInstr->SetSrc1(funcOpnd);
-    bailOutInstr->SetSrc2(IR::IntConstOpnd::New(index, TyInt32, insertBeforeInstr->m_func));
-    insertBeforeInstr->InsertBefore(bailOutInstr);
+    // Two bailout checks, an object check followed by a function type ID check, are required. These bailout instructions are created
+    // when lowering checkFunctionEntryPoint rather than being created here as checkFunctionEntryPoint can be hoisted outside of a loop.
+    IR::Instr *checkIsFuncObj = IR::BailOutInstr::New(Js::OpCode::CheckIsFuncObj, bailOutKind, insertBeforeInstr, callInstr->m_func);
+    checkIsFuncObj->SetSrc1(callInstr->GetSrc1()->AsRegOpnd());
+    checkIsFuncObj->SetByteCodeOffset(insertBeforeInstr);
+    insertBeforeInstr->InsertBefore(checkIsFuncObj);
 }
 
 IR::Instr *
@@ -4525,29 +4475,17 @@ Inline::PrepareInsertionPoint(IR::Instr *callInstr, const FunctionJITTimeInfo *f
 {
     Assert(insertBeforeInstr);
     Assert(insertBeforeInstr->m_func == callInstr->m_func);
-    IR::BailOutKind bailOutKind = IR::BailOutOnInlineFunction;
 
-    IR::RegOpnd * funcOpnd = callInstr->GetSrc1()->AsRegOpnd();
+    IR::Instr *checkFuncInfo = IR::BailOutInstr::New(Js::OpCode::CheckFuncInfo, IR::BailOutOnInlineFunction, insertBeforeInstr, callInstr->m_func);
+    checkFuncInfo->SetSrc1(callInstr->GetSrc1()->AsRegOpnd());
 
-    // FunctionBody check is the primary bailout instruction, create it first
-    IR::BailOutInstr* primaryBailOutInstr = IR::BailOutInstr::New(Js::OpCode::BailOnNotEqual, bailOutKind, insertBeforeInstr, callInstr->m_func);
-    primaryBailOutInstr->SetByteCodeOffset(insertBeforeInstr);
+    IR::AddrOpnd* inlinedFuncInfo = IR::AddrOpnd::New(funcInfo->GetFunctionInfoAddr(), IR::AddrOpndKindDynamicFunctionInfo, insertBeforeInstr->m_func);
+    checkFuncInfo->SetSrc2(inlinedFuncInfo);
 
-    // 1. Bailout if function object is not an object.
-    IR::Instr *bailOutIfNotObject = IR::BailOutInstr::New(Js::OpCode::BailOnNotObject,
-                                                          bailOutKind,
-                                                          primaryBailOutInstr->GetBailOutInfo(),
-                                                          callInstr->m_func);
-    InsertObjectCheck(funcOpnd, insertBeforeInstr, bailOutIfNotObject);
+    checkFuncInfo->SetByteCodeOffset(insertBeforeInstr);
+    insertBeforeInstr->InsertBefore(checkFuncInfo);
 
-    // 2. Bailout if function object is not a TypeId_Function
-    IR::Instr* bailOutIfNotJsFunction = IR::BailOutInstr::New(Js::OpCode::BailOnNotEqual, bailOutKind, primaryBailOutInstr->GetBailOutInfo(), callInstr->m_func);
-    InsertFunctionTypeIdCheck(funcOpnd, insertBeforeInstr, bailOutIfNotJsFunction);
-
-    // 3. Bailout if function body doesn't match funcInfo
-    InsertFunctionInfoCheck(funcOpnd, insertBeforeInstr, primaryBailOutInstr, funcInfo);
-
-    return primaryBailOutInstr;
+    return checkFuncInfo;
 }
 
 IR::ByteCodeUsesInstr*

--- a/lib/Backend/Inline.h
+++ b/lib/Backend/Inline.h
@@ -153,10 +153,7 @@ private:
     void SetInlineeFrameStartSym(Func *inlinee, uint actualCount);
     void CloneCallSequence(IR::Instr* callInstr, IR::Instr* clonedCallInstr);
 
-    void InsertObjectCheck(IR::RegOpnd * funcOpnd, IR::Instr* insertBeforeInstr, IR::Instr*bailOutInstr);
-    void InsertFunctionTypeIdCheck(IR::RegOpnd * funcOpnd, IR::Instr* insertBeforeInstr, IR::Instr*bailOutInstr);
     void InsertJsFunctionCheck(IR::Instr * callInstr, IR::Instr *insertBeforeInstr, IR::BailOutKind bailOutKind);
-    void InsertFunctionInfoCheck(IR::RegOpnd * funcOpnd, IR::Instr *insertBeforeInstr, IR::Instr* bailoutInstr, const FunctionJITTimeInfo *funcInfo);
     void InsertFunctionObjectCheck(IR::RegOpnd * funcOpnd, IR::Instr *insertBeforeInstr, IR::Instr* bailoutInstr, const FunctionJITTimeInfo *funcInfo);
 
     void TryResetObjTypeSpecFldInfoOn(IR::PropertySymOpnd* propertySymOpnd);

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -565,6 +565,7 @@ private:
     IR::Instr *     LowerBailOnNotPolymorphicInlinee(IR::Instr * instr);
     IR::Instr *     LowerBailOnNotStackArgs(IR::Instr * instr);
     IR::Instr *     LowerBailOnNotObject(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
+    IR::Instr *     LowerCheckIsFuncObj(IR::Instr *instr, bool checkFuncInfo = false);
     IR::Instr *     LowerBailOnTrue(IR::Instr *instr, IR::LabelInstr *labelBailOut = nullptr);
     IR::Instr *     LowerBailOnNotBuiltIn(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
     IR::Instr *     LowerBailOnNotInteger(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
@@ -799,6 +800,11 @@ private:
 
     IR::LabelInstr* InsertLoopTopLabel(IR::Instr * insertBeforeInstr);
     IR::Instr *     AddBailoutToHelperCallInstr(IR::Instr * helperCallInstr, BailOutInfo * bailoutInfo, IR::BailOutKind  bailoutKind, IR::Instr * primaryBailoutInstr);
+
+    IR::Instr* InsertObjectCheck(IR::RegOpnd *funcOpnd, IR::Instr *insertBeforeInstr, IR::BailOutKind bailOutKind, BailOutInfo *bailOutInfo);
+    IR::Instr* InsertFunctionTypeIdCheck(IR::RegOpnd *funcOpnd, IR::Instr *insertBeforeInstr, IR::BailOutKind bailOutKind, BailOutInfo *bailOutInfo);
+    IR::Instr* InsertFunctionInfoCheck(IR::RegOpnd *funcOpnd, IR::Instr *insertBeforeInstr, IR::AddrOpnd *inlinedFuncInfo, IR::BailOutKind bailOutKind, BailOutInfo *bailOutInfo);
+
 public:
     static IRType   GetImplicitCallFlagsType()
     {

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -771,6 +771,8 @@ MACRO_BACKEND_ONLY(     InlineRegExpExec,    Empty,          OpSideEffect|OpInli
 
 MACRO_BACKEND_ONLY(     CallIFixed,          Empty,          OpSideEffect|OpUseAllFields|OpCallInstr|OpInlineCallInstr)
 MACRO_BACKEND_ONLY(     CheckFixedFld,       Empty,          OpFastFldInstr|OpTempObjectSources|OpCanCSE)
+MACRO_BACKEND_ONLY(     CheckIsFuncObj,      Empty,          OpCanCSE | OpBailOutRec)
+MACRO_BACKEND_ONLY(     CheckFuncInfo,       Empty,          OpCanCSE | OpBailOutRec)
 MACRO_BACKEND_ONLY(     CheckPropertyGuardAndLoadType,  Empty,          OpFastFldInstr|OpTempObjectSources|OpDoNotTransfer)
 MACRO_BACKEND_ONLY(     CheckObjType,        Empty,          OpFastFldInstr|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     AdjustObjType,       Empty,          OpSideEffect)

--- a/test/FixedFields/NonFixedFieldHoist.baseline
+++ b/test/FixedFields/NonFixedFieldHoist.baseline
@@ -1,0 +1,3 @@
+-489500
+TypeError: Function expected
+TypeError: Object doesn't support property or method 'foo'

--- a/test/FixedFields/NonFixedFieldHoist.js
+++ b/test/FixedFields/NonFixedFieldHoist.js
@@ -1,0 +1,44 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo(a,b){ return a + b; }
+function bar(a,b){ return a - b; }
+
+var obj = {};
+obj.foo = foo;
+
+function test(obj)
+{
+    var count = 0;
+
+    for (var i = 0; i < 1000; i++)
+    {
+        count += obj.foo(10, i);
+    }
+
+    return count;
+}
+
+obj.foo = bar;
+WScript.Echo(test(obj));
+obj.foo = 10;
+try
+{
+    WScript.Echo(test(obj));
+}
+catch(e)
+{
+    WScript.Echo(e);
+}
+
+var obj2 = {};
+try
+{
+    WScript.Echo(test(obj2));
+}
+catch(e)
+{
+    WScript.Echo(e);
+}

--- a/test/FixedFields/rlexe.xml
+++ b/test/FixedFields/rlexe.xml
@@ -2,6 +2,19 @@
 <regress-exe>
   <test>
     <default>
+      <files>NonFixedFieldHoist.js</files>
+      <baseline>NonFixedFieldHoist.baseline</baseline>
+      <compile-flags>-maxinterpretcount:1 -bgjit- -off:simplejit</compile-flags>
+    </default>
+  </test>
+    <test>
+    <default>
+      <files>NonFixedFieldHoist.js</files>
+      <baseline>NonFixedFieldHoist.baseline</baseline>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>FixedFieldsOnSingletons.js</files>
       <baseline>FixedFieldsOnSingletons.baseline</baseline>
     </default>


### PR DESCRIPTION
This optimization groups bailout instrs (created by the inliner when a non fixed field is called) into a single instr (CheckFunctionEntryPoint) which can be hoisted outside of a loop.

This is still a work in progress, I am making a PR for review.

Benchmark:

```
function benchMark(monomorphic)
{
    function foo(a,b){ return a + b; }
    function bar(a,b){ return a - b; }
    
    var obj = {foo: foo};
    
    function test(obj)
    {
        var count = 0;
        for (var i = 0; i < 10000; i++)
        {
            // must check type of non fixed field
            count += obj.foo(10, i);
        }
        return count;
    }
    
    if(!monomorphic) test(obj);
    
    obj.foo = bar;
    
    var start = new Date();
    for (var i = 0; i < 50000; i++) test(obj);
    var end = new Date();
    
    print(end-start);
}
var monomorphic = true;
benchMark(monomorphic);
```

monomorphic == true with optimization: ~237
monomorphic == true without optimization: ~351

monomorphic == false with optimization: ~472
monomorphic  == false without optimization: ~581

Kraken benchmark:
```
TEST - NATIVE                BASE            TEST         DIFF   RATIO(%)
---------------------------------------------------------------------------
ai-astar                 1255.3 +-1.1%  1248.1 +-0.6%     -7.2   -0.6%
audio-beat-detection       82.3 +-1.9%    80.8 +-2.3%     -1.6   -1.9%
audio-dft                  83.3 +-14.2%   75.3 +-2.4%     -8.0   -9.6%
audio-fft                  72.0 +-9.6%    65.3 +-0.7%     -6.7   -9.3%
audio-oscillator           87.0 +-5.2%    82.7 +-2.1%     -4.3   -5.0%
imaging-darkroom          100.0 +-1.7%   100.9 +-3.1%      0.9    0.9%
imaging-desaturate         80.8 +-1.5%    79.8 +-1.1%     -1.0   -1.2%
imaging-gaussian-blur      94.2 +-2.2%    92.1 +-2.0%     -2.1   -2.2%
json-parse-financial       27.0 +-2.5%    27.7 +-4.2%      0.7    2.5%
json-stringify-tinderbox   19.1 +-1.6%    19.0 +-0.0%     -0.1   -0.6%
stanford-crypto-aes       102.0 +-1.6%   101.6 +-2.2%     -0.4   -0.4%
stanford-crypto-ccm        68.4 +-2.3%    69.7 +-3.3%      1.2    1.8%
stanford-crypto-pbkdf2    106.3 +-1.4%   104.9 +-0.9%     -1.4   -1.4%
stanford-crypto-sha256-i   34.2 +-1.8%    34.0 +-2.0%     -0.2   -0.6%
---------------------------------------------------------------------------
TOTAL TIME               2212.1 +-2.2%  2181.8 +-1.2%    -30.3   -1.4%
```