### PR TITLE
remove byteLength from asm.js imports

### DIFF
--- a/lib/Runtime/Language/AsmJs.h
+++ b/lib/Runtime/Language/AsmJs.h
@@ -48,8 +48,6 @@ namespace Js
         static bool CheckNewArrayView( AsmJsModuleCompiler &m, PropertyName varName, ParseNode *newExpr );
         static bool CheckFunction( AsmJsModuleCompiler &m, ParseNodeFnc* fncNode );
         static bool CheckFunctionsSequential(AsmJsModuleCompiler &m);
-        static bool CheckChangeHeap(AsmJsModuleCompiler &m);
-        static bool CheckByteLengthCall(AsmJsModuleCompiler &m, ParseNode * node, ParseNode * newBufferDecl);
         static bool CheckGlobalVariableInitImport( AsmJsModuleCompiler &m, PropertyName varName, ParseNode *initNode, bool isMutable = true );
         static bool CheckGlobalVariableImportExpr(AsmJsModuleCompiler &m, PropertyName varName, AsmJSCoercion coercion, ParseNode *coercedExpr);
         static bool CheckFunctionTables(AsmJsModuleCompiler& m);

--- a/lib/Runtime/Language/AsmJsBuiltInNames.h
+++ b/lib/Runtime/Language/AsmJsBuiltInNames.h
@@ -21,12 +21,8 @@
 #define ASMJS_MATH_DOUBLE_CONST_NAMES(name, propertyName, value) ASMJS_MATH_CONST_NAMES(name, propertyName, value)
 #endif
 
-#ifndef ASMJS_ARRAY_NAMES
-#define ASMJS_ARRAY_NAMES(name, propertyName)
-#endif
-
 #ifndef ASMJS_TYPED_ARRAY_NAMES
-#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) ASMJS_ARRAY_NAMES(name, propertyName)
+#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName)
 #endif
 
 #ifdef ENABLE_JS_BUILTINS
@@ -73,12 +69,10 @@ ASMJS_TYPED_ARRAY_NAMES(Uint32Array,  Uint32Array)
 ASMJS_TYPED_ARRAY_NAMES(Int32Array,   Int32Array)
 ASMJS_TYPED_ARRAY_NAMES(Float32Array, Float32Array)
 ASMJS_TYPED_ARRAY_NAMES(Float64Array, Float64Array)
-ASMJS_ARRAY_NAMES(byteLength,   byteLength)
 
 // help the caller to undefine all the macros
 #undef ASMJS_JSBUILTIN_MATH_FUNC_NAMES
 #undef ASMJS_MATH_FUNC_NAMES
 #undef ASMJS_MATH_CONST_NAMES
 #undef ASMJS_MATH_DOUBLE_CONST_NAMES
-#undef ASMJS_ARRAY_NAMES
 #undef ASMJS_TYPED_ARRAY_NAMES

--- a/lib/Runtime/Language/AsmJsLink.cpp
+++ b/lib/Runtime/Language/AsmJsLink.cpp
@@ -138,31 +138,8 @@ namespace Js{
 
     bool ASMLink::CheckArrayLibraryMethod(ScriptContext* scriptContext, const Var stdlib, const AsmJSTypedArrayBuiltinFunction arrayLibMethod)
     {
-        Var arrayFuncObj;
         switch (arrayLibMethod)
         {
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_byteLength:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::byteLength, scriptContext);
-            if (VarIs<JavascriptFunction>(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                if (arrayLibFunc->IsBoundFunction())
-                {
-                    BoundFunction* boundFunc = (BoundFunction*)arrayLibFunc;
-                    RecyclableObject* thisObj = boundFunc->GetBoundThis();
-                    if (VarIs<JavascriptFunction>(thisObj))
-                    {
-                        JavascriptFunction * thisFunc = (JavascriptFunction*)thisObj;
-                        if (thisFunc->GetFunctionInfo()->GetOriginalEntryPoint() != (&ArrayBuffer::EntryInfo::GetterByteLength)->GetOriginalEntryPoint())
-                        {
-                            return false;
-                        }
-                    }
-                    JavascriptFunction* targetFunc = boundFunc->GetTargetFunction();
-                    return targetFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&JavascriptFunction::EntryInfo::Call)->GetOriginalEntryPoint();
-                }
-            }
-            break;
 #define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_##name: \
             return CheckIsBuiltinFunction(scriptContext, stdlib, PropertyIds::##propertyName, propertyName##::EntryInfo::NewInstance);
 #include "AsmJsBuiltInNames.h"

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -1001,27 +1001,6 @@ namespace Js
         return nullptr;
     }
 
-    bool AsmJsModuleCompiler::CheckByteLengthCall(ParseNode * callNode, ParseNode * bufferDecl)
-    {
-        if (callNode->nop != knopCall || callNode->AsParseNodeCall()->pnodeTarget->nop != knopName)
-        {
-            return false;
-        }
-        AsmJsTypedArrayFunction* arrayFunc = LookupIdentifier<AsmJsTypedArrayFunction>(callNode->AsParseNodeCall()->pnodeTarget->name());
-        if (!arrayFunc)
-        {
-            return false;
-        }
-
-        return callNode->AsParseNodeCall()->argCount == 1 &&
-            !callNode->AsParseNodeCall()->isApplyCall &&
-            !callNode->AsParseNodeCall()->isEvalCall &&
-            callNode->AsParseNodeCall()->spreadArgCount == 0 &&
-            arrayFunc->GetArrayBuiltInFunction() == AsmJSTypedArrayBuiltin_byteLength &&
-            callNode->AsParseNodeCall()->pnodeArgs->nop == knopName &&
-            callNode->AsParseNodeCall()->pnodeArgs->name()->GetPropertyId() == bufferDecl->name()->GetPropertyId();
-    }
-
     bool AsmJsModuleCompiler::Fail(ParseNode* usepn, const wchar *error)
     {
         AsmJSCompiler::OutputError(GetScriptContext(), error);
@@ -1203,7 +1182,6 @@ namespace Js
         arrayFunctions[AsmJSTypedArrayBuiltin_Uint32Array] = ArrayFunc(PropertyIds::Uint32Array, Anew(&mAllocator, AsmJsTypedArrayFunction, nullptr, &mAllocator, AsmJSTypedArrayBuiltin_Uint32Array, ArrayBufferView::TYPE_UINT32));
         arrayFunctions[AsmJSTypedArrayBuiltin_Float32Array] = ArrayFunc(PropertyIds::Float32Array, Anew(&mAllocator, AsmJsTypedArrayFunction, nullptr, &mAllocator, AsmJSTypedArrayBuiltin_Float32Array, ArrayBufferView::TYPE_FLOAT32));
         arrayFunctions[AsmJSTypedArrayBuiltin_Float64Array] = ArrayFunc(PropertyIds::Float64Array, Anew(&mAllocator, AsmJsTypedArrayFunction, nullptr, &mAllocator, AsmJSTypedArrayBuiltin_Float64Array, ArrayBufferView::TYPE_FLOAT64));
-        arrayFunctions[AsmJSTypedArrayBuiltin_byteLength] = ArrayFunc(PropertyIds::byteLength, Anew(&mAllocator, AsmJsTypedArrayFunction, nullptr, &mAllocator, AsmJSTypedArrayBuiltin_byteLength, ArrayBufferView::TYPE_COUNT));
 
         for (int i = 0; i < AsmJSTypedArrayBuiltin_COUNT; i++)
         {
@@ -1917,7 +1895,7 @@ namespace Js
             case AsmJsSymbol::TypedArrayBuiltinFunction:
                 switch (asmSlot->builtinArrayFunc)
                 {
-#define ASMJS_ARRAY_NAMES(name, propertyName) \
+#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) \
             case AsmJSTypedArrayBuiltin_##name: \
                 value = JavascriptOperators::OP_GetProperty(stdLibObj, PropertyIds::##propertyName, scriptContext); \
                 break;

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -277,7 +277,6 @@ namespace Js {
         bool AddStandardLibraryMathName(PropertyId id, AsmJsMathFunction* func, AsmJSMathBuiltinFunction mathLibFunctionName);
         bool AddStandardLibraryMathName(PropertyId id, const double* cstAddr, AsmJSMathBuiltinFunction mathLibFunctionName);
         bool AddStandardLibraryArrayName(PropertyId id, AsmJsTypedArrayFunction * func, AsmJSTypedArrayBuiltinFunction mathLibFunctionName);
-        bool CheckByteLengthCall(ParseNode * node, ParseNode * newBufferDecl);
     };
 
     template<typename T>

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -90,7 +90,7 @@ namespace Js
     };
     enum AsmJSTypedArrayBuiltinFunction
     {
-#define ASMJS_ARRAY_NAMES(name, propertyName) AsmJSTypedArrayBuiltin_##name,
+#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) AsmJSTypedArrayBuiltin_##name,
 #include "AsmJsBuiltInNames.h"
         AsmJSTypedArrayBuiltin_COUNT
     };

--- a/test/AsmJs/relink.js
+++ b/test/AsmJs/relink.js
@@ -14,7 +14,6 @@ function foo(stdlib, imports, heap)
     const b = 3.5;
     var inf = stdlib.Infinity;
     var I8=stdlib.Int8Array;
-    var len = stdlib.byteLength;
     var ln2 = stdlib.Math.LN2;
     var i8= new I8(heap);
     var c = fr(4);
@@ -48,7 +47,6 @@ function foo(stdlib, imports, heap)
     var table1 = [f, g, f, g];
     return {fExp:f, gExp:g};
 }
-this['byteLength'] = Function.prototype.call.bind(Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength').get);
 var buffer = new ArrayBuffer(1<<24);
 var module1 = foo(this, {bar: function f(c){print("import func, val " + c)}, c: 4.5, d: 12}, buffer);
 var module2 = foo(this, {bar: function f(c){print("import2 func, val " + c)}, c: 5.5, d: 13}, new ArrayBuffer(1<<25));


### PR DESCRIPTION
byteLength was only used for changeHeap, which was removed from asm.js spec.

There was bug in how it handled bound this, but since we shouldn't be having it in our list of imports at all, so fixed by removing all the handling for it.

Fixes #6052