### PR TITLE
Fixing Crosssite issue during Array.Concat OS: 18874745

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -480,6 +480,7 @@ namespace Js
 
     inline void JavascriptArray::GenericDirectSetItemAt(const uint32 index, Var newValue)
     {
+        newValue = CrossSite::MarshalVar(this->GetScriptContext(), newValue);
         this->DirectSetItemAt(index, newValue);
     }
 

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -222,6 +222,31 @@ var tests = [
       }
   },
   {
+    name: "CrossSite issue while array concat OS: 18874745",
+    body: function () {
+          function test0() {
+            var IntArr0 = Array();
+            var sc0Code = `
+              Object.defineProperty(Array, Symbol.species, { value : function() {
+                      return IntArr0;
+                      }
+                  }
+              );
+            test = function(a, list) {
+                return [a].concat(list);
+            }
+            function out() {
+              test({}, [1]);
+            }
+            `;
+            var sc0 = WScript.LoadScript(sc0Code, 'samethread');
+            sc0.IntArr0 = IntArr0;
+            sc0.out();
+          }
+         test0();
+      }
+  },
+  {
     name: "calling promise's function as constructor should not be allowed",
     body: function () {
         var var_0 = new Promise(function () {});                                           


### PR DESCRIPTION
We were not marshalling the value while putting into the destination array.
Fixed that by marshalling it.
