### PR TITLE
Add JSRT API for externalizing ArrayBuffers

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -200,6 +200,7 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
 
     m_jsApiHooks.pfJsrtDetachArrayBuffer = (JsAPIHooks::JsrtDetachArrayBufferPtr)GetChakraCoreSymbol(library, "JsDetachArrayBuffer");
     m_jsApiHooks.pfJsrtGetArrayBufferFreeFunction = (JsAPIHooks::JsrtGetArrayBufferFreeFunction)GetChakraCoreSymbol(library, "JsGetArrayBufferFreeFunction");
+    m_jsApiHooks.pfJsrtExternalizeArrayBuffer = (JsAPIHooks::JsrtExternalizeArrayBufferPtr)GetChakraCoreSymbol(library, "JsExternalizeArrayBuffer");
 
 #ifdef _WIN32
     m_jsApiHooks.pfJsrtConnectJITProcess = (JsAPIHooks::JsrtConnectJITProcess)GetChakraCoreSymbol(library, "JsConnectJITProcess");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -138,7 +138,8 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtVarDeserializerFreePtr)(JsVarDeserializerHandle deserializerHandle);
 
     typedef JsErrorCode(WINAPI *JsrtDetachArrayBufferPtr)(JsValueRef buffer);
-    typedef JsErrorCode(WINAPI* JsrtGetArrayBufferFreeFunction)(JsValueRef buffer, ArrayBufferFreeFn** freeFn);
+    typedef JsErrorCode(WINAPI* JsrtGetArrayBufferFreeFunction)(JsValueRef buffer, ArrayBufferFreeFn* freeFn);
+    typedef JsErrorCode(WINAPI* JsrtExternalizeArrayBufferPtr)(JsValueRef buffer);
 
     JsrtCreateRuntimePtr pfJsrtCreateRuntime;
     JsrtCreateContextPtr pfJsrtCreateContext;
@@ -270,6 +271,7 @@ struct JsAPIHooks
 
     JsrtDetachArrayBufferPtr pfJsrtDetachArrayBuffer;
     JsrtGetArrayBufferFreeFunction pfJsrtGetArrayBufferFreeFunction;
+    JsrtExternalizeArrayBufferPtr pfJsrtExternalizeArrayBuffer;
 #ifdef _WIN32
     JsrtConnectJITProcess pfJsrtConnectJITProcess;
 #endif
@@ -512,7 +514,8 @@ public:
     static JsErrorCode WINAPI JsConnectJITProcess(HANDLE processHandle, void* serverSecurityDescriptor, UUID connectionId) { return HOOK_JS_API(ConnectJITProcess(processHandle, serverSecurityDescriptor, connectionId)); }
 #endif
 
-    static JsErrorCode WINAPI JsGetArrayBufferFreeFunction(JsValueRef buffer, ArrayBufferFreeFn** freeFn) { return HOOK_JS_API(GetArrayBufferFreeFunction(buffer, freeFn)); }
+    static JsErrorCode WINAPI JsGetArrayBufferFreeFunction(JsValueRef buffer, ArrayBufferFreeFn* freeFn) { return HOOK_JS_API(GetArrayBufferFreeFunction(buffer, freeFn)); }
+    static JsErrorCode WINAPI JsExternalizeArrayBuffer(JsValueRef buffer) { return HOOK_JS_API(ExternalizeArrayBuffer(buffer)); }
 };
 
 class AutoRestoreContext

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -1887,7 +1887,7 @@ CHAKRA_API
 JsDetachArrayBuffer(
     _In_ JsValueRef arrayBuffer);
 
-typedef void __cdecl ArrayBufferFreeFn(void* ptr);
+typedef void(__cdecl *ArrayBufferFreeFn)(void*);
 
 /// <summary>
 ///     Returns the function which free the underlying buffer of ArrayBuffer
@@ -1901,8 +1901,18 @@ typedef void __cdecl ArrayBufferFreeFn(void* ptr);
 CHAKRA_API
 JsGetArrayBufferFreeFunction(
     _In_ JsValueRef arrayBuffer,
-    _Out_ ArrayBufferFreeFn** freeFn);
+    _Out_ ArrayBufferFreeFn* freeFn);
 
+/// <summary>
+///     Take ownership of current ArrayBuffer
+/// </summary>
+/// <param name="arrayBuffer">An ArrayBuffer to take ownership of</param>
+/// <returns>
+///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+/// </returns>
+CHAKRA_API
+JsExternalizeArrayBuffer(
+    _In_ JsValueRef arrayBuffer);
 
 #ifdef _WIN32
 #include "ChakraCoreWindows.h"

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -498,6 +498,25 @@ JsSetArrayBufferExtraInfo(
 }
 
 CHAKRA_API
+JsExternalizeArrayBuffer(
+    _In_ JsValueRef arrayBufferVar)
+{
+    VALIDATE_JSREF(arrayBufferVar);
+    return ContextAPINoScriptWrapper_NoRecord([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
+
+        Js::ArrayBuffer* arrayBuffer = Js::JavascriptOperators::TryFromVar<Js::ArrayBuffer>(arrayBufferVar);
+        if (!arrayBuffer)
+        {
+            return JsErrorInvalidArgument;
+        }
+
+        arrayBuffer->Externalize();
+
+        return JsNoError;
+    });
+}
+
+CHAKRA_API
 JsDetachArrayBuffer(
     _In_ JsValueRef arrayBuffer)
 {
@@ -1419,7 +1438,7 @@ JsConnectJITProcess(_In_ HANDLE processHandle, _In_opt_ void* serverSecurityDesc
 CHAKRA_API
 JsGetArrayBufferFreeFunction(
     _In_ JsValueRef arrayBuffer,
-    _Out_ ArrayBufferFreeFn** freeFn)
+    _Out_ ArrayBufferFreeFn* freeFn)
 {
   VALIDATE_JSREF(arrayBuffer);
   PARAM_NOT_NULL(freeFn);
@@ -1430,7 +1449,7 @@ JsGetArrayBufferFreeFunction(
           return JsErrorInvalidArgument;
         }
 
-        *freeFn = (ArrayBufferFreeFn*)Js::VarTo<Js::ArrayBuffer>(arrayBuffer)->GetArrayBufferFreeFn();
+        *freeFn = Js::VarTo<Js::ArrayBuffer>(arrayBuffer)->GetArrayBufferFreeFn();
         return JsNoError;
       });
 }

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -122,7 +122,9 @@
     JsCreateWeakReference
     JsDetachArrayBuffer
     JsGetArrayBufferExtraInfo
+    JsExternalizeArrayBuffer
     JsGetAndClearExceptionWithMetadata
+    JsGetArrayBufferFreeFunction
     JsGetArrayEntriesFunction
     JsGetArrayForEachFunction
     JsGetArrayKeysFunction
@@ -168,5 +170,4 @@
     JsVarSerializerSetTransferableVars
     JsVarSerializerWriteRawBytes
     JsVarSerializerWriteValue
-    JsGetArrayBufferFreeFunction
 #endif

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -637,7 +637,7 @@ namespace Js
     ArrayBufferContentForDelayedFreeBase* ArrayBuffer::CopyBufferContentForDelayedFree(RefCountedBuffer * content, DECLSPEC_GUARD_OVERFLOW uint32 bufferLength)
     {
         Assert(content != nullptr);
-        FreeFn* freeFn = nullptr;
+        FreeFn freeFn = nullptr;
 #if ENABLE_FAST_ARRAYBUFFER
         if (IsValidVirtualBufferLength(bufferLength))
         {
@@ -831,7 +831,7 @@ namespace Js
         return result;
     }
 
-    ArrayBuffer::FreeFn* JavascriptArrayBuffer::GetArrayBufferFreeFn()
+    ArrayBuffer::FreeFn JavascriptArrayBuffer::GetArrayBufferFreeFn()
     {
 #if ENABLE_FAST_ARRAYBUFFER
         if (IsValidVirtualBufferLength(bufferLength))
@@ -847,7 +847,7 @@ namespace Js
 
     ArrayBufferDetachedStateBase* JavascriptArrayBuffer::CreateDetachedState(RefCountedBuffer * content, uint32 bufferLength)
     {
-        FreeFn* freeFn = nullptr;
+        FreeFn freeFn = nullptr;
         ArrayBufferAllocationType allocationType;
 #if ENABLE_FAST_ARRAYBUFFER
         if (IsValidVirtualBufferLength(bufferLength))
@@ -914,14 +914,14 @@ namespace Js
         if (refCount == 0)
         {
             BYTE * buffer = content->GetBuffer();
-            if (buffer)
+            if (buffer && !this->externalized)
             {
                 // Recycler may not be available at Dispose. We need to
                 // free the memory and report that it has been freed at the same
                 // time. Otherwise, AllocationPolicyManager is unable to provide correct feedback
 #if ENABLE_FAST_ARRAYBUFFER
         //AsmJS Virtual Free
-                if (buffer && IsValidVirtualBufferLength(this->bufferLength))
+                if (IsValidVirtualBufferLength(this->bufferLength))
                 {
                     FreeMemAlloc(buffer);
                 }

--- a/lib/Runtime/Library/DelayFreeArrayBufferHelper.h
+++ b/lib/Runtime/Library/DelayFreeArrayBufferHelper.h
@@ -93,10 +93,10 @@ namespace Js
     template <typename FreeFN>
     class ArrayBufferContentForDelayedFree : public ArrayBufferContentForDelayedFreeBase
     {
-        FreeFN* freeFunction;
+        FreeFN freeFunction;
 
     public:
-        ArrayBufferContentForDelayedFree(RefCountedBuffer *content, uint32 len, Recycler *r, FreeFN * freeFunction)
+        ArrayBufferContentForDelayedFree(RefCountedBuffer *content, uint32 len, Recycler *r, FreeFN freeFunction)
             : ArrayBufferContentForDelayedFreeBase( content, len, r), freeFunction(freeFunction)
         {}
 


### PR DESCRIPTION
This API gives the host control of an ArrayBuffer's lifetime