### PR TITLE
Add SlotArrayCheck in Lowerer instead of IRBuilder

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -143,7 +143,6 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     , constantAddressRegOpnd(alloc)
     , lastConstantAddressRegLoadInstr(nullptr)
     , m_totalJumpTableSizeInBytesForSwitchStatements(0)
-    , slotArrayCheckTable(nullptr)
     , frameDisplayCheckTable(nullptr)
     , stackArgWithFormalsTracker(nullptr)
     , m_forInLoopBaseDepth(0)
@@ -1030,29 +1029,6 @@ Func::GetLocalsPointer() const
 }
 
 #endif
-
-void Func::AddSlotArrayCheck(IR::SymOpnd *fieldOpnd)
-{
-    if (PHASE_OFF(Js::ClosureRangeCheckPhase, this))
-    {
-        return;
-    }
-
-    Assert(IsTopFunc());
-    if (this->slotArrayCheckTable == nullptr)
-    {
-        this->slotArrayCheckTable = SlotArrayCheckTable::New(m_alloc, 4);
-    }
-
-    PropertySym *propertySym = fieldOpnd->m_sym->AsPropertySym();
-    uint32 slot = propertySym->m_propertyId;
-    uint32 *pSlotId = this->slotArrayCheckTable->FindOrInsert(slot, propertySym->m_stackSym->m_id);
-
-    if (pSlotId && (*pSlotId == (uint32)-1 || *pSlotId < slot))
-    {
-        *pSlotId = propertySym->m_propertyId;
-    }
-}
 
 void Func::AddFrameDisplayCheck(IR::SymOpnd *fieldOpnd, uint32 slotId)
 {

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -665,7 +665,6 @@ public:
     PropertyIdSet lazyBailoutProperties;
     bool anyPropertyMayBeWrittenTo;
 
-    SlotArrayCheckTable *slotArrayCheckTable;
     FrameDisplayCheckTable *frameDisplayCheckTable;
 
     IR::Instr *         m_headInstr;
@@ -995,7 +994,6 @@ public:
     void MarkConstantAddressSyms(BVSparse<JitArenaAllocator> * bv);
     void DisableConstandAddressLoadHoist() { canHoistConstantAddressLoad = false; }
 
-    void AddSlotArrayCheck(IR::SymOpnd *fieldOpnd);
     void AddFrameDisplayCheck(IR::SymOpnd *fieldOpnd, uint32 slotId = (uint32)-1);
 
     void EnsureStackArgWithFormalsTracker();

--- a/lib/Backend/IRBuilder.h
+++ b/lib/Backend/IRBuilder.h
@@ -292,7 +292,6 @@ private:
     Js::RegSlot         GetEnvRegForEvalCode() const;
     Js::RegSlot         GetEnvRegForInnerFrameDisplay() const;
     void                AddEnvOpndForInnerFrameDisplay(IR::Instr *instr, uint offset);
-    bool                DoSlotArrayCheck(IR::SymOpnd *fieldOpnd, bool doDynamicCheck);
     void                EmitClosureRangeChecks();
     void                DoClosureRegCheck(Js::RegSlot reg);
     void                BuildInitCachedScope(int auxOffset, int offset);

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -229,6 +229,7 @@ private:
     IR::Instr *     LowerDeleteElemI(IR::Instr *instr, bool strictMode);
     IR::Instr *     LowerStElemC(IR::Instr *instr);
     void            LowerLdArrHead(IR::Instr *instr);
+    IR::Instr*      AddSlotArrayCheck(PropertySym *propertySym, IR::Instr* instr);
     IR::Instr *     LowerStSlot(IR::Instr *instr);
     IR::Instr *     LowerStSlotChkUndecl(IR::Instr *instr);
     void            LowerStLoopBodyCount(IR::Instr* instr);

--- a/test/Bugs/loopcrash.js
+++ b/test/Bugs/loopcrash.js
@@ -1,0 +1,32 @@
+//------------------------------------------------------------------------------------------------------- 
+// Copyright (C) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information. 
+//------------------------------------------------------------------------------------------------------- 
+function test0() { 
+  var i32 = new Int32Array(1); 
+  { 
+    class class0 { 
+    } 
+    class class8 { 
+    } 
+    class class17 {
+      static func91(argMath135) {
+        if (new class0() * h) {  
+        }   
+      }  
+      static func94() { 
+        return class8.func78; 
+      } 
+    } 
+    for (var _strvar2 in i32) { 
+      continue;	     
+      try { 
+      } catch (ex) { 
+        class8; 
+      } 
+    } 
+  } 
+} 
+test0(); 
+test0(); 
+print("Passed");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -557,4 +557,10 @@
       <compile-flags>-esdynamicimport -mutehosterrormsg -args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>loopcrash.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport  -bgjit- -loopinterpretcount:1</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes OS#19767482

We insert LdSlots at the top of the function in jitloopbody for all syms
that are coming in live to the loop. These LdSlots should be restored
correctly on BailOutFromSimpleJitToJitLoopBody.
However we do unreachable code elimination in flowgraph in simplejit,
which can dead code the uses of these syms, and so they will not be
restored on bailout.
This works if we run deadstore pass which will cleanup all the LdSlots
inserted at the top of the function, after we run unreachable block
elimination phase.
But since we turn off deadstore for functions with try/catch, we end up
having a nullptr AV when we do a SlotArrayCheck followed by LdSlot
