### PR TITLE
Provide an API to expose Free function of ArrayBuffer

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -199,6 +199,7 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtVarDeserializerFree = (JsAPIHooks::JsrtVarDeserializerFreePtr)GetChakraCoreSymbol(library, "JsVarDeserializerFree");
 
     m_jsApiHooks.pfJsrtDetachArrayBuffer = (JsAPIHooks::JsrtDetachArrayBufferPtr)GetChakraCoreSymbol(library, "JsDetachArrayBuffer");
+    m_jsApiHooks.pfJsrtGetArrayBufferFreeFunction = (JsAPIHooks::JsrtGetArrayBufferFreeFunction)GetChakraCoreSymbol(library, "JsGetArrayBufferFreeFunction");
 
 #ifdef _WIN32
     m_jsApiHooks.pfJsrtConnectJITProcess = (JsAPIHooks::JsrtConnectJITProcess)GetChakraCoreSymbol(library, "JsConnectJITProcess");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -138,6 +138,7 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtVarDeserializerFreePtr)(JsVarDeserializerHandle deserializerHandle);
 
     typedef JsErrorCode(WINAPI *JsrtDetachArrayBufferPtr)(JsValueRef buffer);
+    typedef JsErrorCode(WINAPI* JsrtGetArrayBufferFreeFunction)(JsValueRef buffer, ArrayBufferFreeFn** freeFn);
 
     JsrtCreateRuntimePtr pfJsrtCreateRuntime;
     JsrtCreateContextPtr pfJsrtCreateContext;
@@ -268,6 +269,7 @@ struct JsAPIHooks
     JsrtVarDeserializerFreePtr pfJsrtVarDeserializerFree;
 
     JsrtDetachArrayBufferPtr pfJsrtDetachArrayBuffer;
+    JsrtGetArrayBufferFreeFunction pfJsrtGetArrayBufferFreeFunction;
 #ifdef _WIN32
     JsrtConnectJITProcess pfJsrtConnectJITProcess;
 #endif
@@ -509,6 +511,8 @@ public:
 #ifdef _WIN32
     static JsErrorCode WINAPI JsConnectJITProcess(HANDLE processHandle, void* serverSecurityDescriptor, UUID connectionId) { return HOOK_JS_API(ConnectJITProcess(processHandle, serverSecurityDescriptor, connectionId)); }
 #endif
+
+    static JsErrorCode WINAPI JsGetArrayBufferFreeFunction(JsValueRef buffer, ArrayBufferFreeFn** freeFn) { return HOOK_JS_API(GetArrayBufferFreeFunction(buffer, freeFn)); }
 };
 
 class AutoRestoreContext

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -374,6 +374,9 @@ JsValueRef __stdcall WScriptJsrt::SerializeObject(JsValueRef callee, bool isCons
             BYTE *buffer = nullptr;
             uint32 bufferLength = 0;
             IfJsrtErrorSetGo(ChakraRTInterface::JsGetArrayBufferStorage(arrayBuffer, &buffer, &bufferLength));
+            ArrayBufferFreeFn* freeFn = nullptr;
+            IfJsrtErrorSetGo(ChakraRTInterface::JsGetArrayBufferFreeFunction(arrayBuffer, &freeFn));
+
             blob->transferableArrays.push_back(std::make_pair((void*)buffer, bufferLength));
             IfJsrtErrorSetGo(ChakraRTInterface::JsDetachArrayBuffer(arrayBuffer));
         }

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -1887,6 +1887,22 @@ CHAKRA_API
 JsDetachArrayBuffer(
     _In_ JsValueRef arrayBuffer);
 
+typedef void __cdecl ArrayBufferFreeFn(void* ptr);
+
+/// <summary>
+///     Returns the function which free the underlying buffer of ArrayBuffer
+/// </summary>
+/// <param name="arrayBuffer">An ArrayBuffer for which Free function to be returned </param>
+/// <param name="freeFn">Free function will be returned</param>
+/// <returns>
+///     The code <c>JsNoError</c> if the operation succeeded, a failure code
+///     otherwise.
+/// </returns>
+CHAKRA_API
+JsGetArrayBufferFreeFunction(
+    _In_ JsValueRef arrayBuffer,
+    _Out_ ArrayBufferFreeFn** freeFn);
+
 
 #ifdef _WIN32
 #include "ChakraCoreWindows.h"

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -1442,3 +1442,21 @@ JsConnectJITProcess(_In_ HANDLE processHandle, _In_opt_ void* serverSecurityDesc
     return JsNoError;
 }
 #endif
+CHAKRA_API
+JsGetArrayBufferFreeFunction(
+    _In_ JsValueRef arrayBuffer,
+    _Out_ ArrayBufferFreeFn** freeFn)
+{
+  VALIDATE_JSREF(arrayBuffer);
+  PARAM_NOT_NULL(freeFn);
+  return ContextAPINoScriptWrapper_NoRecord(
+      [&](Js::ScriptContext* scriptContext) -> JsErrorCode {
+        if (!Js::VarIs<Js::ArrayBuffer>(arrayBuffer))
+        {
+          return JsErrorInvalidArgument;
+        }
+
+        *freeFn = (ArrayBufferFreeFn*)Js::VarTo<Js::ArrayBuffer>(arrayBuffer)->GetArrayBufferFreeFn();
+        return JsNoError;
+      });
+}

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -168,4 +168,5 @@
     JsVarSerializerSetTransferableVars
     JsVarSerializerWriteRawBytes
     JsVarSerializerWriteValue
+    JsGetArrayBufferFreeFunction
 #endif

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -831,6 +831,20 @@ namespace Js
         return result;
     }
 
+    ArrayBuffer::FreeFn* JavascriptArrayBuffer::GetArrayBufferFreeFn()
+    {
+#if ENABLE_FAST_ARRAYBUFFER
+        if (IsValidVirtualBufferLength(bufferLength))
+        {
+            return FreeMemAlloc;
+        }
+        else
+#endif
+        {
+            return free;
+        }
+    }
+
     ArrayBufferDetachedStateBase* JavascriptArrayBuffer::CreateDetachedState(RefCountedBuffer * content, uint32 bufferLength)
     {
         FreeFn* freeFn = nullptr;

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -205,6 +205,9 @@ namespace Js
         virtual BYTE* GetBuffer() const override;
         RefCountedBuffer *GetBufferContent() { return bufferContent;  }
         static int GetBufferContentsOffset() { return offsetof(ArrayBuffer, bufferContent); }
+
+        typedef void __cdecl FreeFn(void* ptr);
+        virtual FreeFn* GetArrayBufferFreeFn() { return nullptr; }
         static int GetByteLengthOffset() { return offsetof(ArrayBuffer, bufferLength); }
         virtual void AddParent(ArrayBufferParent* parent) override;
 
@@ -230,7 +233,6 @@ namespace Js
     protected:
         virtual void ReportExternalMemoryFree();
 
-        typedef void __cdecl FreeFn(void* ptr);
         virtual ArrayBufferDetachedStateBase* CreateDetachedState(RefCountedBuffer * content, DECLSPEC_GUARD_OVERFLOW uint32 bufferLength) = 0;
 
         // This function will be called from External buffer and projection buffer as they pass the buffer
@@ -308,7 +310,9 @@ namespace Js
         virtual bool IsValidAsmJsBufferLength(uint length, bool forceCheck = false) override;
         virtual bool IsValidVirtualBufferLength(uint length) const override;
 
-    protected:
+        virtual FreeFn* GetArrayBufferFreeFn() override;
+
+       protected:
         JavascriptArrayBuffer(DynamicType * type);
         virtual ArrayBufferDetachedStateBase* CreateDetachedState(RefCountedBuffer * content, DECLSPEC_GUARD_OVERFLOW uint32 bufferLength) override;
 

--- a/lib/SCACore/SCAEngine.h
+++ b/lib/SCACore/SCAEngine.h
@@ -136,9 +136,7 @@ namespace Js
             AssertMsg(index < this->m_cTransferableVars, "Index out of range.");
             ArrayBuffer *ab = VarTo<ArrayBuffer>(m_transferableVars[index]);
 
-            // TODO reuse the same ArrayBuffer instead of creating a new ArrayBuffer.
-            // Current ArrayBuffer's from m_transferableVars are JsrtExternalArrayBuffer.
-            return library->CreateArrayBuffer((byte*)ab->GetBuffer(), ab->GetByteLength());
+            return ab;
         }
 
         static Dst Clone(Src root, Cloner* cloner, Var* transferableVars, size_t cTransferableVars)


### PR DESCRIPTION
After deserialize the ArrayBuffer, the host needs to know how to
free the underlying buffer. The exposed API will provide an way
to tell how to free the underlying buffer.
