### PR TITLE
LinearScan::InsertSecondChanceCompensation does not always restore a register saved to the stack at the beginning of a loop.

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4032,7 +4032,7 @@ BackwardPass::DeadStoreOrChangeInstrForScopeObjRemoval(IR::Instr ** pInstrPrev)
     IR::Instr * instr = this->currentInstr;
     Func * currFunc = instr->m_func;
 
-    if (this->tag == Js::DeadStorePhase && instr->m_func->IsStackArgsEnabled() && !IsPrePass())
+    if (this->tag == Js::DeadStorePhase && instr->m_func->IsStackArgsEnabled() && (IsPrePass() || !currentBlock->loop))
     {
         switch (instr->m_opcode)
         {

--- a/test/RegAlloc/RegAllocBug_0.js
+++ b/test/RegAlloc/RegAllocBug_0.js
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function f() {
+    var o_0 = {};
+    var o_1 = {};
+    var o_2 = {};
+    var arr_0 = Array();
+    o_0.length = 1;
+    for (var i = 0; i < 2; i++) {
+        Object.defineProperty(o_2, '', {});
+        function g(arr_1) {
+            for (var j = 0; j < 3; j++) {
+                arr_1[0] = arr_0;
+                var a = 3, k = 3;
+                for (; o_0.length * 1214425553.2;
+                    k -= 4) {
+                    a -= 2;
+                    if (a < -5) {
+                        break;
+                    }
+                    if (false) {
+                        b = c;
+                        arguments;
+                    }
+                }
+            }
+        }
+        g(o_1);
+        o_2 = o_0;
+    }
+}
+f();
+print("pass");

--- a/test/RegAlloc/rlexe.xml
+++ b/test/RegAlloc/rlexe.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<regress-exe>
+   <test>
+    <default>
+      <files>RegAllocBug_0.js</files>
+      <compile-flags>-mic:1 -off:simplejit</compile-flags>
+    </default>
+  </test> 
+</regress-exe>

--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -156,6 +156,11 @@
 </dir>
 <dir>
   <default>
+    <files>RegAlloc</files>
+  </default>
+</dir>
+<dir>
+  <default>
     <files>GlobalFunctions</files>
   </default>
 </dir>


### PR DESCRIPTION
More specifically, the root cause of this issue is that the inner loop of a nested for loop's liveOnBackEdgeSyms would not be populated with a symbol due to DeadStoreOrChangeInstrForScopeObjRemoval not executing during DeadStore's prepass.