### PR TITLE
Fixing TrackAssignment for destructuring syntax

### DIFF
--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -508,6 +508,20 @@ var tests = [
         };
         test1();
     }
+  },
+  {
+    name: "Destructuring expression : Array expression instead of name ",
+    body: function () {
+        function test1(){
+            assert.throws(function () { eval("({a: b => []} = [2])") }, SyntaxError, 
+                "", "Unexpected operator in destructuring expression");
+            
+            assert.throws(function () { eval("for([a => {}] in []);") }, SyntaxError,
+                "", "Unexpected operator in destructuring expression");
+                        
+        };
+        test1();
+    }
   }
 ];
 


### PR DESCRIPTION
We got nullpointer AV as the destructuring syntax is erroneous and we will suppose to get an error.
But we did track assignment before. Fixing this by delaying the trackassignment after error checks.
