### PR TITLE
Fix assert when building newly rooted path type

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -2695,7 +2695,12 @@ namespace Js
             newTypeHandler = PathTypeHandlerBase::FromTypeHandler(type->GetTypeHandler());
             if (attr == ObjectSlotAttr_Setter)
             {
-                newTypeHandler->SetSetterSlot(newTypeHandler->GetTypePath()->LookupInline(propertyId, newTypeHandler->GetPathLength()), (PathTypeSetterSlotIndex)(newTypeHandler->GetPathLength() - 1));
+                PropertyIndex getterIndex = newTypeHandler->GetTypePath()->LookupInline(propertyId, newTypeHandler->GetPathLength());
+                Assert(getterIndex != Constants::NoSlot);
+                if (attributes[getterIndex] & ObjectSlotAttr_Accessor)
+                {
+                    newTypeHandler->SetSetterSlot(getterIndex, (PathTypeSetterSlotIndex)(newTypeHandler->GetPathLength() - 1));
+                }
             }
         }
         Assert(newTypeHandler->GetPathLength() == GetPathLength());

--- a/test/es5/objlitgetset3.js
+++ b/test/es5/objlitgetset3.js
@@ -1,0 +1,12 @@
+var v_8184 = {
+    d: "vEH1gs5LChZC6hiytm4BhQY6D1BvBbSR",
+    set d(x) { this.d = x + 0x1337; },
+    f: undefined,
+    d: -0,
+    m: 794.4080805517691,
+    get a() { return 1337; }
+};
+
+v_8184.__proto__ = {};
+if (v_8184.d === -0)
+    WScript.Echo('pass');

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -84,6 +84,11 @@
   </test>
   <test>
     <default>
+      <files>ObjLitGetSet3.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>ObjLitGetSetParseOnly.js</files>
       <baseline>ObjLitGetSetParseOnly.baseline</baseline>
     </default>


### PR DESCRIPTION
Setter-related bookkeeping need not be done for dead setter slots.