### PR TITLE
OS#20500679: Disable addition of masking blocks for speculation hoisting when globopt is off

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -3857,7 +3857,7 @@ BackwardPass::ProcessBlock(BasicBlock * block)
            this->tag == Js::DeadStorePhase
         // We don't do the masking in simplejit due to reduced perf concerns and the issues
         // with handling try/catch structures with late-added blocks
-        && !this->func->IsSimpleJit()
+        && this->func->DoGlobOpt()
         // We don't need the masking blocks in asmjs/wasm mode
         && !block->GetFirstInstr()->m_func->GetJITFunctionBody()->IsAsmJsMode()
         && !block->GetFirstInstr()->m_func->GetJITFunctionBody()->IsWasmFunction()

--- a/test/EH/regionBugSpecHoisting.js
+++ b/test/EH/regionBugSpecHoisting.js
@@ -1,0 +1,28 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var ui8 = new Uint8Array(1);
+  try {
+    try {
+      for (var _strvar28 in ui8) {
+        try {
+          return '';
+        } catch (ex) {
+        }
+        try {
+        } catch (ex) {
+        }
+      }
+   } catch(ex) {
+   }
+  } finally {
+  }
+}
+test0();
+test0();
+test0();
+test0();
+print("Passed\n");

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -210,4 +210,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>regionBugSpecHoisting.js</files>
+      <compile-flags>-mic:1 -off:simplejit</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Addition of masking on blocks for speculation hoisting on loop out edges was turned off for SimpleJit due to reduced perf concerns and issues with assigning regions.
However, it was not turned off when globopt is turned off. So we ended up with asserts regarding regions in FlowGraph::Destroy.
This changes fixes this.
