### PR TITLE
WebAssembly LEB128 check extra bits

### DIFF
--- a/test/WasmSpec/baselines/testsuite/core/binary.baseline
+++ b/test/WasmSpec/baselines/testsuite/core/binary.baseline
@@ -1,11 +1,1 @@
-(50) testsuite/core/binary.wast:192: assert_malformed module failed. Should have had an error
-(51) testsuite/core/binary.wast:200: assert_malformed module failed. Should have had an error
-(52) testsuite/core/binary.wast:210: assert_malformed module failed. Should have had an error
-(53) testsuite/core/binary.wast:220: assert_malformed module failed. Should have had an error
-(54) testsuite/core/binary.wast:230: assert_malformed module failed. Should have had an error
-(55) testsuite/core/binary.wast:240: assert_malformed module failed. Should have had an error
-(56) testsuite/core/binary.wast:251: assert_malformed module failed. Should have had an error
-(57) testsuite/core/binary.wast:261: assert_malformed module failed. Should have had an error
-(58) testsuite/core/binary.wast:271: assert_malformed module failed. Should have had an error
-(59) testsuite/core/binary.wast:281: assert_malformed module failed. Should have had an error
-71/81 tests passed.
+81/81 tests passed.


### PR DESCRIPTION
When reading the last byte of a LEB128, the additional unused bits should be all zeros (or can be all ones if signed LEB128).
For instance, when reading a uint32, you need to read 5 bytes with 7 bits used per bytes that's 35 bits, so there are 3 bits that needs to be checked.
This doesn't change anything in practice other than spec compliance.
I took the opportunity to simplify the LEB128 decoding code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5888)
<!-- Reviewable:end -->
