### PR TITLE
Fix assertion violation when destructuring pattern contains arrow function

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -13197,7 +13197,7 @@ ParseNodePtr Parser::ParseDestructuredVarDecl(tokens declarationType, bool isDec
 
             // In this destructuring case we can force error here as we cannot assign.
 
-            if (!fCanAssign)
+            if (!fCanAssign || m_token.tk == tkDArrow)
             {
                 Error(ERRInvalidAssignmentTarget);
             }

--- a/test/es6/destructuring.js
+++ b/test/es6/destructuring.js
@@ -247,6 +247,10 @@ var tests = [
 
       // OS 597319: Parens before a default value should not throw
       assert.doesNotThrow(function () { eval("[((((vrh190 )))) = 5184] = []"); }, "Destructured array assignment with parens before a default expression should not throw");
+
+      // Arrow functions as array pattern elements
+      assert.throws(function () { eval("var x; [x => 1] = [1]")}, SyntaxError, "Array pattern with arrow function throws", "Invalid destructuring assignment target");
+      assert.throws(function () { eval("[x => 1] = [1]")}, SyntaxError, "Array pattern with arrow function throws", "Invalid destructuring assignment target");
     }
   },
   {


### PR DESCRIPTION
Fixes #6008
