### PR TITLE
While inlining don't add bytecodeuses of args if it has same bytecodeReg as dst

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -2215,7 +2215,7 @@ Inline::InlineBuiltInFunction(
                 StackSym * sym = argInstr->GetSrc1()->GetStackSym();
                 if (!sym->m_isSingleDef || !sym->m_instrDef->GetSrc1() || !sym->m_instrDef->GetSrc1()->IsConstOpnd())
                 {
-                    if (!sym->IsFromByteCodeConstantTable())
+                    if (!sym->IsFromByteCodeConstantTable() && sym->GetByteCodeRegSlot() != callInstrDst->GetStackSym()->GetByteCodeRegSlot())
                     {
                         byteCodeUsesInstr->Set(argInstr->GetSrc1());
                     }


### PR DESCRIPTION
Fixes #5971
