### PR TITLE
fix assert parsing invalid asm.js module

### DIFF
--- a/lib/Runtime/Language/AsmJsUtils.cpp
+++ b/lib/Runtime/Language/AsmJsUtils.cpp
@@ -37,7 +37,10 @@ namespace Js
             ParseNode* rhs = GetBinaryRight( body );
             if( rhs && rhs->nop == knopList )
             {
-                AssertMsg( lhs->nop == knopStr, "this should be use asm" );
+                if (lhs->nop != knopStr)
+                {
+                    return false;
+                }
                 *var = rhs;
                 return true;
             }

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -1004,6 +1004,13 @@
   </test>
   <test>
     <default>
+      <files>useasmbug.js</files>
+      <baseline>useasmbug.baseline</baseline>
+      <compile-flags>-testtrace:asmjs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>lambda.js</files>
       <baseline>lambda.baseline</baseline>
       <compile-flags>-testtrace:asmjs</compile-flags>

--- a/test/AsmJs/useasmbug.baseline
+++ b/test/AsmJs/useasmbug.baseline
@@ -1,0 +1,1 @@
+Asm.js compilation failed.

--- a/test/AsmJs/useasmbug.js
+++ b/test/AsmJs/useasmbug.js
@@ -1,0 +1,10 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function $() {
+    "use asm"
+    ( );
+    return
+}


### PR DESCRIPTION
Malformed "use asm" statement could cause benign assert in asm.js parser. Reject the malformed asm.js instead of asserting.

Fixes #5996