### PR TITLE
don't look up numeric properties from cache in json code

### DIFF
--- a/lib/Runtime/Library/JSONStringifier.cpp
+++ b/lib/Runtime/Library/JSONStringifier.cpp
@@ -221,22 +221,31 @@ _Ret_notnull_ Var
 JSONStringifier::ReadValue(_In_ JavascriptString* key, _In_opt_ const PropertyRecord* propertyRecord, _In_ RecyclableObject* holder)
 {
     Var value = nullptr;
-    PropertyString* propertyString = JavascriptOperators::TryFromVar<PropertyString>(key);
     PropertyValueInfo info;
-    if (propertyString != nullptr)
-    {
-        PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), false);
-        if (propertyString->TryGetPropertyFromCache<false /* ownPropertyOnly */, false /* OutputExistence */>(holder, holder, &value, this->scriptContext, &info))
-        {
-            return value;
-        }
-    }
 
     if (propertyRecord == nullptr)
     {
         key->GetPropertyRecord(&propertyRecord);
     }
-    JavascriptOperators::GetProperty(holder, propertyRecord->GetPropertyId(), &value, this->scriptContext, &info);
+
+    if (propertyRecord->IsNumeric())
+    {
+        JavascriptOperators::GetItem(holder, propertyRecord->GetNumericValue(), &value, this->scriptContext);
+    }
+    else
+    {
+        PropertyString* propertyString = JavascriptOperators::TryFromVar<PropertyString>(key);
+        if (propertyString != nullptr)
+        {
+            PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), false);
+            if (propertyString->TryGetPropertyFromCache<false /* ownPropertyOnly */, false /* OutputExistence */>(holder, holder, &value, this->scriptContext, &info))
+            {
+                return value;
+            }
+        }
+        JavascriptOperators::GetProperty(holder, propertyRecord->GetPropertyId(), &value, this->scriptContext, &info);
+    }
+
     return value;
 }
 

--- a/test/JSON/cacheassert.js
+++ b/test/JSON/cacheassert.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+JSON.stringify({}, [0]);                                                           
+JSON.stringify({0: {}}, [0]);
+
+print("Pass")

--- a/test/JSON/rlexe.xml
+++ b/test/JSON/rlexe.xml
@@ -16,6 +16,11 @@
   </test>
   <test>
     <default>
+      <files>cacheassert.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>stringify-replacer.js</files>
       <baseline>stringify-replacer.baseline</baseline>
       <compile-flags>-recyclerstress</compile-flags>


### PR DESCRIPTION
inline caches don't support numeric properties, so skip inline cache check lookup for numeric properties in json stringifier

Fixes #5951