### PR TITLE
Fix crawler assert of 2 lifetimes with same bytecode reg

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4059,6 +4059,7 @@ BackwardPass::DeadStoreOrChangeInstrForScopeObjRemoval(IR::Instr ** pInstrPrev)
                         Assert(currFunc->HasStackSymForFormal(value));
                         StackSym * paramStackSym = currFunc->GetStackSymForFormal(value);
                         IR::RegOpnd * srcOpnd = IR::RegOpnd::New(paramStackSym, TyVar, currFunc);
+                        srcOpnd->SetIsJITOptimizedReg(true);
                         instr->ReplaceSrc1(srcOpnd);
                         this->ProcessSymUse(paramStackSym, true, true);
 


### PR DESCRIPTION
The optimization copy-proping away argument object references in inlinees was missing a isJitOptimizeReg flag.
VSO bug: 20813519
