### PR TITLE
make EndSwitch flush cases to the EndSwitch offset

### DIFF
--- a/lib/Backend/SwitchIRBuilder.cpp
+++ b/lib/Backend/SwitchIRBuilder.cpp
@@ -163,7 +163,7 @@ SwitchIRBuilder::BeginSwitch()
 void
 SwitchIRBuilder::EndSwitch(uint32 offset, uint32 targetOffset)
 {
-    FlushCases(targetOffset);
+    FlushCases(offset);
     AssertMsg(m_caseNodes->Count() == 0, "Not all switch case nodes built by end of switch");
 
     // only generate the final unconditional jump at the end of the switch


### PR DESCRIPTION
This makes it so that if targetOffset is breaking out of a loop we won't have problems (could happen in wasm).

Now cases will go to EndSwitch, which just does direct branch to targetOffset. In normal cases, that will be cleaned up by RetargetBrToBr peep, so codegen doesn't change.

Fixes #6037