### PR TITLE
WebAssembly spec tests harness improvements

### DIFF
--- a/test/WasmSpec/baselines/testsuite/js-api/global/constructor.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/global/constructor.any.baseline
@@ -1,38 +1,38 @@
 Harness Status: OK
-Found 36 tests: Fail = 32 Pass = 4
-Fail name  Object expected
-Fail length  Object expected
-Pass No arguments  
+Found 36 tests: Fail = 35 Pass = 1
+Fail name  assert_equals: WebAssembly.Global name should be Global expected "Global" but got ""
+Fail length  assert_equals: WebAssembly.Global length should be 1 expected 1 but got 0
+Fail No arguments  assert_throws: function "() => new WebAssembly.Global()" did not throw
 Pass Calling  
-Fail Order of evaluation  Object doesn't support this action
-Pass Invalid descriptor argument  
-Pass Invalid type argument  
-Fail i64 with default  Object doesn't support this action
-Fail Default value for type i32  Object doesn't support this action
-Fail Explicit value undefined for type i32  Object doesn't support this action
-Fail Explicit value null for type i32  Object doesn't support this action
-Fail Explicit value true for type i32  Object doesn't support this action
-Fail Explicit value false for type i32  Object doesn't support this action
-Fail Explicit value 2 for type i32  Object doesn't support this action
-Fail Explicit value "3" for type i32  Object doesn't support this action
-Fail Explicit value object with toString for type i32  Object doesn't support this action
-Fail Explicit value object with valueOf for type i32  Object doesn't support this action
-Fail Default value for type f32  Object doesn't support this action
-Fail Explicit value undefined for type f32  Object doesn't support this action
-Fail Explicit value null for type f32  Object doesn't support this action
-Fail Explicit value true for type f32  Object doesn't support this action
-Fail Explicit value false for type f32  Object doesn't support this action
-Fail Explicit value 2 for type f32  Object doesn't support this action
-Fail Explicit value "3" for type f32  Object doesn't support this action
-Fail Explicit value object with toString for type f32  Object doesn't support this action
-Fail Explicit value object with valueOf for type f32  Object doesn't support this action
-Fail Default value for type f64  Object doesn't support this action
-Fail Explicit value undefined for type f64  Object doesn't support this action
-Fail Explicit value null for type f64  Object doesn't support this action
-Fail Explicit value true for type f64  Object doesn't support this action
-Fail Explicit value false for type f64  Object doesn't support this action
-Fail Explicit value 2 for type f64  Object doesn't support this action
-Fail Explicit value "3" for type f64  Object doesn't support this action
-Fail Explicit value object with toString for type f64  Object doesn't support this action
-Fail Explicit value object with valueOf for type f64  Object doesn't support this action
-Fail Stray argument  Object doesn't support this action
+Fail Order of evaluation  assert_array_equals: lengths differ, expected 4 got 0
+Fail Invalid descriptor argument  assert_throws: new Global(undefined) function "() => new WebAssembly.Global(invalidArgument)" did not throw
+Fail Invalid type argument  assert_throws: function "() => new WebAssembly.Global(argument)" did not throw
+Fail i64 with default  assert_throws: function "() => global.value" did not throw
+Fail Default value for type i32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value undefined for type i32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value null for type i32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value true for type i32  assert_equals: value expected (number) 1 but got (undefined) undefined
+Fail Explicit value false for type i32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value 2 for type i32  assert_equals: value expected (number) 2 but got (undefined) undefined
+Fail Explicit value "3" for type i32  assert_equals: value expected (number) 3 but got (undefined) undefined
+Fail Explicit value object with toString for type i32  assert_equals: value expected (number) 5 but got (undefined) undefined
+Fail Explicit value object with valueOf for type i32  assert_equals: value expected (number) 8 but got (undefined) undefined
+Fail Default value for type f32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value undefined for type f32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value null for type f32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value true for type f32  assert_equals: value expected (number) 1 but got (undefined) undefined
+Fail Explicit value false for type f32  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value 2 for type f32  assert_equals: value expected (number) 2 but got (undefined) undefined
+Fail Explicit value "3" for type f32  assert_equals: value expected (number) 3 but got (undefined) undefined
+Fail Explicit value object with toString for type f32  assert_equals: value expected (number) 5 but got (undefined) undefined
+Fail Explicit value object with valueOf for type f32  assert_equals: value expected (number) 8 but got (undefined) undefined
+Fail Default value for type f64  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value undefined for type f64  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value null for type f64  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value true for type f64  assert_equals: value expected (number) 1 but got (undefined) undefined
+Fail Explicit value false for type f64  assert_equals: value expected (number) 0 but got (undefined) undefined
+Fail Explicit value 2 for type f64  assert_equals: value expected (number) 2 but got (undefined) undefined
+Fail Explicit value "3" for type f64  assert_equals: value expected (number) 3 but got (undefined) undefined
+Fail Explicit value object with toString for type f64  assert_equals: value expected (number) 5 but got (undefined) undefined
+Fail Explicit value object with valueOf for type f64  assert_equals: value expected (number) 8 but got (undefined) undefined
+Fail Stray argument  assert_equals: value expected (number) 0 but got (undefined) undefined

--- a/test/WasmSpec/baselines/testsuite/js-api/global/toString.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/global/toString.any.baseline
@@ -1,3 +1,3 @@
 Harness Status: OK
 Found 1 tests: Fail = 1
-Fail Object.prototype.toString on an Global  Object doesn't support this action
+Fail Object.prototype.toString on an Global  assert_equals: expected "[object WebAssembly.Global]" but got "[object Object]"

--- a/test/WasmSpec/baselines/testsuite/js-api/global/value-get-set.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/global/value-get-set.any.baseline
@@ -1,36 +1,36 @@
 Harness Status: OK
 Found 34 tests: Fail = 34
-Fail Branding  Unable to get property 'prototype' of undefined or null reference
-Fail Immutable i32 (missing)  Object doesn't support this action
-Fail Immutable i32 (undefined)  Object doesn't support this action
-Fail Immutable i32 (null)  Object doesn't support this action
-Fail Immutable i32 (false)  Object doesn't support this action
-Fail Immutable i32 (empty string)  Object doesn't support this action
-Fail Immutable i32 (zero)  Object doesn't support this action
-Fail Mutable i32 (true)  Object doesn't support this action
-Fail Mutable i32 (one)  Object doesn't support this action
-Fail Mutable i32 (string)  Object doesn't support this action
-Fail Mutable i32 (true on prototype)  Object doesn't support this action
-Fail Immutable f32 (missing)  Object doesn't support this action
-Fail Immutable f32 (undefined)  Object doesn't support this action
-Fail Immutable f32 (null)  Object doesn't support this action
-Fail Immutable f32 (false)  Object doesn't support this action
-Fail Immutable f32 (empty string)  Object doesn't support this action
-Fail Immutable f32 (zero)  Object doesn't support this action
-Fail Mutable f32 (true)  Object doesn't support this action
-Fail Mutable f32 (one)  Object doesn't support this action
-Fail Mutable f32 (string)  Object doesn't support this action
-Fail Mutable f32 (true on prototype)  Object doesn't support this action
-Fail Immutable f64 (missing)  Object doesn't support this action
-Fail Immutable f64 (undefined)  Object doesn't support this action
-Fail Immutable f64 (null)  Object doesn't support this action
-Fail Immutable f64 (false)  Object doesn't support this action
-Fail Immutable f64 (empty string)  Object doesn't support this action
-Fail Immutable f64 (zero)  Object doesn't support this action
-Fail Mutable f64 (true)  Object doesn't support this action
-Fail Mutable f64 (one)  Object doesn't support this action
-Fail Mutable f64 (string)  Object doesn't support this action
-Fail Mutable f64 (true on prototype)  Object doesn't support this action
-Fail i64 with default  Object doesn't support this action
-Fail Calling setter without argument  Object doesn't support this action
-Fail Stray argument  Object doesn't support this action
+Fail Branding  assert_equals: expected "object" but got "undefined"
+Fail Immutable i32 (missing)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable i32 (undefined)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable i32 (null)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable i32 (false)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable i32 (empty string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable i32 (zero)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable i32 (true)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable i32 (one)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable i32 (string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable i32 (true on prototype)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (missing)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (undefined)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (null)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (false)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (empty string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f32 (zero)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f32 (true)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f32 (one)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f32 (string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f32 (true on prototype)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (missing)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (undefined)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (null)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (false)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (empty string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Immutable f64 (zero)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f64 (true)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f64 (one)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f64 (string)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail Mutable f64 (true on prototype)  assert_equals: initial value expected (number) 0 but got (undefined) undefined
+Fail i64 with default  assert_throws: function "() => global.value" did not throw
+Fail Calling setter without argument  assert_equals: expected "object" but got "undefined"
+Fail Stray argument  assert_equals: expected "object" but got "undefined"

--- a/test/WasmSpec/baselines/testsuite/js-api/global/valueOf.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/global/valueOf.any.baseline
@@ -1,4 +1,4 @@
 Harness Status: OK
 Found 2 tests: Fail = 2
-Fail Branding  Unable to get property 'prototype' of undefined or null reference
-Fail Stray argument  Object doesn't support this action
+Fail Branding  assert_throws: this=true function "() => fn.call(thisValue)" did not throw
+Fail Stray argument  assert_equals: expected (number) 0 but got (object) object "[object Object]"

--- a/test/WasmSpec/baselines/testsuite/js-api/interface.any.baseline
+++ b/test/WasmSpec/baselines/testsuite/js-api/interface.any.baseline
@@ -1,0 +1,74 @@
+Harness Status: OK
+Found 72 tests: Pass = 54 Fail = 18
+Pass WebAssembly: property descriptor  
+Pass WebAssembly: calling  
+Pass WebAssembly: constructing  
+Pass WebAssembly.Module: property descriptor  
+Pass WebAssembly.Module: prototype  
+Pass WebAssembly.Module: prototype.constructor  
+Pass WebAssembly.Instance: property descriptor  
+Pass WebAssembly.Instance: prototype  
+Pass WebAssembly.Instance: prototype.constructor  
+Pass WebAssembly.Memory: property descriptor  
+Pass WebAssembly.Memory: prototype  
+Pass WebAssembly.Memory: prototype.constructor  
+Pass WebAssembly.Table: property descriptor  
+Pass WebAssembly.Table: prototype  
+Pass WebAssembly.Table: prototype.constructor  
+Fail WebAssembly.Global: property descriptor  assert_false: enumerable expected false got true
+Pass WebAssembly.Global: prototype  
+Pass WebAssembly.Global: prototype.constructor  
+Pass WebAssembly.CompileError: property descriptor  
+Pass WebAssembly.CompileError: prototype  
+Pass WebAssembly.CompileError: prototype.constructor  
+Pass WebAssembly.LinkError: property descriptor  
+Pass WebAssembly.LinkError: prototype  
+Pass WebAssembly.LinkError: prototype.constructor  
+Pass WebAssembly.RuntimeError: property descriptor  
+Pass WebAssembly.RuntimeError: prototype  
+Pass WebAssembly.RuntimeError: prototype.constructor  
+Fail WebAssembly.validate  assert_true: enumerable expected true got false
+Pass WebAssembly.validate: name  
+Pass WebAssembly.validate: length  
+Fail WebAssembly.compile  assert_true: enumerable expected true got false
+Pass WebAssembly.compile: name  
+Pass WebAssembly.compile: length  
+Fail WebAssembly.instantiate  assert_true: enumerable expected true got false
+Pass WebAssembly.instantiate: name  
+Pass WebAssembly.instantiate: length  
+Fail WebAssembly.Module.exports  assert_true: enumerable expected true got false
+Pass WebAssembly.Module.exports: name  
+Pass WebAssembly.Module.exports: length  
+Fail WebAssembly.Module.imports  assert_true: enumerable expected true got false
+Pass WebAssembly.Module.imports: name  
+Pass WebAssembly.Module.imports: length  
+Fail WebAssembly.Module.customSections  assert_true: enumerable expected true got false
+Pass WebAssembly.Module.customSections: name  
+Pass WebAssembly.Module.customSections: length  
+Fail WebAssembly.Instance.exports  assert_true: enumerable expected true got false
+Pass WebAssembly.Instance.exports: getter  
+Pass WebAssembly.Instance.exports: setter  
+Fail WebAssembly.Memory.grow  assert_true: enumerable expected true got false
+Pass WebAssembly.Memory.grow: name  
+Pass WebAssembly.Memory.grow: length  
+Fail WebAssembly.Memory.buffer  assert_true: enumerable expected true got false
+Pass WebAssembly.Memory.buffer: getter  
+Pass WebAssembly.Memory.buffer: setter  
+Fail WebAssembly.Table.grow  assert_true: enumerable expected true got false
+Pass WebAssembly.Table.grow: name  
+Pass WebAssembly.Table.grow: length  
+Fail WebAssembly.Table.get  assert_true: enumerable expected true got false
+Pass WebAssembly.Table.get: name  
+Pass WebAssembly.Table.get: length  
+Fail WebAssembly.Table.set  assert_true: enumerable expected true got false
+Pass WebAssembly.Table.set: name  
+Pass WebAssembly.Table.set: length  
+Fail WebAssembly.Table.length  assert_true: enumerable expected true got false
+Pass WebAssembly.Table.length: getter  
+Pass WebAssembly.Table.length: setter  
+Fail WebAssembly.Global.valueOf  assert_equals: expected "object" but got "undefined"
+Pass WebAssembly.Global.valueOf: name  
+Pass WebAssembly.Global.valueOf: length  
+Fail WebAssembly.Global.value  assert_equals: expected "object" but got "undefined"
+Fail WebAssembly.Global.value: getter  assert_equals: expected "object" but got "undefined"
+Fail WebAssembly.Global.value: setter  assert_equals: expected "object" but got "undefined"

--- a/test/WasmSpec/convert-test-suite/config.json5
+++ b/test/WasmSpec/convert-test-suite/config.json5
@@ -3,16 +3,8 @@
     "chakra",
     "chakra_generated",
     "testsuite/core",
-    "testsuite/js-api/constructor",
-    "testsuite/js-api/global",
-    "testsuite/js-api/instance",
-    "testsuite/js-api/memory",
-    "testsuite/js-api/module",
-    "testsuite/js-api/table",
-
-    "features/extends",
-    "features/nontrapping",
-    "features/threads"
+    "testsuite/js-api",
+    "features",
   ],
   "features": [{
     "flags": ["-wasmfastarray-"],
@@ -23,7 +15,7 @@
       "testsuite/core/memory.wast",
       "testsuite/core/memory_trap.wast",
       "testsuite/core/resizing.wast",
-      "testsuite/core/traps.wast"
+      "testsuite/core/traps.wast",
     ]
   }, {
     "flags": ["-wasmMathExFilter"],
@@ -33,7 +25,7 @@
       "testsuite/core/i64.wast",
       "chakra_generated/chakra_i32.wast",
       "chakra_generated/chakra_i64.wast",
-      "testsuite/core/traps.wast"
+      "testsuite/core/traps.wast",
     ]
   }, {
     "required": true,
@@ -43,7 +35,7 @@
     ],
     "files": [
       "chakra_generated/chakra_extends_i32.wast",
-      "chakra_generated/chakra_extends_i64.wast"
+      "chakra_generated/chakra_extends_i64.wast",
     ]
   }, {
     "required": true,
@@ -59,7 +51,7 @@
     ],
     "files": [
       "chakra/chakra_atomic_load.wast",
-      "chakra/chakra_atomic_store.wast"
+      "chakra/chakra_atomic_store.wast",
     ]
   }, {
     "flags": ["-WasmThreads", "-ESSharedArrayBuffer", "-WasmSharedArrayVirtualBuffer-", "-WasmFastArray-"],
@@ -68,11 +60,22 @@
     ],
     "files": [
       "chakra/chakra_atomic_load.wast",
-      "chakra/chakra_atomic_store.wast"
+      "chakra/chakra_atomic_store.wast",
     ]
   }],
   "excludes": [
-    "testsuite/core/names.wast"
+    // Names not supported yet
+    "testsuite/core/names.wast",
+    // Limits testing is too slow and is mostly a duplicate of tests/wasm/limts.js
+    "testsuite/js-api/limits.js",
+
+    // Harness files, no tests in there
+    "testsuite/js-api/assertions.js",
+    "testsuite/js-api/bad-imports.js",
+    "testsuite/js-api/instanceTestFactory.js",
+    "testsuite/js-api/wasm-constants.js",
+    "testsuite/js-api/wasm-module-builder.js",
+    "testsuite/js-api/table/assertions.js",
   ],
   "xplat-excludes": [
   ]

--- a/test/WasmSpec/convert-test-suite/index.js
+++ b/test/WasmSpec/convert-test-suite/index.js
@@ -8,9 +8,10 @@ const fs = require("fs-extra");
 const Bluebird = require("bluebird");
 const {spawn} = require("child_process");
 const slash = require("slash");
+const json5 = require("json5");
 
 Bluebird.promisifyAll(fs);
-const config = require("./config.json");
+const config = json5.parse(fs.readFileSync(path.join(__dirname, "config.json5")));
 const rlRoot = path.resolve(__dirname, "..");
 const folders = config.folders.map(folder => path.resolve(rlRoot, folder));
 const baselineDir = path.join(rlRoot, "baselines");

--- a/test/WasmSpec/convert-test-suite/package-lock.json
+++ b/test/WasmSpec/convert-test-suite/package-lock.json
@@ -170,6 +170,14 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -218,6 +226,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/test/WasmSpec/convert-test-suite/package.json
+++ b/test/WasmSpec/convert-test-suite/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "fs-extra": "^0.30.0",
+    "json5": "^2.1.0",
     "sexpr-plus": "^7.0.0",
     "slash": "^1.0.0",
     "yargs": "^4.7.1"

--- a/test/WasmSpec/jsapi.js
+++ b/test/WasmSpec/jsapi.js
@@ -17,6 +17,11 @@ WScript.Flag(`-wasmMaxTableSize:${(Math.pow(2,32)-1)|0}`);
 
 self.addEventListener = function() {};
 
+if (!WebAssembly.Global) {
+  // Shim WebAssembly.Global so the tests fails, but don't crash
+  WebAssembly.Global = class {}
+}
+
 class ConsoleTestEnvironment {
   constructor() {
     this.all_loaded = false;

--- a/test/WasmSpec/rlexe.xml
+++ b/test/WasmSpec/rlexe.xml
@@ -1240,6 +1240,21 @@
   <test>
     <default>
       <files>jsapi.js</files>
+      <baseline>baselines/testsuite/js-api/interface.any.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/js-api/interface.any.js -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>jsapi.js</files>
+      <baseline>baselines/testsuite/js-api/interface.any.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/js-api/interface.any.js -endargs -nonative</compile-flags>
+      <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>jsapi.js</files>
       <baseline>baselines/testsuite/js-api/constructor/compile.any.baseline</baseline>
       <compile-flags>-wasm -args testsuite/js-api/constructor/compile.any.js -endargs</compile-flags>
     </default>
@@ -1549,21 +1564,6 @@
       <files>jsapi.js</files>
       <baseline>baselines/testsuite/js-api/module/toString.any.baseline</baseline>
       <compile-flags>-wasm -args testsuite/js-api/module/toString.any.js -endargs -nonative</compile-flags>
-      <tags>exclude_dynapogo</tags>
-    </default>
-  </test>
-  <test>
-    <default>
-      <files>jsapi.js</files>
-      <baseline>baselines/testsuite/js-api/table/assertions.baseline</baseline>
-      <compile-flags>-wasm -args testsuite/js-api/table/assertions.js -endargs</compile-flags>
-    </default>
-  </test>
-  <test>
-    <default>
-      <files>jsapi.js</files>
-      <baseline>baselines/testsuite/js-api/table/assertions.baseline</baseline>
-      <compile-flags>-wasm -args testsuite/js-api/table/assertions.js -endargs -nonative</compile-flags>
       <tags>exclude_dynapogo</tags>
     </default>
   </test>


### PR DESCRIPTION
Use json5 to be able to document convert-test-suite/config.json5 with comments
include/exclude relevant files in the wasm spec js-api testsuite
Shim WebAssembly.Global so some test don't crash the test harness

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5887)
<!-- Reviewable:end -->
