### PR TITLE
fix bug with -NaN and +NaN in sets

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -303,9 +303,10 @@ namespace Js {
            if (typeId == TypeIds_Number)
            {
                double numberValue = JavascriptNumber::GetValue(value);
+               // NaN and -NaN do not canonicalize to the same value, but they are equal, so only allow +NaN
                return JavascriptNumber::IsNan(numberValue)
                    ? JavascriptNumber::IsNegative(numberValue)
-                        ? JavascriptNumber::ToVar(JavascriptNumber::NegativeNaN)
+                        ? nullptr
                         : JavascriptNumber::ToVar(JavascriptNumber::NaN)
                    : value;
            }

--- a/test/es6/set_functionality.js
+++ b/test/es6/set_functionality.js
@@ -742,6 +742,15 @@ var tests = [
             assert.isTrue(set.has(value), "1.0 should be equal to the value 1 and set has it");
         }
     },
+    {
+        name: "-NaN and +NaN in set should not assert (github #6063)",
+        body: function() {
+            let set = new Set([+NaN, -NaN, "asdf"]);
+            assert.isTrue(set.has(-NaN));
+            assert.isTrue(set.has(NaN));
+            assert.isTrue(set.has("asdf"));
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
This will cause assert and will make it so that we might not get same signed NaN out from set.entries.

Fixes #6063