### PR TITLE
reenable ObjectCopyPhase

### DIFF
--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -914,7 +914,7 @@ namespace Js
         }
 #endif
 
-        if (!PHASE_ON1(ObjectCopyPhase))
+        if (PHASE_OFF1(ObjectCopyPhase))
         {
             return false;
         }

--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -452,7 +452,7 @@
   <test>
     <default>
       <files>assign.js</files>
-      <compile-flags>-args summary -endargs -on:ObjectCopy -trace:ObjectCopy</compile-flags>
+      <compile-flags>-args summary -endargs -trace:ObjectCopy</compile-flags>
       <baseline>assign.baseline</baseline>
     </default>
   </test>


### PR DESCRIPTION
ObjectCopyPhase was inadvertently disabled during a merge a few months ago