### PR TITLE
WebAssembly.Memory & Table consctructor spec compliance

### DIFF
--- a/lib/Runtime/Library/WebAssembly.cpp
+++ b/lib/Runtime/Library/WebAssembly.cpp
@@ -288,12 +288,18 @@ Var WebAssembly::TryResolveResponse(RecyclableObject* function, Var thisArg, Var
 uint32
 WebAssembly::ToNonWrappingUint32(Var val, ScriptContext * ctx)
 {
-    double i = JavascriptConversion::ToInteger(val, ctx);
-    if (i < 0 || i > (double)UINT32_MAX)
+    double i = JavascriptConversion::ToNumber(val, ctx);
+    if (
+        JavascriptNumber::IsNan(i) ||
+        JavascriptNumber::IsPosInf(i) ||
+        JavascriptNumber::IsNegInf(i) ||
+        i < 0 ||
+        i > (double)UINT32_MAX
+    )
     {
-        JavascriptError::ThrowRangeError(ctx, JSERR_ArgumentOutOfRange);
+        JavascriptError::ThrowTypeError(ctx, JSERR_NeedNumber);
     }
-    return (uint32)i;
+    return (uint32)JavascriptConversion::ToInteger(i);
 }
 
 void

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -22,22 +22,33 @@ WebAssemblyMemory::WebAssemblyMemory(ArrayBufferBase* buffer, uint32 initial, ui
 }
 
 
-_Must_inspect_result_ bool WebAssemblyMemory::AreLimitsValid(uint32 initial, uint32 maximum)
+void WebAssemblyMemory::CheckLimits(ScriptContext * scriptContext, uint32 initial, uint32 maximum)
 {
-    return initial <= maximum && initial <= Wasm::Limits::GetMaxMemoryInitialPages() && maximum <= Wasm::Limits::GetMaxMemoryMaximumPages();
+    if (maximum < initial)
+    {
+        JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
+    }
+    if (initial > Wasm::Limits::GetMaxMemoryInitialPages())
+    {
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid, _u("descriptor.initial"));
+    }
+    if (maximum > Wasm::Limits::GetMaxMemoryMaximumPages())
+    {
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid, _u("descriptor.maximum"));
+    }
 }
 
 
-_Must_inspect_result_ bool WebAssemblyMemory::AreLimitsValid(uint32 initial, uint32 maximum, uint32 bufferLength)
+void WebAssemblyMemory::CheckLimits(ScriptContext * scriptContext, uint32 initial, uint32 maximum, uint32 bufferLength)
 {
-    if (!AreLimitsValid(initial, maximum))
-    {
-        return false;
-    }
+    CheckLimits(scriptContext, initial, maximum);
     // Do the mul after initial checks to avoid potential unneeded OOM exception
     const uint32 initBytes = UInt32Math::Mul<WebAssembly::PageSize>(initial);
     const uint32 maxBytes = UInt32Math::Mul<WebAssembly::PageSize>(maximum);
-    return initBytes <= bufferLength && bufferLength <= maxBytes;
+    if (initBytes > bufferLength || bufferLength > maxBytes)
+    {
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid);
+    }
 }
 
 Var
@@ -60,10 +71,14 @@ WebAssemblyMemory::NewInstance(RecyclableObject* function, CallInfo callInfo, ..
 
     if (args.Info.Count < 2 || !JavascriptOperators::IsObject(args[1]))
     {
-        JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject, _u("memoryDescriptor"));
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject, _u("descriptor"));
     }
     DynamicObject * memoryDescriptor = VarTo<DynamicObject>(args[1]);
 
+    if (!JavascriptOperators::OP_HasProperty(memoryDescriptor, PropertyIds::initial, scriptContext))
+    {
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedNumber, _u("descriptor.initial"));
+    }
     Var initVar = JavascriptOperators::OP_GetProperty(memoryDescriptor, PropertyIds::initial, scriptContext);
     uint32 initial = WebAssembly::ToNonWrappingUint32(initVar, scriptContext);
 
@@ -271,10 +286,7 @@ WebAssemblyMemory::EntryGetterBuffer(RecyclableObject* function, CallInfo callIn
 WebAssemblyMemory *
 WebAssemblyMemory::CreateMemoryObject(uint32 initial, uint32 maximum, bool isShared, ScriptContext * scriptContext)
 {
-    if (!AreLimitsValid(initial, maximum))
-    {
-        JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
-    }
+    CheckLimits(scriptContext, initial, maximum);
     uint32 byteLength = UInt32Math::Mul<WebAssembly::PageSize>(initial);
     ArrayBufferBase* buffer = nullptr;
 #ifdef ENABLE_WASM_THREADS
@@ -300,10 +312,7 @@ WebAssemblyMemory::CreateMemoryObject(uint32 initial, uint32 maximum, bool isSha
 
 WebAssemblyMemory * WebAssemblyMemory::CreateForExistingBuffer(uint32 initial, uint32 maximum, uint32 currentByteLength, ScriptContext * scriptContext)
 {
-    if (!AreLimitsValid(initial, maximum, currentByteLength))
-    {
-        JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
-    }
+    CheckLimits(scriptContext, initial, maximum, currentByteLength);
     ArrayBufferBase* buffer = scriptContext->GetLibrary()->CreateWebAssemblyArrayBuffer(currentByteLength);
     Assert(buffer);
     if (currentByteLength > 0 && buffer->GetByteLength() == 0)
@@ -317,10 +326,11 @@ WebAssemblyMemory * WebAssemblyMemory::CreateForExistingBuffer(uint32 initial, u
 #ifdef ENABLE_WASM_THREADS
 WebAssemblyMemory * WebAssemblyMemory::CreateFromSharedContents(uint32 initial, uint32 maximum, SharedContents* sharedContents, ScriptContext * scriptContext)
 {
-    if (!sharedContents || !AreLimitsValid(initial, maximum, sharedContents->bufferLength))
+    if (!sharedContents)
     {
-        JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid);
     }
+    CheckLimits(scriptContext, initial, maximum, sharedContents->bufferLength);
     ArrayBufferBase* buffer = scriptContext->GetLibrary()->CreateWebAssemblySharedArrayBuffer(sharedContents);
     return RecyclerNewFinalized(scriptContext->GetRecycler(), WebAssemblyMemory, buffer, initial, maximum, scriptContext->GetLibrary()->GetWebAssemblyMemoryType());
 }

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -50,8 +50,8 @@ namespace Js
 #endif
     private:
         WebAssemblyMemory(ArrayBufferBase* buffer, uint32 initial, uint32 maximum, DynamicType * type);
-        static _Must_inspect_result_ bool AreLimitsValid(uint32 initial, uint32 maximum);
-        static _Must_inspect_result_ bool AreLimitsValid(uint32 initial, uint32 maximum, uint32 bufferLength);
+        static void CheckLimits(ScriptContext * scriptContext, uint32 initial, uint32 maximum);
+        static void CheckLimits(ScriptContext * scriptContext, uint32 initial, uint32 maximum, uint32 bufferLength);
 
         Field(ArrayBufferBase*) m_buffer;
 

--- a/lib/Runtime/Library/WebAssemblyTable.cpp
+++ b/lib/Runtime/Library/WebAssemblyTable.cpp
@@ -46,7 +46,8 @@ WebAssemblyTable::NewInstance(RecyclableObject* function, CallInfo callInfo, ...
     DynamicObject * tableDescriptor = VarTo<DynamicObject>(args[1]);
 
     Var elementVar = JavascriptOperators::OP_GetProperty(tableDescriptor, PropertyIds::element, scriptContext);
-    if (!JavascriptOperators::StrictEqualString(elementVar, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("anyfunc"))))
+    auto elementStr = JavascriptConversion::ToString(elementVar, scriptContext);
+    if (!JavascriptOperators::StrictEqualString(elementStr, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("anyfunc"))))
     {
         JavascriptError::ThrowTypeError(scriptContext, WASMERR_ExpectedAnyFunc, _u("tableDescriptor.element"));
     }
@@ -55,9 +56,9 @@ WebAssemblyTable::NewInstance(RecyclableObject* function, CallInfo callInfo, ...
     uint32 initial = WebAssembly::ToNonWrappingUint32(initVar, scriptContext);
 
     uint32 maximum = Wasm::Limits::GetMaxTableSize();
-    if (JavascriptOperators::OP_HasProperty(tableDescriptor, PropertyIds::maximum, scriptContext))
+    Var maxVar = JavascriptOperators::OP_GetProperty(tableDescriptor, PropertyIds::maximum, scriptContext);
+    if (!JavascriptOperators::IsUndefined(maxVar))
     {
-        Var maxVar = JavascriptOperators::OP_GetProperty(tableDescriptor, PropertyIds::maximum, scriptContext);
         maximum = WebAssembly::ToNonWrappingUint32(maxVar, scriptContext);
     }
     return Create(initial, maximum, scriptContext);

--- a/test/WasmSpec/baselines/testsuite/js-api/memory/constructor.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/memory/constructor.any.baseline
@@ -1,25 +1,25 @@
 Harness Status: OK
-Found 24 tests: Pass = 9 Fail = 15
+Found 24 tests: Pass = 24
 Pass name  
 Pass length  
 Pass No arguments  
 Pass Calling  
-Fail Invalid descriptor argument  assert_throws: new Memory(object "[object Object]") function "() => new WebAssembly.Memory(invalidArgument)" did not throw
-Fail Undefined initial value in descriptor  assert_throws: function "() => new WebAssembly.Memory({ "initial": undefined })" did not throw
-Fail Out-of-range initial value in descriptor: NaN  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" did not throw
-Fail Out-of-range maximum value in descriptor: NaN  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" did not throw
-Fail Out-of-range initial value in descriptor: Infinity  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: Infinity  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: -Infinity  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: -Infinity  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: -1  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: -1  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: 4294967296  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: 4294967296  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: 68719476736  assert_throws: function "() => new WebAssembly.Memory({ "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: 68719476736  assert_throws: function "() => new WebAssembly.Memory({ "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
+Pass Invalid descriptor argument  
+Pass Undefined initial value in descriptor  
+Pass Out-of-range initial value in descriptor: NaN  
+Pass Out-of-range maximum value in descriptor: NaN  
+Pass Out-of-range initial value in descriptor: Infinity  
+Pass Out-of-range maximum value in descriptor: Infinity  
+Pass Out-of-range initial value in descriptor: -Infinity  
+Pass Out-of-range maximum value in descriptor: -Infinity  
+Pass Out-of-range initial value in descriptor: -1  
+Pass Out-of-range maximum value in descriptor: -1  
+Pass Out-of-range initial value in descriptor: 4294967296  
+Pass Out-of-range maximum value in descriptor: 4294967296  
+Pass Out-of-range initial value in descriptor: 68719476736  
+Pass Out-of-range maximum value in descriptor: 68719476736  
 Pass Initial value exceeds maximum  
-Fail Proxy descriptor  assert_unreached: Should not call [[HasProperty]] with maximum Reached unreachable code
+Pass Proxy descriptor  
 Pass Order of evaluation for descriptor  
 Pass Zero initial  
 Pass Non-zero initial  

--- a/test/WasmSpec/baselines/testsuite/js-api/memory/grow.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/memory/grow.any.baseline
@@ -1,6 +1,6 @@
 Harness Status: OK
-Found 18 tests: Fail = 10 Pass = 8
-Fail Missing arguments  assert_throws: function "() => memory.grow()" did not throw
+Found 18 tests: Pass = 18
+Pass Missing arguments  
 Pass Branding  
 Pass Zero initial  
 Pass Zero initial with valueOf  
@@ -8,13 +8,13 @@ Pass Non-zero initial
 Pass Zero initial with respected maximum  
 Pass Zero initial with respected maximum grown twice  
 Pass Zero initial growing too much  
-Fail Out-of-range argument: undefined  assert_throws: function "() => memory.grow(value)" did not throw
-Fail Out-of-range argument: NaN  assert_throws: function "() => memory.grow(value)" did not throw
-Fail Out-of-range argument: Infinity  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: -Infinity  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: -1  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: 4294967296  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: 68719476736  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: "0x100000000"  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: object "[object Object]"  assert_throws: function "() => memory.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
+Pass Out-of-range argument: undefined  
+Pass Out-of-range argument: NaN  
+Pass Out-of-range argument: Infinity  
+Pass Out-of-range argument: -Infinity  
+Pass Out-of-range argument: -1  
+Pass Out-of-range argument: 4294967296  
+Pass Out-of-range argument: 68719476736  
+Pass Out-of-range argument: "0x100000000"  
+Pass Out-of-range argument: object "[object Object]"  
 Pass Stray argument  

--- a/test/WasmSpec/baselines/testsuite/js-api/table/constructor.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/table/constructor.any.baseline
@@ -1,25 +1,25 @@
 Harness Status: OK
-Found 27 tests: Pass = 11 Fail = 16
+Found 27 tests: Pass = 24 Fail = 3
 Pass name  
 Pass length  
 Pass No arguments  
 Pass Calling  
 Pass Empty descriptor  
 Pass Invalid descriptor argument  
-Fail Undefined initial value in descriptor  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": undefined })" did not throw
+Pass Undefined initial value in descriptor  
 Pass Undefined element value in descriptor  
-Fail Out-of-range initial value in descriptor: NaN  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" did not throw
-Fail Out-of-range maximum value in descriptor: NaN  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" did not throw
-Fail Out-of-range initial value in descriptor: Infinity  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: Infinity  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: -Infinity  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: -Infinity  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: -1  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: -1  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: 4294967296  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: 4294967296  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range initial value in descriptor: 68719476736  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range maximum value in descriptor: 68719476736  assert_throws: function "() => new WebAssembly.Table({ "element": "anyfunc", "initial": 0, "maximum": value })" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
+Pass Out-of-range initial value in descriptor: NaN  
+Pass Out-of-range maximum value in descriptor: NaN  
+Pass Out-of-range initial value in descriptor: Infinity  
+Pass Out-of-range maximum value in descriptor: Infinity  
+Pass Out-of-range initial value in descriptor: -Infinity  
+Pass Out-of-range maximum value in descriptor: -Infinity  
+Pass Out-of-range initial value in descriptor: -1  
+Pass Out-of-range maximum value in descriptor: -1  
+Pass Out-of-range initial value in descriptor: 4294967296  
+Pass Out-of-range maximum value in descriptor: 4294967296  
+Pass Out-of-range initial value in descriptor: 68719476736  
+Pass Out-of-range maximum value in descriptor: 68719476736  
 Pass Initial value exceeds maximum  
 Pass Basic (zero)  
 Pass Basic (non-zero)  

--- a/test/WasmSpec/baselines/testsuite/js-api/table/constructor.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/table/constructor.any.baseline
@@ -1,5 +1,5 @@
 Harness Status: OK
-Found 27 tests: Pass = 24 Fail = 3
+Found 27 tests: Pass = 27
 Pass name  
 Pass length  
 Pass No arguments  
@@ -24,6 +24,6 @@ Pass Initial value exceeds maximum
 Pass Basic (zero)  
 Pass Basic (non-zero)  
 Pass Stray argument  
-Fail Proxy descriptor  assert_unreached: Should not call [[HasProperty]] with maximum Reached unreachable code
-Fail Type conversion for descriptor.element  tableDescriptor.element is not AnyFunc
-Fail Order of evaluation for descriptor  tableDescriptor.element is not AnyFunc
+Pass Proxy descriptor  
+Pass Type conversion for descriptor.element  
+Pass Order of evaluation for descriptor  

--- a/test/WasmSpec/baselines/testsuite/js-api/table/get-set.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/table/get-set.any.baseline
@@ -1,32 +1,32 @@
 Harness Status: OK
-Found 30 tests: Fail = 26 Pass = 4
-Fail Missing arguments: get  assert_throws: function "() => table.get()" did not throw
+Found 30 tests: Pass = 29 Fail = 1
+Pass Missing arguments: get  
 Pass Branding: get  
 Pass Missing arguments: set  
 Pass Branding: set  
-Fail Basic  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Growing  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-bounds  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting non-function  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting non-wasm function  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting non-wasm arrow function  assert_throws: undefined: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: undefined  assert_throws: function "() => table.get(value)" did not throw
-Fail Setting out-of-range argument: undefined  assert_throws: function "() => table.set(value, null)" did not throw
-Fail Getting out-of-range argument: NaN  assert_throws: function "() => table.get(value)" did not throw
-Fail Setting out-of-range argument: NaN  assert_throws: function "() => table.set(value, null)" did not throw
-Fail Getting out-of-range argument: Infinity  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: Infinity  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: -Infinity  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: -Infinity  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: -1  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: -1  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: 4294967296  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: 4294967296  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: 68719476736  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: 68719476736  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: "0x100000000"  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: "0x100000000"  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Getting out-of-range argument: object "[object Object]"  assert_throws: function "() => table.get(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Setting out-of-range argument: object "[object Object]"  assert_throws: function "() => table.set(value, null)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
+Pass Basic  
+Pass Growing  
+Pass Setting out-of-bounds  
+Pass Setting non-function  
+Pass Setting non-wasm function  
+Pass Setting non-wasm arrow function  
+Pass Getting out-of-range argument: undefined  
+Pass Setting out-of-range argument: undefined  
+Pass Getting out-of-range argument: NaN  
+Pass Setting out-of-range argument: NaN  
+Pass Getting out-of-range argument: Infinity  
+Pass Setting out-of-range argument: Infinity  
+Pass Getting out-of-range argument: -Infinity  
+Pass Setting out-of-range argument: -Infinity  
+Pass Getting out-of-range argument: -1  
+Pass Setting out-of-range argument: -1  
+Pass Getting out-of-range argument: 4294967296  
+Pass Setting out-of-range argument: 4294967296  
+Pass Getting out-of-range argument: 68719476736  
+Pass Setting out-of-range argument: 68719476736  
+Pass Getting out-of-range argument: "0x100000000"  
+Pass Setting out-of-range argument: "0x100000000"  
+Pass Getting out-of-range argument: object "[object Object]"  
+Pass Setting out-of-range argument: object "[object Object]"  
 Fail Order of argument conversion  assert_equals: expected 1 but got 0
 Pass Stray argument  

--- a/test/WasmSpec/baselines/testsuite/js-api/table/grow.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/table/grow.any.baseline
@@ -1,17 +1,17 @@
 Harness Status: OK
-Found 15 tests: Fail = 14 Pass = 1
-Fail Missing arguments  assert_throws: function "() => table.grow()" did not throw
+Found 15 tests: Pass = 15
+Pass Missing arguments  
 Pass Branding  
-Fail Basic  assert_throws: before: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Reached maximum  assert_throws: before: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Exceeded maximum  assert_throws: before: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: undefined  assert_throws: function "() => table.grow(value)" did not throw
-Fail Out-of-range argument: NaN  assert_throws: function "() => table.grow(value)" did not throw
-Fail Out-of-range argument: Infinity  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: -Infinity  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: -1  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: 4294967296  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: 68719476736  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: "0x100000000"  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Out-of-range argument: object "[object Object]"  assert_throws: function "() => table.grow(value)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
-Fail Stray argument  assert_throws: before: table.get(-1) function "() => table.get(-1)" threw object "RangeError: argument out of range" ("RangeError") expected object "TypeError" ("TypeError")
+Pass Basic  
+Pass Reached maximum  
+Pass Exceeded maximum  
+Pass Out-of-range argument: undefined  
+Pass Out-of-range argument: NaN  
+Pass Out-of-range argument: Infinity  
+Pass Out-of-range argument: -Infinity  
+Pass Out-of-range argument: -1  
+Pass Out-of-range argument: 4294967296  
+Pass Out-of-range argument: 68719476736  
+Pass Out-of-range argument: "0x100000000"  
+Pass Out-of-range argument: object "[object Object]"  
+Pass Stray argument  

--- a/test/wasm/api.js
+++ b/test/wasm/api.js
@@ -403,7 +403,7 @@ async function testTableApi(baseModule) {
   console.log(`call_i32(29): ${call_i32(29)}`);
   console.log(`call_i32(30): ${call_i32(30)}`);
 
-  const table2 = new WebAssembly.Table({element: "anyfunc"});
+  const table2 = new WebAssembly.Table({element: "anyfunc", initial: 0});
   table.grow(0);
   try {table2.get(0); console.log("Failed. Unexpected successfull call to table2.get(0)");} catch (e) {}
   table.grow(1);

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -145,9 +145,9 @@ g3: 45
 
 WebAssembly.Memory tests
 Test 0 passed. Expected Error: TypeError: WebAssembly.Memory: cannot be called without the new keyword
-Test 1 passed. Expected Error: TypeError: 'memoryDescriptor' is null or not an object
-Test 2 passed. Expected Error: TypeError: 'memoryDescriptor' is null or not an object
-Test 3 passed. Expected Error: TypeError: 'memoryDescriptor' is null or not an object
+Test 1 passed. Expected Error: TypeError: 'descriptor' is null or not an object
+Test 2 passed. Expected Error: TypeError: 'descriptor' is null or not an object
+Test 3 passed. Expected Error: TypeError: 'descriptor' is null or not an object
 Test 4 passed. Expected Error: TypeError: WebAssembly.Memory object expected
 Test 5 passed. Expected Error: TypeError: WebAssembly.Memory object expected
 Test 6 passed. Expected Error: TypeError: WebAssembly.Memory object expected


### PR DESCRIPTION
- Use TypeError instead of RangeError when initial/maximum have the wrong type (ie: not uint32).
- Check for NaN, Infinity and -Infinity for NonWrappingUint32 conversion
- Do not use HasProperty to see if the descriptor has a property, instead just use GetProperty and check against `undefined`. This is according to https://heycam.github.io/webidl/#dfn-present
- Convert Table `descriptor.element` to string before doing the comparison

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5886)
<!-- Reviewable:end -->
