### PR TITLE
OS#19035235:Fix constant branch folding for BrOnObject

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6956,7 +6956,20 @@ GlobOpt::CanProveConditionalBranch(IR::Instr *instr, Value *src1Val, Value *src2
         {
             return false;
         }
-        *result = !src1ValueInfo->IsPrimitive();
+
+        if (src1ValueInfo->IsPrimitive())
+        {
+            *result = false;
+        }
+        else
+        {
+            if (src1ValueInfo->HasBeenPrimitive())
+            {
+                return false;
+            }
+            *result = true;
+        }
+
         break;
     }
     default:

--- a/test/Optimizer/bugconstfoldobject.baseline
+++ b/test/Optimizer/bugconstfoldobject.baseline
@@ -1,0 +1,3 @@
+[object Object]
+[object Object]
+[object Object]

--- a/test/Optimizer/bugconstfoldobject.js
+++ b/test/Optimizer/bugconstfoldobject.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  class class3 {
+    constructor() {
+      return '9'.match(/^(?=[a7])$/gim);
+    }
+  }
+  strvar0 = new class3();
+  new class3();
+  WScript.Echo(strvar0);
+}
+test0();
+test0();
+test0();
+


### PR DESCRIPTION
BrOnObject is true for non-primitives, false for primitives. We were relying on IsDefinite along with IsPrimitive check to constant fold BrOnObject.
But this is not sufficient for a valueType like Null | Object. IsPrimitive returns false because it sees the Object bit, we cannot constant fold BrOnObject to true with just this check.
Because the valueType can also be Null. This change fixes this.
