### PR TITLE
Cleanup some region propagation code from flowgraph

### DIFF
--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -201,10 +201,7 @@ private:
     void        BuildLoop(BasicBlock *headBlock, BasicBlock *tailBlock, Loop *parentLoop = nullptr);
     void        WalkLoopBlocks(BasicBlock *block, Loop *loop, JitArenaAllocator *tempAlloc);
     void        AddBlockToLoop(BasicBlock *block, Loop *loop);
-    bool        IsEHTransitionInstr(IR::Instr *instr);
-    BasicBlock * GetPredecessorForRegionPropagation(BasicBlock *block);
     void        UpdateRegionForBlock(BasicBlock *block);
-    void        UpdateRegionForBlockFromEHPred(BasicBlock *block, bool reassign = false);
     Region *    PropagateRegionFromPred(BasicBlock *block, BasicBlock *predBlock, Region *predRegion, IR::Instr * &tryInstr);
     IR::Instr * PeepCm(IR::Instr *instr);
     IR::Instr * PeepTypedCm(IR::Instr *instr);


### PR DESCRIPTION
We don't really need UpdateRegionFromEHPred. UpdateRegionFromPred is sufficient.
I had added UpdateRegionFromEHPred when we would get different region for a block, based on the predecessor we chose.
But since then, we add all possible flow edges for try/finallys and hence we don't have this issue anymore.
This change does the cleanup.
