### PR TITLE
Fixing class.name issue

### DIFF
--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -119,6 +119,16 @@ using namespace Js;
         ScriptFunction* scriptFunc = ScriptFunction::OP_NewScFunc(environment, infoRef);
         scriptFunc->SetHomeObj(homeObj);
 
+        // After setting homeobject we need to set the name if the object is ready.
+        if ((*infoRef)->GetFunctionProxy()->GetUndeferredFunctionType())
+        {
+            if (!scriptFunc->IsAnonymousFunction() && !scriptFunc->GetFunctionProxy()->EnsureDeserialized()->GetIsStaticNameFunction())
+            {
+                JavascriptString * functionName = scriptFunc->GetDisplayNameImpl();
+                scriptFunc->SetPropertyWithAttributes(PropertyIds::name, functionName, PropertyConfigurable, nullptr);
+            }
+        }
+
         return scriptFunc;
         JIT_HELPER_END(ScrFunc_OP_NewScFuncHomeObj);
     }

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -233,6 +233,25 @@ var tests = [
         var_3 = Promise.prototype.finally.call(var_0, var_1);                              
         assert.throws(() => { new var_2([]).var_3(); },TypeError);
       }
+  },
+  {
+    name: "class name should not change if calling multiple times",
+    body: function () {
+        function getClass() {
+          class A {
+            constructor() {
+
+            }
+          };
+          return A;
+        }
+        let f1 = getClass();
+        let f2 = getClass();
+        let f3 = getClass();
+        assert.areEqual("A", f1.name);
+        assert.areEqual("A", f2.name);
+        assert.areEqual("A", f3.name);
+      }
   }
 
 ];


### PR DESCRIPTION
When initializing the same class multiple times - we were failed to put the .name on the new
function object. That is because we initialize the object by EnsureObjectReady before setting the homeobject.
Fixed that by setting the name after setting the homeobject.
