### PR TITLE
Do not expose async function resumer callbacks to user code

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -1447,13 +1447,7 @@ namespace Js
         value = JavascriptOperators::GetProperty(next, PropertyIds::value, scriptContext);
         Var promiseVar = CALL_FUNCTION(scriptContext->GetThreadContext(), promiseResolve, CallInfo(CallFlags_Value, 2), library->GetPromiseConstructor(), value);
         JavascriptPromise* promise = VarTo<JavascriptPromise>(promiseVar);
-
-        Var promiseThen = JavascriptOperators::GetProperty(promise, PropertyIds::then, scriptContext);
-        if (!JavascriptConversion::IsCallable(promiseThen))
-        {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction);
-        }
-        CALL_FUNCTION(scriptContext->GetThreadContext(), VarTo<RecyclableObject>(promiseThen), CallInfo(CallFlags_Value, 3), promise, successFunction, failFunction);
+        CreateThenPromise(promise, successFunction, failFunction, scriptContext);
 
         END_SAFE_REENTRANT_REGION
     }

--- a/test/es7/asyncawait-functionality.baseline
+++ b/test/es7/asyncawait-functionality.baseline
@@ -37,8 +37,9 @@ Executing test #31 - Async and arguments.caller
 Executing test #32 - Async and split scope
 Test #32 - Success initial value of the formal is the same as the default param value
 Test #32 - Success initial value of the body symbol is the same as the default param value
-Executing test #33 - `then` is called with both onFulfilled and onRejected
-Test #33 - then: true, catch: true
+Executing test #33 - `then` is not called when awaiting a non-promise or native promise
+Executing test #34 - `then` is called when awaiting a promise subclass
+Executing test #35 - `then` is called when awaiting a non-promise thenable
 
 Completion Results:
 Test #1 - Success lambda expression with no argument called with result = 'true'
@@ -85,7 +86,8 @@ Test #28 - Success finally block is executed in async body
 Test #30 - Success async function and arguments.callee
 Test #32 - Success updated value of the formal is the same as the value returned from the second async function
 Test #32 - Success updated value of the body symbol is the same as the value returned from the second async function
-Test #33 - Success caught the expected exception
+Test #34 - Success "then" called on a promise subclass
+Test #35 - Success "then" called on a thenable
 Test #6 - Success await in an async function #1 called with result = '-4'
 Test #6 - Success await in an async function #2 called with result = '2'
 Test #6 - Success await in an async function catch a rejected Promise in 'err'. Error = 'Error: My Error'

--- a/test/es7/asyncawait-functionality.js
+++ b/test/es7/asyncawait-functionality.js
@@ -1039,29 +1039,57 @@ var tests = [
         }
     },
     {
-        name: "`then` is called with both onFulfilled and onRejected",
+        name: "`then` is not called when awaiting a non-promise or native promise",
         body: function (index) {
-            async function bar() {
-                throw new Error("Whoops");
-            }
-
-            async function foo() {
-                try {
-                    await bar();
-                } catch (e){
-                    echo(`Test #${index} - Success caught the expected exception`);
-                }
+            async function f() {
+                await 1;
+                await Promise.resolve(1);
             }
 
             var oldThen = Promise.prototype.then;
-            Promise.prototype.then = function(thenx, catchx) {
-                echo(`Test #${index} - then: ${!!thenx}, catch: ${!!catchx}`)
+            Promise.prototype.then = function(onResolve, onReject) {
+                echo(`Test #${index} - Failed "then" called on non-promise or native promise`);
                 return oldThen.apply(this, arguments);
-            }
+            };
 
-            foo();
+            f();
 
             Promise.prototype.then = oldThen;
+        }
+    },
+    {
+        name: "`then` is called when awaiting a promise subclass",
+        body: function (index) {
+            class PromiseSubclass extends Promise {
+                constructor(executor) { super(executor); }
+                then(onResolve, onReject) {
+                    echo(`Test #${index} - Success "then" called on a promise subclass`);
+                    return super.then(onResolve, onReject);
+                }
+            }
+
+            async function f() {
+                await PromiseSubclass.resolve(1);
+            }
+
+            f();
+        }
+    },
+    {
+        name: "`then` is called when awaiting a non-promise thenable",
+        body: function (index) {
+            let thenable = {
+                then(onResolve, onReject) {
+                    echo(`Test #${index} - Success "then" called on a thenable`);
+                    return Promise.resolve(1);
+                }
+            };
+
+            async function f() {
+                await thenable;
+            }
+
+            f();
         }
     }
 ];


### PR DESCRIPTION
Chakra currently exposes the "resumer" callbacks for `await` expressions within async functions because it calls the "then" method of `await` operand directly. In effect, `await` becomes:

```js
Promise.resolve(operand).then(resumeSuccess, resumeFail);
```

The resumer functions can be obtained by monkey-patching `Promise.prototype.then`:

```js
// Monkey-patch "then"
let oldThen = Promise.prototype.then;
Promise.prototype.then = function(onResolve, onReject) {
  console.log("Got resumers");
  oldThen.call(this, onResolve, onReject);
};

async function af() {
  // This will call the monkey-patched "then"
  // with async function resumers
  await 1;
}
```

This PR removes the ability to capture the resumers and aligns Chakra with the [current specification of await](https://tc39.github.io/ecma262/#await).