### PR TITLE
make JsCloneObject able to handle all objects, instead of just path type objects

### DIFF
--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -735,10 +735,10 @@ CHAKRA_API JsCloneObject(_In_ JsValueRef source, _Out_ JsValueRef* newObject)
     VALIDATE_JSREF(source);
 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext* scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
-        Js::JavascriptProxy* proxy = Js::JavascriptOperators::TryFromVar<Js::JavascriptProxy>(source);
-        if (proxy != nullptr)
+
+        while (Js::VarIs<Js::JavascriptProxy>(source))
         {
-            source = proxy->GetTarget();
+            source = Js::UnsafeVarTo<Js::JavascriptProxy>(source)->GetTarget();
         }
 
         // We can currently only clone certain types of dynamic objects

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -2723,9 +2723,9 @@ CHAKRA_API JsHasExternalData(_In_ JsValueRef object, _Out_ bool *value)
 
     BEGIN_JSRT_NO_EXCEPTION
     {
-        if (Js::VarIs<Js::JavascriptProxy>(object))
+        while (Js::VarIs<Js::JavascriptProxy>(object))
         {
-            object = Js::VarTo<Js::JavascriptProxy>(object);
+            object = Js::UnsafeVarTo<Js::JavascriptProxy>(object);
         }
         *value = (Js::VarIs<JsrtExternalObject>(object)
 #ifdef _CHAKRACOREBUILD
@@ -2743,18 +2743,18 @@ CHAKRA_API JsGetExternalData(_In_ JsValueRef object, _Out_ void **data)
 
     BEGIN_JSRT_NO_EXCEPTION
     {
-        if (Js::VarIs<Js::JavascriptProxy>(object))
+        while (Js::VarIs<Js::JavascriptProxy>(object))
         {
-            object = Js::VarTo<Js::JavascriptProxy>(object)->GetTarget();
+            object = Js::UnsafeVarTo<Js::JavascriptProxy>(object)->GetTarget();
         }
         if (Js::VarIs<JsrtExternalObject>(object))
         {
-            *data = Js::VarTo<JsrtExternalObject>(object)->GetSlotData();
+            *data = Js::UnsafeVarTo<JsrtExternalObject>(object)->GetSlotData();
         }
 #ifdef _CHAKRACOREBUILD
         else if (Js::VarIs<Js::CustomExternalWrapperObject>(object))
         {
-            *data = Js::VarTo<Js::CustomExternalWrapperObject>(object)->GetSlotData();
+            *data = Js::UnsafeVarTo<Js::CustomExternalWrapperObject>(object)->GetSlotData();
         }
 #endif
         else
@@ -2772,18 +2772,18 @@ CHAKRA_API JsSetExternalData(_In_ JsValueRef object, _In_opt_ void *data)
 
     BEGIN_JSRT_NO_EXCEPTION
     {
-        if (Js::VarIs<Js::JavascriptProxy>(object))
+        while (Js::VarIs<Js::JavascriptProxy>(object))
         {
-            object = Js::VarTo<Js::JavascriptProxy>(object)->GetTarget();
+            object = Js::UnsafeVarTo<Js::JavascriptProxy>(object)->GetTarget();
         }
         if (Js::VarIs<JsrtExternalObject>(object))
         {
-            Js::VarTo<JsrtExternalObject>(object)->SetSlotData(data);
+            Js::UnsafeVarTo<JsrtExternalObject>(object)->SetSlotData(data);
         }
 #ifdef _CHAKRACOREBUILD
         else if (Js::VarIs<Js::CustomExternalWrapperObject>(object))
         {
-            Js::VarTo<Js::CustomExternalWrapperObject>(object)->SetSlotData(data);
+            Js::UnsafeVarTo<Js::CustomExternalWrapperObject>(object)->SetSlotData(data);
         }
 #endif
         else

--- a/lib/Jsrt/JsrtExternalObject.cpp
+++ b/lib/Jsrt/JsrtExternalObject.cpp
@@ -157,8 +157,7 @@ JsrtExternalObject* JsrtExternalObject::Create(void *data, uint inlineSlotSize, 
     return externalObject;
 }
 
-JsrtExternalObject*
-JsrtExternalObject::Copy(bool deepCopy)
+JsrtExternalObject* JsrtExternalObject::Copy(bool deepCopy)
 {
     Recycler* recycler = this->GetRecycler();
     JsrtExternalType* type = this->GetExternalType();

--- a/lib/Jsrt/JsrtExternalObject.h
+++ b/lib/Jsrt/JsrtExternalObject.h
@@ -60,11 +60,14 @@ protected:
 
 public:
     JsrtExternalObject(JsrtExternalType * type, void *data, uint inlineSlotSize);
+    JsrtExternalObject(JsrtExternalObject* instance, bool deepCopy);
 
 #ifdef _CHAKRACOREBUILD
     static JsrtExternalObject * Create(void *data, uint inlineSlotSize, JsTraceCallback traceCallback, JsFinalizeCallback finalizeCallback, Js::RecyclableObject * prototype, Js::ScriptContext *scriptContext, JsrtExternalType * type);
 #endif
     static JsrtExternalObject * Create(void *data, uint inlineSlotSize, JsFinalizeCallback finalizeCallback, Js::RecyclableObject * prototype, Js::ScriptContext *scriptContext, JsrtExternalType * type);
+
+    virtual JsrtExternalObject* Copy(bool deepCopy) override;
 
     JsrtExternalType * GetExternalType() const { return (JsrtExternalType *)this->GetType(); }
 

--- a/lib/Runtime/Library/CustomExternalWrapperObject.cpp
+++ b/lib/Runtime/Library/CustomExternalWrapperObject.cpp
@@ -140,8 +140,7 @@ BOOL CustomExternalWrapperObject::EnsureInitialized(ScriptContext* requestContex
     return TRUE;
 }
 
-CustomExternalWrapperObject*
-CustomExternalWrapperObject::Copy(bool deepCopy)
+CustomExternalWrapperObject* CustomExternalWrapperObject::Copy(bool deepCopy)
 {
     Recycler* recycler = this->GetRecycler();
     CustomExternalWrapperType* externalType = this->GetExternalType();

--- a/lib/Runtime/Library/CustomExternalWrapperObject.h
+++ b/lib/Runtime/Library/CustomExternalWrapperObject.h
@@ -61,12 +61,14 @@ namespace Js
         };
 
         CustomExternalWrapperObject(CustomExternalWrapperType * type, void *data, uint inlineSlotSize);
+        CustomExternalWrapperObject(CustomExternalWrapperObject* instance, bool deepCopy);
 
         BOOL IsObjectAlive();
         BOOL VerifyObjectAlive();
 
         static CustomExternalWrapperObject * Create(void *data, uint inlineSlotSize, JsTraceCallback traceCallback, JsFinalizeCallback finalizeCallback, JsGetterSetterInterceptor ** getterSetterInterceptor, RecyclableObject * prototype, ScriptContext *scriptContext);
-        static CustomExternalWrapperObject * Clone(CustomExternalWrapperObject * source, ScriptContext * scriptContext);
+
+        virtual CustomExternalWrapperObject* Copy(bool deepCopy) override;
 
         static BOOL GetOwnPropertyDescriptor(RecyclableObject * obj, PropertyId propertyId, ScriptContext* requestContext, PropertyDescriptor* propertyDescriptor);
         static BOOL DefineOwnPropertyDescriptor(RecyclableObject * obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* requestContext);

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -840,7 +840,7 @@ namespace Js
         return reinterpret_cast<Field(Var)*>(reinterpret_cast<size_t>(this) + this->GetOffsetOfInlineSlots());
     }
 
-    bool DynamicObject::IsCompatibleForCopy(DynamicObject* from, bool ignoreSideEffects) const
+    bool DynamicObject::IsCompatibleForCopy(DynamicObject* from) const
     {
         if (this->GetTypeHandler()->GetInlineSlotCapacity() != from->GetTypeHandler()->GetInlineSlotCapacity())
         {
@@ -876,7 +876,7 @@ namespace Js
             }
             return false;
         }
-        if (PathTypeHandlerBase::FromTypeHandler(from->GetTypeHandler())->HasAccessors() && !ignoreSideEffects)
+        if (PathTypeHandlerBase::FromTypeHandler(from->GetTypeHandler())->HasAccessors())
         {
             if (PHASE_TRACE1(ObjectCopyPhase))
             {
@@ -892,7 +892,7 @@ namespace Js
             }
             return false;
         }
-        if (!from->GetTypeHandler()->AllPropertiesAreEnumerable() && !ignoreSideEffects)
+        if (!from->GetTypeHandler()->AllPropertiesAreEnumerable())
         {
             if (PHASE_TRACE1(ObjectCopyPhase))
             {
@@ -900,7 +900,7 @@ namespace Js
             }
             return false;
         }
-        if (from->IsExternal() && !ignoreSideEffects)
+        if (from->IsExternal())
         {
             if (PHASE_TRACE1(ObjectCopyPhase))
             {
@@ -920,7 +920,7 @@ namespace Js
         return true;
     }
 
-    bool DynamicObject::TryCopy(DynamicObject* from, bool ignoreSideEffects)
+    bool DynamicObject::TryCopy(DynamicObject* from)
     {
 #if ENABLE_TTD
         if (from->GetScriptContext()->ShouldPerformRecordOrReplayAction())
@@ -934,7 +934,7 @@ namespace Js
             return false;
         }
         // Validate that objects are compatible
-        if (!this->IsCompatibleForCopy(from, ignoreSideEffects))
+        if (!this->IsCompatibleForCopy(from))
         {
             return false;
         }

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -172,7 +172,7 @@ namespace Js
 #endif
 
     private:
-        bool IsCompatibleForCopy(DynamicObject* from, bool ignoreSideEffects) const;
+        bool IsCompatibleForCopy(DynamicObject* from) const;
 
         bool IsObjectHeaderInlinedTypeHandlerUnchecked() const;
     public:
@@ -232,7 +232,7 @@ namespace Js
         void InvalidateHasOnlyWritableDataPropertiesInPrototypeChainCacheIfPrototype();
         void ResetObject(DynamicType* type, BOOL keepProperties);
 
-        bool TryCopy(DynamicObject* from, bool ignoreSideEffects = false);
+        bool TryCopy(DynamicObject* from);
 
         virtual void SetIsPrototype();
 
@@ -334,7 +334,7 @@ namespace Js
 
         void SetObjectArray(ArrayObject* objectArray);
 
-        DynamicObject * Copy(bool deepCopy);
+        virtual DynamicObject* Copy(bool deepCopy);
     protected:
         BOOL GetEnumeratorWithPrefix(JavascriptEnumerator * prefixEnumerator, JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext * scriptContext, EnumeratorCache * enumeratorCache);
 
@@ -350,6 +350,7 @@ namespace Js
         static DynamicObject * BoxStackInstance(DynamicObject * instance, bool deepCopy);
 
     private:
+
         ArrayObject* EnsureObjectArray();
         ArrayObject* GetObjectArrayOrFlagsAsArray() const { return objectArray; }
 


### PR DESCRIPTION
This improves the JsCloneObject API to work with more object types