### PR TITLE
Memop confusing type-spec syms and var syms

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -8845,7 +8845,11 @@ BackwardPass::RestoreInductionVariableValuesAfterMemOp(Loop *loop)
             opCode = Js::OpCode::Sub_I4;
         }
         Func *localFunc = loop->GetFunc();
-        StackSym *sym = localFunc->m_symTable->FindStackSym(symId)->GetInt32EquivSym(localFunc);
+        StackSym *sym = localFunc->m_symTable->FindStackSym(symId);
+        if (!sym->IsInt32())
+        {
+            sym = sym->GetInt32EquivSym(localFunc);
+        }
         
         IR::Opnd *inductionVariableOpnd = IR::RegOpnd::New(sym, IRType::TyInt32, localFunc);
         IR::Opnd *tempInductionVariableOpnd = IR::RegOpnd::New(IRType::TyInt32, localFunc);
@@ -8929,7 +8933,7 @@ BackwardPass::IsEmptyLoopAfterMemOp(Loop *loop)
                         {
                             Assert(instr->GetDst());
                             if (instr->GetDst()->GetStackSym()
-                                && loop->memOpInfo->inductionVariablesUsedAfterLoop->Test(globOpt->GetVarSymID(instr->GetDst()->GetStackSym())))
+                                && loop->memOpInfo->inductionVariablesUsedAfterLoop->Test(instr->GetDst()->GetStackSym()->m_id))
                             {
                                 // We have use after the loop for a variable defined inside the loop. So the loop can't be removed.
                                 return false;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2216,10 +2216,20 @@ MemOpCheckInductionVariable:
                 if (!loop->memOpInfo->inductionVariableChangeInfoMap->ContainsKey(inductionSymID))
                 {
                     loop->memOpInfo->inductionVariableChangeInfoMap->Add(inductionSymID, inductionVariableChangeInfo);
+                    if (sym->m_id != inductionSymID)
+                    {
+                        // Backwards pass uses this bit-vector to lookup upwardExposedUsed/bytecodeUpwardExposedUsed symbols, which are not necessarily vars.  Just add both.
+                        loop->memOpInfo->inductionVariableChangeInfoMap->Add(sym->m_id, inductionVariableChangeInfo);
+                    }
                 }
                 else
                 {
                     loop->memOpInfo->inductionVariableChangeInfoMap->Item(inductionSymID, inductionVariableChangeInfo);
+                    if (sym->m_id != inductionSymID)
+                    {
+                        // Backwards pass uses this bit-vector to lookup upwardExposedUsed/bytecodeUpwardExposedUsed symbols, which are not necessarily vars.  Just add both.
+                        loop->memOpInfo->inductionVariableChangeInfoMap->Item(sym->m_id, inductionVariableChangeInfo);
+                    }
                 }
             }
             else
@@ -2228,6 +2238,11 @@ MemOpCheckInductionVariable:
                 {
                     Loop::InductionVariableChangeInfo inductionVariableChangeInfo = { 1, isIncr };
                     loop->memOpInfo->inductionVariableChangeInfoMap->Add(inductionSymID, inductionVariableChangeInfo);
+                    if (sym->m_id != inductionSymID)
+                    {
+                        // Backwards pass uses this bit-vector to lookup upwardExposedUsed/bytecodeUpwardExposedUsed symbols, which are not necessarily vars.  Just add both.
+                        loop->memOpInfo->inductionVariableChangeInfoMap->Add(sym->m_id, inductionVariableChangeInfo);
+                    }
                 }
                 else
                 {
@@ -2242,6 +2257,11 @@ MemOpCheckInductionVariable:
                     }
                     inductionVariableChangeInfo.isIncremental = isIncr;
                     loop->memOpInfo->inductionVariableChangeInfoMap->Item(inductionSymID, inductionVariableChangeInfo);
+                    if (sym->m_id != inductionSymID)
+                    {
+                        // Backwards pass uses this bit-vector to lookup upwardExposedUsed/bytecodeUpwardExposedUsed symbols, which are not necessarily vars.  Just add both.
+                        loop->memOpInfo->inductionVariableChangeInfoMap->Item(sym->m_id, inductionVariableChangeInfo);
+                    }
                 }
             }
             break;

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -438,6 +438,25 @@ Peeps::PeepBranch(IR::BranchInstr *branchInstr, bool *const peepedRef)
         //
         // Remove branch-to-next
         //
+        IR::Instr * instrSkip = instrNext;
+        while (instrSkip != targetInstr && instrSkip->IsLabelInstr())
+        {
+            // Skip adjacent labels
+            instrSkip = instrSkip->GetNextRealInstrOrLabel();
+        }
+        if (instrSkip->IsLabelInstr())
+        {
+            if (instrNext == instrSkip)
+            {
+                instrSkip = nullptr;
+            }
+            else
+            {
+                IR::Instr *instrTmp = instrSkip;
+                instrSkip = instrNext;
+                instrNext = instrTmp;
+            }
+        }
         if (targetInstr == instrNext)
         {
             if (!branchInstr->IsLowered())
@@ -532,7 +551,14 @@ Peeps::PeepBranch(IR::BranchInstr *branchInstr, bool *const peepedRef)
                 // The branch removal could have exposed a branch to next opportunity.
                 return Peeps::PeepBranch(instrPrev->AsBranchInstr());
             }
-            return instrNext;
+            if (instrSkip)
+            {
+                return instrSkip;
+            }
+            else
+            {
+                return instrNext;
+            }
         }
     }
     else if (branchInstr->IsConditional())


### PR DESCRIPTION
Memop had a bitvector containing only var syms, but the backwards pass was querying it using bits from upwardExposed and bytecodeUpwardExposed bitvectors, which contain type-spec syms.
