### PR TITLE
Not all Win10 processes have CFG

### DIFF
--- a/lib/Common/Core/GlobalSecurityPolicy.cpp
+++ b/lib/Common/Core/GlobalSecurityPolicy.cpp
@@ -101,10 +101,6 @@ GlobalSecurityPolicy::GlobalSecurityPolicy()
         {
             RaiseFailFastException(nullptr, nullptr, FAIL_FAST_GENERATE_EXCEPTION_ADDRESS);
         }
-
-#if defined (NTBUILD)
-        AssertOrFailFast(readOnlyData.isCFGEnabled);
-#endif
     }
 
 #endif //_CONTROL_FLOW_GUARD


### PR DESCRIPTION
My previous CFG change assumed that for Chakra.dll (which only runs on Win10), CFG had to be enabled.
This is true for Edge, but not other processes as CFG is an opt-in feature.
