### PR TITLE
OS#18874701: Clear valuetype of profiledInstr, when it transforms from LdElemI_A to Ld_A

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -13270,6 +13270,11 @@ GlobOpt::OptStackArgLenAndConst(IR::Instr* instr, Value** src1Val)
             {
                 instr->ClearBailOutInfo();
             }
+            if (instr->IsProfiledInstr())
+            {
+                Assert(opcode == Js::OpCode::Ld_A || opcode == Js::OpCode::Typeof);
+                instr->AsProfiledInstr()->u.FldInfo().valueType = ValueType::Uninitialized;
+            }
             *src1Val = this->OptSrc(instr->GetSrc1(), &instr);
             instr->m_func->hasArgLenAndConstOpt = true;
         };


### PR DESCRIPTION
Otherwise we may end up reading the profiled value type stored in the union (instr->AsProfiledInstr()->u) incorrectly.
