### PR TITLE
OS#19405757: Don't reset hasBailedOut bit when we bailout from a non exception finally region

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1178,7 +1178,7 @@ BailOutRecord::BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, Bail
     bool * hasBailedOutBitPtr = layout->functionObject->GetScriptContext()->GetThreadContext()->GetHasBailedOutBitPtr();
     Assert(!bailOutRecord->ehBailoutData || hasBailedOutBitPtr ||
         bailOutRecord->ehBailoutData->ht == Js::HandlerType::HT_Finally /* When we bailout from inlinee in non exception finally, we maynot see hasBailedOutBitPtr*/);
-    if (hasBailedOutBitPtr && bailOutRecord->ehBailoutData)
+    if (hasBailedOutBitPtr && bailOutRecord->ehBailoutData && bailOutRecord->ehBailoutData->ht != Js::HandlerType::HT_Finally)
     {
         *hasBailedOutBitPtr = true;
     }

--- a/test/EH/hasBailedOutBug3.js
+++ b/test/EH/hasBailedOutBug3.js
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.Echo = function (n) {
+  formatOutput(n.toString());
+};
+function formatOutput(n) {
+  return n.replace(/[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?/g, function () {
+  });
+}
+function test0() {
+  var GiantPrintArray = [];
+  var protoObj0 = {};
+  try {
+    function func36() {
+      try {
+      }
+       finally {
+        WScript.Echo('' + b);
+        GiantPrintArray.push(protoObj0);
+      }
+    }
+    func36();
+    __loopSecondaryVar3_0;
+  } catch (ex) {
+    b = ex;
+  }
+}
+test0();
+test0();
+test0();
+print("Passed\n");
+

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -191,6 +191,11 @@
   </test>
   <test>
     <default>
+       <files>hasBailedOutBug3.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
        <files>StackOverflow.js</files>
     </default>
   </test>


### PR DESCRIPTION
We use hasBailedOut bit to indicate wheter we have to catch the exception or pass the exception up the call stack.
For this, we maintain a stack of hasBailedOut bit ptrs based on exception handling depth via ctors/dtors when we enter/leave an exception handling region.
But, we execute non-exception finally after the dtor pops off the current exception handling region's hasBailedOut bit. Therefore, setting it on bailout would be incorrect, because the top of the stack of hasBailedOut bits is not of the current try-finally, but of its parent.
