### PR TITLE
Call user-defined toPrimitive on symbol objects

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -378,8 +378,13 @@ CommonNumber:
         case TypeIds_SymbolObject:
             {
                 JavascriptSymbolObject* symbolObject = UnsafeVarTo<JavascriptSymbolObject>(aValue);
+                ScriptContext* objectScriptContext = symbolObject->GetScriptContext();
+                if (objectScriptContext->optimizationOverrides.GetSideEffects() & SideEffects_ToPrimitive)
+                {
+                    return MethodCallToPrimitive<hint>(symbolObject, requestContext);
+                }
 
-                return CrossSite::MarshalVar(requestContext, symbolObject->Unwrap(), symbolObject->GetScriptContext());
+                return CrossSite::MarshalVar(requestContext, symbolObject->Unwrap(), objectScriptContext);
             }
 
         case TypeIds_Date:

--- a/lib/Runtime/Types/TypeHandler.cpp
+++ b/lib/Runtime/Types/TypeHandler.cpp
@@ -562,7 +562,6 @@ using namespace Js;
                 scriptContext->optimizationOverrides.SetSideEffects((SideEffects)(SideEffects_ValueOf & possibleSideEffects));
                 scriptContext->optimizationOverrides.SetSideEffects((SideEffects)(SideEffects_ToString & possibleSideEffects));
             }
-
             else if (propertyId == PropertyIds::valueOf)
             {
                 scriptContext->optimizationOverrides.SetSideEffects((SideEffects)(SideEffects_ValueOf & possibleSideEffects));

--- a/test/es6/toPrimitive.js
+++ b/test/es6/toPrimitive.js
@@ -55,6 +55,19 @@ var tests = [
             assert.areEqual(s, Object(s)[Symbol.toPrimitive](), ""); // true
             assert.areEqual(s, Symbol.prototype[Symbol.toPrimitive].call(s), ""); // true
 
+            var symbolObject = Object(s);
+            Object.defineProperty(symbolObject, Symbol.toPrimitive, {
+                value: function() { return 42; },
+                configurable: true,
+            });
+            assert.areEqual(+symbolObject, 42, "User-defined @@toPrimitive is called on symbol objects");
+            Object.defineProperty(symbolObject, Symbol.toPrimitive, { value: undefined });
+            Object.defineProperty(symbolObject, 'valueOf', {
+                value: function() { return 43; },
+                configurable: true,
+            });
+            assert.areEqual(+symbolObject, 43, "OrdinaryToPrimitive is called if @@toPrimitive is undefined");
+
             assert.areEqual(Symbol.toPrimitive, Symbol.toPrimitive[Symbol.toPrimitive](), "Symbol.toPrimitive");
             assert.areEqual(Symbol.iterator, Symbol.iterator[Symbol.toPrimitive](), "Symbol.iterator");
             assert.areEqual(Symbol.hasInstance, Symbol.hasInstance[Symbol.toPrimitive](), "Symbol.hasInstance");


### PR DESCRIPTION
Users can override the `Symbol.toPrimitive` method on symbol wrapper objects.

Fixes #6036