### PR TITLE
Fix patterns in rest formal parameters.

### DIFF
--- a/lib/Parser/FormalsUtil.h
+++ b/lib/Parser/FormalsUtil.h
@@ -38,5 +38,10 @@ void MapFormalsFromPattern(ParseNodeFnc *pnodeFunc, Fn fn)
             Parser::MapBindIdentifier(pnode->AsParseNodeParamPattern()->pnode1, fn);
         }
     }
-}
 
+    ParseNodePtr rest = pnodeFunc->pnodeRest;
+    if (rest != nullptr && rest->nop == knopParamPattern)
+    {
+        Parser::MapBindIdentifier(rest->AsParseNodeParamPattern()->pnode1, fn);
+    }
+}

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -509,7 +509,7 @@ public:
     ParseNodePtr pnodeParams;
     ParseNodePtr pnodeVars;
     ParseNodePtr pnodeBody;
-    ParseNodeVar * pnodeRest;
+    ParseNodePtr pnodeRest;
 
     FuncInfo *funcInfo; // function information gathered during byte code generation
     Scope *scope;

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -249,15 +249,15 @@ var tests = [
   {
     name: "Rest as pattern at param with arguments/eval at function body",
     body: function () {
-        (function ([a, b], c, ...{rest1, rest2}) {
+        (function ([a, b], c, ...{'0': rest1, '1': rest2}) {
             eval("");
             assert.areEqual(rest1, 4);
             assert.areEqual(rest2, 5);
             assert.areEqual(c, 3);
             assert.areEqual(arguments[1], 3);
-        })([1, 2], 3, {rest1:4, rest2:5});
+        })([1, 2], 3, 4, 5);
 
-        (function ([a, b], c, ...{rest1, rest2}) {
+        (function ([a, b], c, ...{'0': rest1, '1': rest2}) {
             (function () {
                 assert.areEqual(rest1, 4);
                 assert.areEqual(rest2, 5);
@@ -265,7 +265,7 @@ var tests = [
             })();
             eval("");
             assert.areEqual(arguments[0], [1, 2]);
-        })([1, 2], 3, {rest1:4, rest2:5});
+        })([1, 2], 3, 4, 5);
     }
   },
   {

--- a/test/es6/rest.js
+++ b/test/es6/rest.js
@@ -10,23 +10,37 @@ var tests = [
     name: "Rest parsing and errors",
     body: function () {
       assert.throws(function () { eval("function foo(...a, ...b) {}")},          SyntaxError,    "More than one rest parameter throws", "The rest parameter must be the last parameter in a formals list.");
+      assert.throws(function () { eval("function foo(...[a], ...b) {}")},          SyntaxError,    "More than one rest parameter throws", "The rest parameter must be the last parameter in a formals list.");
+      assert.throws(function () { eval("function foo(...a, ...[b]) {}")},          SyntaxError,    "More than one rest parameter throws", "The rest parameter must be the last parameter in a formals list.");
       assert.throws(function () { eval("function foo(a, ...b, c) => {}")},       SyntaxError,    "Rest parameter not in the last position throws", "The rest parameter must be the last parameter in a formals list.");
+      assert.throws(function () { eval("function foo(a, ...[b], c) => {}")},       SyntaxError,    "Rest pattern parameter not in the last position throws", "The rest parameter must be the last parameter in a formals list.");
       assert.throws(function () { eval("var obj = class { method(a, b = 1, ...c = [2,3]) {} };")},         SyntaxError, "Rest parameter cannot have a default value");
       assert.throws(function () { eval("function f(c, a, ...a) { }")},           SyntaxError,    "Duplicate parameters are not allowed for non-simple parameter list with only rest", "Duplicate formal parameter names not allowed in this context");
+      assert.throws(function () { eval("function f(c, a, ...[a]) { }")},           SyntaxError,    "Duplicate parameters are not allowed for non-simple parameter list with rest array pattern", "Let/Const redeclaration");
+      assert.throws(function () { eval("function f(c, a, ...{b:a}) { }")},           SyntaxError,    "Duplicate parameters are not allowed for non-simple parameter list with rest object pattern", "Let/Const redeclaration");
       assert.throws(function () { eval("function f(c = 10, a, ...a) { }")},      SyntaxError,    "Duplicate parameters are not allowed for non-simple parameter list with both rest and default", "Duplicate formal parameter names not allowed in this context");
       assert.throws(function () { eval("function f(...a) { 'use strict'; }"); },          SyntaxError, "Strict mode cannot be applied to functions with rest parameter", "Illegal 'use strict' directive in function with non-simple parameter list");
       assert.throws(function () { eval("function f(a, ...b) { 'use strict'; }"); },       SyntaxError, "Strict mode cannot be applied to functions with rest parameter", "Illegal 'use strict' directive in function with non-simple parameter list");
+      assert.throws(function () { eval("function f(a, ...[b]) { 'use strict'; }"); },       SyntaxError, "Strict mode cannot be applied to functions with rest parameter", "Illegal 'use strict' directive in function with non-simple parameter list");
       assert.throws(function () { eval("function f() { \"use strict\"; function g(a, b, c, ...a) { } }")}, SyntaxError, "Cannot have duplicate parameters for a function with non-simple parameter list, which is already in strict mode", "Duplicate formal parameter names not allowed in strict mode");
       assert.throws(function () { eval("function f() { \"use strict\"; function g(a, b, a, ...c) { } }")}, SyntaxError, "Cannot have duplicate parameters for a function with non-simple parameter list with rest, which is already in strict mode", "Duplicate formal parameter names not allowed in strict mode");
 
       assert.throws(function () { eval("function foo(a = b, ...b) {}; foo();")}, ReferenceError, "Rest parameters cannot be referenced in default expressions (use before declaration)", "Use before declaration");
+      assert.throws(function () { eval("function foo(a = b, ...[b]) {}; foo();")}, ReferenceError, "Rest parameters cannot be referenced in default expressions (use before declaration)", "Use before declaration");
+      assert.throws(function () { eval("function foo(a = b, ...{c:b}) {}; foo();")}, ReferenceError, "Rest parameters cannot be referenced in default expressions (use before declaration)", "Use before declaration");
 
       // Redeclaration errors - non-simple in this case means any parameter list with a rest parameter
       assert.doesNotThrow(function () { eval("function foo(...a) { var a; }"); },
                     "Var redeclaration does not throw with a non-simple parameter list");
+      assert.doesNotThrow(function () { eval("function foo(...[a]) { var a; }"); },
+                    "Var redeclaration does not throw with a non-simple parameter list");
       assert.doesNotThrow(function () { eval("function foo(a, ...b) { var a; }"); },
                     "Var redeclaration does not throw with a non-simple parameter list on a non-rest parameter");
       assert.throws(function () { function foo(...a) { eval('var a;'); }; foo(); },
+          ReferenceError,
+          "Var redeclaration throws with a non-simple parameter list inside an eval",
+          "Let/Const redeclaration");
+      assert.throws(function () { function foo(...[a]) { eval('var a;'); }; foo(); },
           ReferenceError,
           "Var redeclaration throws with a non-simple parameter list inside an eval",
           "Let/Const redeclaration");
@@ -44,6 +58,7 @@ var tests = [
           "Let/Const redeclaration");
 
       assert.doesNotThrow(function () { function foo(...a) { eval('let a;'); }; foo(); }, "Let redeclaration inside an eval does not throw with a non-simple parameter list");
+      assert.doesNotThrow(function () { function foo(...[a]) { eval('let a;'); }; foo(); }, "Let redeclaration inside an eval does not throw with a non-simple parameter list");
       assert.doesNotThrow(function () { function foo(...a) { eval('const a = "str";'); }; foo() }, "Const redeclaration inside an eval does not throw with a non-simple parameter list");
       assert.throws(function () { function foo(a, ...b) { eval('var a;'); }; foo(); },
                     ReferenceError,
@@ -58,14 +73,22 @@ var tests = [
                     SyntaxError,
                     "Setter methods cannot have a rest parameter",
                     "Unexpected ... operator");
+      assert.throws(function () { eval("var x = { set setter(...[x]) {} }"); },
+                    SyntaxError,
+                    "Setter methods cannot have a rest pattern parameter",
+                    "Unexpected ... operator");
       assert.throws(function () { eval("var x = class { set setter(...x) {} }"); },
+                    SyntaxError,
+                    "Class setter methods cannot have a rest parameter",
+                    "Unexpected ... operator");
+      assert.throws(function () { eval("var x = class { set setter(...[x]) {} }"); },
                     SyntaxError,
                     "Class setter methods cannot have a rest parameter",
                     "Unexpected ... operator");
 
       // Default evaluation of 'this' should happen after the rest formal is assigned a register
       assert.doesNotThrow(function () { eval("function foo(a = this, ...b) {}"); }, "'this' referenced in formal defaults should not affect rest parameter");
-
+      assert.doesNotThrow(function () { eval("function foo(a = this, ...[b]) {}"); }, "'this' referenced in formal defaults should not affect rest parameter");
     }
   },
   {
@@ -115,6 +138,158 @@ var tests = [
 
       // The following takes a different path in the JIT
       assert.areEqual([1,2,3,4,5,6],   singleRest(1,2,3,4,5,6),     "Rest is a non-empty array with any parameters to a function with only a rest parameter");
+    }
+  },
+  {
+    name: "Rest pattern basic uses and sanity checks",
+    body: function () {
+      function foo(a, b, c, ...[d]) { return [a, b, c, d]; }
+
+      var bar = (a, b, c, ...[d]) => [a, b, c, d];
+
+      class restClass {
+        method(a, b, c, ...[d]) { return [a, b, c, d]; }
+      };
+      var baz = new restClass();
+
+      var obj = {
+        method(a, b, c, ...[d]) { return [a, b, c, d]; },
+        evalMethod(a, b, c, ...[d]) { return eval("[a, b, c, d]"); }
+      };
+
+      var funcObj = new Function("a, b, c, ...[d]", "return [a, b, c, d]");
+
+      function singleRest(...[d]) { return d; }
+
+      function objRest(...{'0': a, '1': b, length}) { return [a, b, length]; }
+
+      assert.areEqual([1,2,undefined,undefined], foo(1,2),
+        "Rest is an empty array with too few parameters to a function");
+      assert.areEqual([1,2,3,undefined], foo(1,2,3),                  
+        "Rest is an empty array with the exact number of parameters to a function");
+      assert.areEqual([1,2,3,4], foo(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a function");
+
+      assert.areEqual([1,2,undefined,undefined], bar(1,2),
+        "Rest is an empty array with too few parameters to a lambda");
+      assert.areEqual([1,2,3,undefined], bar(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a lambda");
+      assert.areEqual([1,2,3,4], bar(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a lambda");
+
+      assert.areEqual([1,2,undefined,undefined], baz.method(1,2),
+        "Rest is an empty array with too few parameters to a class method");
+      assert.areEqual([1,2,3, undefined], baz.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a class method");
+      assert.areEqual([1,2,3,4], baz.method(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a class method");
+
+      assert.areEqual([1,2,undefined,undefined], obj.method(1,2),
+        "Rest is an empty array with too few parameters to a method");
+      assert.areEqual([1,2,3,undefined], obj.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a method");
+      assert.areEqual([1,2,3,4], obj.method(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a method");
+
+      assert.areEqual([1,2,undefined, undefined], obj.method(1,2),
+        "Rest is an empty array with too few parameters to a method with an eval");
+      assert.areEqual([1,2,3, undefined], obj.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a method with an eval");
+      assert.areEqual([1,2,3,4], obj.method(1,2,3,4,5,6), 
+        "Rest is a non-empty array with too many parameters to a method with an eval");
+
+      assert.areEqual([1,2,undefined,undefined], funcObj(1,2),
+        "Rest is an empty array with too few parameters to a function object");
+      assert.areEqual([1,2,3,undefined], funcObj(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a function object");
+      assert.areEqual([1,2,3,4], funcObj(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a method with a function object");
+
+      // The following takes a different path in the JIT
+      assert.areEqual(1, singleRest(1,2,3,4,5,6),
+        "Rest is a non-empty array with any parameters to a function with only a rest parameter");
+      
+      assert.areEqual([1, 2, 4], objRest(1, 2, 3, 4),
+        "Rest with an object pattern destructures the rest array");
+    }
+  },
+  {
+    name: "Rest pattern uses with arguments and this references",
+    body: function () {
+      function foo(a, b, c, ...[d]) { arguments; return [a, b, c, d]; }
+      function fooThis(a, b, c, ...[d]) { this; return [a, b, c, d]; }
+
+      var bar = (a, b, c, ...[d]) => { arguments; return [a, b, c, d] };
+
+      class restClass {
+        method(a, b, c, ...[d]) { arguments; return [a, b, c, d]; }
+      };
+      var baz = new restClass();
+
+      var obj = {
+        method(a, b, c, ...[d]) { arguments; return [a, b, c, d]; },
+        evalMethod(a, b, c, ...[d]) { arguments; return eval("[a, b, c, d]"); }
+      };
+
+      function testScopeSlots(a, b, c, ...[d]) {
+        function sub() {
+          return [a, b, c, d];
+        }
+        arguments;
+        return sub();
+      }
+
+      assert.areEqual([1,2,undefined,undefined], foo(1,2),
+        "Rest is an empty array with too few parameters to a function");
+      assert.areEqual([1,2,3,undefined], foo(1,2,3),                  
+        "Rest is an empty array with the exact number of parameters to a function");
+      assert.areEqual([1,2,3,4], foo(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a function");
+      
+      assert.areEqual([1,2,undefined,undefined], fooThis(1,2),
+        "Rest is an empty array with too few parameters to a function");
+      assert.areEqual([1,2,3,undefined], fooThis(1,2,3),                  
+        "Rest is an empty array with the exact number of parameters to a function");
+      assert.areEqual([1,2,3,4], fooThis(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a function");
+
+      assert.areEqual([1,2,undefined,undefined], bar(1,2),
+        "Rest is an empty array with too few parameters to a lambda");
+      assert.areEqual([1,2,3,undefined], bar(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a lambda");
+      assert.areEqual([1,2,3,4], bar(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a lambda");
+
+      assert.areEqual([1,2,undefined,undefined], baz.method(1,2),
+        "Rest is an empty array with too few parameters to a class method");
+      assert.areEqual([1,2,3, undefined], baz.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a class method");
+      assert.areEqual([1,2,3,4], baz.method(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a class method");
+
+      assert.areEqual([1,2,undefined,undefined], obj.method(1,2),
+        "Rest is an empty array with too few parameters to a method");
+      assert.areEqual([1,2,3,undefined], obj.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a method");
+      assert.areEqual([1,2,3,4], obj.method(1,2,3,4,5,6),
+        "Rest is a non-empty array with too many parameters to a method");
+
+      assert.areEqual([1,2,undefined, undefined], obj.method(1,2),
+        "Rest is an empty array with too few parameters to a method with an eval");
+      assert.areEqual([1,2,3, undefined], obj.method(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a method with an eval");
+      assert.areEqual([1,2,3,4], obj.method(1,2,3,4,5,6), 
+        "Rest is a non-empty array with too many parameters to a method with an eval");
+
+      assert.areEqual([1,2,undefined,undefined], testScopeSlots(1,2),
+        "Rest is an empty array with too few parameters to a function with a " +
+        "reference to arguments using a sub function");
+      assert.areEqual([1,2,3,undefined], testScopeSlots(1,2,3),
+        "Rest is an empty array with the exact number of parameters to a function " +
+        "with a reference to arguments using a sub function");
+      assert.areEqual([1,2,3,4], testScopeSlots(1,2,3,4,5,6), 
+        "Rest is a non-empty array with too many parameters to a function with a " +
+        "reference to arguments using a sub function");
     }
   },
   {
@@ -248,18 +423,31 @@ var tests = [
     body: function () {
       function inlineTest() {
         function fooInline(a, b, c, ...rest) { arguments; this; return [a, b, c, ...rest]; }
+        function fooInline2(a, b, ...[c]) { arguments; this; return [a, b, c]; }
 
         fooInline(1,2);
         assert.areEqual([1,2,undefined], fooInline(1,2), "Inlined rest handles less actuals than formals correctly");
         assert.areEqual([1,2,undefined], fooInline(...[1,2]), "Inlined rest handles less spread actuals than formals correctly");
 
+        fooInline2(1);
+        assert.areEqual([1,undefined,undefined], fooInline2(1), "Inlined rest handles less actuals than formals correctly");
+        assert.areEqual([1,undefined,undefined], fooInline2(...[1]), "Inlined rest handles less spread actuals than formals correctly");
+
         fooInline(1,2,3);
         assert.areEqual([1,2,3], fooInline(1,2,3), "Inlined rest handles the same amount of actuals and formals correctly");
         assert.areEqual([1,2,3], fooInline(...[1,2,3]), "Inlined rest handles the same amount of spread actuals and formals correctly");
 
+        fooInline2(1,2);
+        assert.areEqual([1,2,undefined], fooInline2(1,2), "Inlined rest handles the same amount of actuals and formals correctly");
+        assert.areEqual([1,2,undefined], fooInline2(...[1,2]), "Inlined rest handles the same amount of spread actuals and formals correctly");
+
         fooInline(1,2,3,4,5,6);
         assert.areEqual([1,2,3,4,5,6], fooInline(1,2,3,4,5,6), "Inlined rest handles the more actuals than formals correctly");
         assert.areEqual([1,2,3,4,5,6], fooInline(...[1,2,3,4,5,6]), "Inlined rest handles the more actuals than formals correctly");
+
+        fooInline2(1,2,3,4,5,6);
+        assert.areEqual([1,2,3], fooInline2(1,2,3,4,5,6), "Inlined rest handles the more actuals than formals correctly");
+        assert.areEqual([1,2,3], fooInline2(...[1,2,3,4,5,6]), "Inlined rest handles the more actuals than formals correctly");
       }
       inlineTest();
       inlineTest();
@@ -274,12 +462,21 @@ var tests = [
             eval();
         }
       };
+      var func5 = function (...[argArr13]) {
+        function foo() {
+            eval();
+        }
+      };
     }
   },
   {
     name: "OS 265363: ArgIn_Rest is emitted in loop bodies",
     body: function () {
       var func4 = function (argArrObj9, ...argArr11) {
+        while (false) {
+        }
+      };
+      var func4 = function (argArrObj9, ...[argArr11]) {
         while (false) {
         }
       };
@@ -290,6 +487,15 @@ var tests = [
     name: "OS 266421: Rest does not create a frame object properly",
     body: function () {
       var func4 = function (...argArr6) {
+        for (var _i in arguments) {
+        }
+      };
+    }
+  },
+  {
+    name: "OS 266421: Rest pattern does not create a frame object properly",
+    body: function () {
+      var func4 = function (...[argArr6]) {
         for (var _i in arguments) {
         }
       };
@@ -308,10 +514,36 @@ var tests = [
     }
   },
   {
+    name: "OS 645508: Nested function reference to parent rest pattern fails",
+    body: function () {
+      function foo(...[bar]) {
+        function child() {
+          bar;
+        }
+        child();
+      }
+      foo();
+    }
+  },
+  {
     name: "Rest parameter is incorrectly assumed to be in a scope slot",
     body: function () {
       function test0() {
         var func1 = function (...argArr5) {
+          arguments[1];
+        };
+        do {
+          func1();
+          _oo2obj2.func1();
+        } while (false);
+      }
+    }
+  },
+  {
+    name: "Rest pattern is incorrectly assumed to be in a scope slot",
+    body: function () {
+      function test0() {
+        var func1 = function (...[argArr5]) {
           arguments[1];
         };
         do {
@@ -344,6 +576,18 @@ var tests = [
     }
   },
   {
+    name: "OSG 5737917: Create arguments object when the only formal is a rest pattern",
+    body: function () {
+      var func1 = function (...[argArr0]) {
+        eval('');
+        return (Object({
+          get: function () {
+          }
+        }));
+      }
+    }
+  },
+  {
     name: "OS 7249217: Rest is able to be in a slot in arguments optimization case",
     body: function () {
       function foo(...argArr9) {
@@ -355,7 +599,20 @@ var tests = [
         }
         assert.areEqual([1,2,3], argArr9, "Arguments scope object optimization allows rest to function correctly");
       }
-      foo(1,2,3);
+      function bar(...[argArr9]) {
+        var protoObj0 = {};
+        with (protoObj0) {
+          arguments;
+          var f = function () {
+            assert.areEqual(1, argArr9, 
+              "Arguments scope object optimization allows rest to function correctly inside with");
+          };
+          f();
+        }
+        assert.areEqual(1, argArr9,
+          "Arguments scope object optimization allows rest to function correctly");
+      }
+      bar(1,2,3);
     }
   }
 ];

--- a/test/es6/trailingcomma.js
+++ b/test/es6/trailingcomma.js
@@ -13,6 +13,7 @@ var tests = [
             assert.doesNotThrow(function () { eval("function foo(a,) {'use strict'; }"); }, "Trailing comma in function declaration under strict mode is a valid syntax");
             assert.throws(function () { eval("function foo(a, ,) {}"); }, SyntaxError, "More than one trailing comma is not valid syntax", "Expected identifier");
             assert.throws(function () { eval("function foo(...a,) {}"); }, SyntaxError, "Trailing comma after rest is not valid syntax", "The rest parameter must be the last parameter in a formals list.");
+            assert.throws(function () { eval("function foo(...[a],) {}"); }, SyntaxError, "Trailing comma after rest pattern is not valid syntax", "The rest parameter must be the last parameter in a formals list.");
             assert.throws(function () { eval("function foo(,) {}"); }, SyntaxError, "Trailing comma after missing name is not valid syntax", "Expected identifier");
             function f1(a,b,) {}
             assert.areEqual(f1.length, 2, "Function's length is not affected by a trailing comma");


### PR DESCRIPTION
Currently, when a pattern is present as a rest parameter the parser incorrectly interprets the pattern as a non-rest parameter. This change allows patterns to appear in the AST for rest parameters.

Fixes #5550
Fixes #5551
