### PR TITLE
Non-breaking revision to JsSetModuleHostInfo per #5875

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -419,7 +419,7 @@ JsErrorCode WScriptJsrt::InitializeModuleInfo(JsValueRef specifier, JsModuleReco
         {
             errorCode = ChakraRTInterface::JsSetModuleHostInfo(moduleRecord, JsModuleHostInfo_NotifyModuleReadyCallback, (void*)WScriptJsrt::NotifyModuleReadyCallback);
 
-            if (errorCode == JsNoError)
+            if (errorCode == JsNoError && moduleRecord != nullptr)
             {
                 errorCode = ChakraRTInterface::JsSetModuleHostInfo(moduleRecord, JsModuleHostInfo_HostDefined, specifier);
             }
@@ -1130,14 +1130,7 @@ Error:
 
 JsErrorCode WScriptJsrt::InitializeModuleCallbacks()
 {
-    JsModuleRecord moduleRecord = JS_INVALID_REFERENCE;
-    JsErrorCode errorCode = ChakraRTInterface::JsInitializeModuleRecord(nullptr, nullptr, &moduleRecord);
-    if (errorCode == JsNoError)
-    {
-        errorCode = InitializeModuleInfo(nullptr, moduleRecord);
-    }
-
-    return errorCode;
+    return InitializeModuleInfo(nullptr, nullptr);
 }
 
 bool WScriptJsrt::Uninitialize()

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -310,8 +310,10 @@ JsModuleEvaluation(
 /// <remarks>
 ///     This is used for four things:
 ///     1. Setting up the callbacks for module loading - note these are actually
-///         set on the current Context not the module so only have to be set for
-///         the first root module in any given context.
+///         set on the module's Context not the module itself so only have to be set
+///         for the first root module in any given context.
+///         Alternatively you can set these on the currentContext by supplying a nullptr
+///         as the requestModule
 ///     2. Setting host defined info on a module record - can be anything that
 ///         you wish to associate with your modules.
 ///     3. Setting a URL for a module to be used for stack traces/debugging -
@@ -319,7 +321,7 @@ JsModuleEvaluation(
 ///         or it will be ignored.
 ///     4. Setting an exception on the module object - only relevant prior to it being Parsed.
 /// </remarks>
-/// <param name="requestModule">The request module.</param>
+/// <param name="requestModule">The request module, optional for setting callbacks, required for other uses.</param>
 /// <param name="moduleHostInfo">The type of host info to be set.</param>
 /// <param name="hostInfo">The host info to be set.</param>
 /// <returns>
@@ -327,7 +329,7 @@ JsModuleEvaluation(
 /// </returns>
 CHAKRA_API
 JsSetModuleHostInfo(
-    _In_ JsModuleRecord requestModule,
+    _In_opt_ JsModuleRecord requestModule,
     _In_ JsModuleHostInfoKind moduleHostInfo,
     _In_ void* hostInfo);
 


### PR DESCRIPTION
This change allows a nullptr  to be supplied as requestModule in JsSetModuleHostInfo in order to use the currentContext when setting callbacks. This means that an embedder can setup module loading callbacks including the dynamic import from script callback without needing a throw away module record.

Note I have updated ch to use this new mechanism whilst leaving the native tests that use the old mechanism untouched so that both options are tested, one by ch and the other by the native tests.

CC: @liminzhu 

closes #5875 