### PR TITLE
WebAssembly fix tee_local behavior

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -963,7 +963,8 @@ EmitInfo WasmBytecodeGenerator::EmitSetLocal(bool tee)
     {
         if (info.type == WasmTypes::Any)
         {
-            throw WasmCompilationException(_u("Can't tee_local unreachable values"));
+            info.location = local.location;
+            info.type = local.type;
         }
         return info;
     }

--- a/test/WasmSpec/baselines/testsuite/core/br.baseline
+++ b/test/WasmSpec/baselines/testsuite/core/br.baseline
@@ -1,2 +1,1 @@
-(43) testsuite/core/br.wast:387: assert_return($$.as-tee_local-value() == i32:1) failed. Unexpectedly threw: CompileError: function as-tee_local-value[39] at offset 1784/2165 (0x6f8/0x875): Can't tee_local unreachable values
-70/71 tests passed.
+71/71 tests passed.

--- a/test/WasmSpec/baselines/testsuite/core/return.baseline
+++ b/test/WasmSpec/baselines/testsuite/core/return.baseline
@@ -1,2 +1,1 @@
-(49) testsuite/core/return.wast:285: assert_return($$.as-tee_local-value() == i32:1) failed. Unexpectedly threw: CompileError: function as-tee_local-value[45] at offset 1672/1839 (0x688/0x72f): Can't tee_local unreachable values
-66/67 tests passed.
+67/67 tests passed.

--- a/test/WasmSpec/baselines/testsuite/core/unreachable.baseline
+++ b/test/WasmSpec/baselines/testsuite/core/unreachable.baseline
@@ -1,2 +1,1 @@
-(47) testsuite/core/unreachable.wast:275: assert_trap($$.as-tee_local-value()) failed. Unexpected error thrown: CompileError: function as-tee_local-value[43] at offset 1588/1711 (0x634/0x6af): Can't tee_local unreachable values
-61/62 tests passed.
+62/62 tests passed.


### PR DESCRIPTION
tee_local should not throw when trying to set Unreachable, but it should always yield the type of the local its trying to set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/5889)
<!-- Reviewable:end -->
