### PR TITLE
Fixing Assert at InitBoxedInlineSegments

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11919,13 +11919,12 @@ Case0:
 
         if (IsInlineSegment(src, instance))
         {
-            Assert(src->size <= SparseArraySegmentBase::INLINE_CHUNK_SIZE);
-
             // Copy head segment data between inlined head segments
             dst = DetermineInlineHeadSegmentPointer<T, 0, true>(static_cast<T*>(this));
             dst->left = src->left;
             dst->length = src->length;
-            dst->size = src->size;
+            uint inlineChunkSize = SparseArraySegmentBase::INLINE_CHUNK_SIZE;
+            dst->size = min(src->size, inlineChunkSize);
         }
         else
         {
@@ -11940,7 +11939,8 @@ Case0:
 
         Assert(IsInlineSegment(src, instance) == IsInlineSegment(dst, static_cast<T*>(this)));
 
-        CopyArray(dst->elements, dst->size, src->elements, src->size);
+        AssertOrFailFast(dst->size <= src->size);
+        CopyArray(dst->elements, dst->size, src->elements, dst->size);
 
         if (!deepCopy)
         {

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -247,6 +247,18 @@ var tests = [
       }
   },
   {
+    name: "Init box javascript array : OS : 20517662",
+    body: function () {
+      var obj = {};
+      obj[0] = 11;
+      obj[1] = {};
+      obj[17] = 222;
+      obj[35] = 333; // This is will increase the size past the inline segment
+      
+      Object.assign({}, obj); // The InitBoxedInlineSegments will be called due to this call.
+    }
+  },
+  {
     name: "calling promise's function as constructor should not be allowed",
     body: function () {
         var var_0 = new Promise(function () {});                                           


### PR DESCRIPTION
The assert will be fired as the size of the segment can be larger than length. Say when you add a item on an Array on that size position.
However the assert needs to go away along with that we need to fix the size of new Array with max of INLINE_CHUNK_SIZE, so that IsInlineSegment logic
works correctly as the new Array's segment was indeed inlined.
Truncating the size would not be a problem as this cannot be smaller than length and later if the size needed to be increased the current segment will be
re-allocated.
