### PR TITLE
Do not convert simple type to path type when deleting built-in function property

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1861,6 +1861,11 @@ namespace Js
 
     BOOL PathTypeHandlerBase::SetAttributesAtIndex(DynamicObject* instance, PropertyId propertyId, PropertyIndex index, PropertyAttributes attributes)
     {
+        if (attributes & PropertyDeleted)
+        {
+            DeleteProperty(instance, propertyId, PropertyOperation_None);
+            return true;
+        }
         return SetAttributesHelper(instance, propertyId, index, GetAttributeArray(), PropertyAttributesToObjectSlotAttributes(attributes));
     }
 

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -677,7 +677,15 @@ namespace Js
             CompileAssert(_countof(descriptors) == size);
             if (size > 1)
             {
-                SetAttribute(instance, index, PropertyDeleted);
+                if (GetIsLocked())
+                {
+                    // Prevent conversion to path type and then dictionary. Remove this when path types support deleted properties.
+                    this->ConvertToNonSharedSimpleType(instance)->SetAttribute(instance, index, PropertyDeleted);
+                }
+                else
+                {
+                    SetAttribute(instance, index, PropertyDeleted);
+                }
             }
             else
             {
@@ -999,6 +1007,10 @@ namespace Js
                         typeHandler = this->ConvertToNonSharedSimpleType(instance);
                     }
                     Assert(!oldType->GetIsLocked() || instance->GetDynamicType() != oldType);
+                }
+                if (descriptors[index].Attributes & PropertyDeleted)
+                {
+                    instance->GetScriptContext()->InvalidateProtoCaches(propertyId);
                 }
                 typeHandler->descriptors[index].Attributes = attributes;
                 if (attributes & PropertyEnumerable)

--- a/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
+++ b/test/DebuggerCommon/ES6_intl_simple_attach.js.dbg.baseline
@@ -171,8 +171,7 @@
               "caller": "Error <large string>",
               "arguments": "Error <large string>"
             },
-            "length": "number 2",
-            "name": "string "
+            "length": "number 2"
           }
         }
       }
@@ -321,8 +320,7 @@
               "caller": "Error <large string>",
               "arguments": "Error <large string>"
             },
-            "length": "number 1",
-            "name": "string "
+            "length": "number 1"
           }
         }
       }
@@ -460,8 +458,7 @@
               "caller": "Error <large string>",
               "arguments": "Error <large string>"
             },
-            "length": "number 1",
-            "name": "string "
+            "length": "number 1"
           },
           "resolvedOptions": {
             "#__proto__": {

--- a/test/Function/deleteProperty.js
+++ b/test/Function/deleteProperty.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var l = (function () {
+    function func_0() {
+    }
+    delete func_0.length;
+    Object.defineProperty(Function.prototype, 'length', { writable: true });
+    func_0.length = 'candy';
+    return func_0.length;
+}());
+
+if (l === 'candy')
+    WScript.Echo('pass')

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -228,6 +228,11 @@
   </test>
   <test>
     <default>
+      <files>deleteProperty.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>newFunction.js</files>
       <baseline>newFunction.baseline</baseline>
     </default>


### PR DESCRIPTION
Catch addition of Deleted attribute in PathTypeHandler SetAttributes API's.