### PR TITLE
Add workaround for dealing with dangling BailOutInfo when replacing shared BailOutInfo

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -1281,7 +1281,7 @@ Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo)
         __assume(UNREACHED);
     }
     
-    if (oldBailOutInfo->bailOutInstr == this)
+    if (oldBailOutInfo->bailOutInstr == this && !oldBailOutInfo->sharedBailOutKind)
     {
         Assert(!oldBailOutInfo->wasCloned && !oldBailOutInfo->wasCopied);
         JitArenaAllocator * alloc = this->m_func->m_alloc;


### PR DESCRIPTION
Consider the following sequence of instructions:

```
        BailOnNotStackArgs  s7           #   Bailout: #0034 (BailOutOnInlineFunction)
        ByteCodeUses   s17               #0034
        CheckFuncInfo  s17               #   Bailout: #0034 (BailOutOnInlineFunction)
```

Both BailOnNotStackArgs and CheckFuncInfo instructions share the same BailOutInfo,
but since we decide to hoist CheckFuncInfo (thereby removing its BailOutInfo)
and not BailOnNotStackArgs, the BailOnNotStackArgs now holds a dangling BailOutInfo.

Since there is no way to know what instructions currently reference a BailOutInfo,
as a workaround, we will only look for this pattern and make sure that we don't free
the BailOutInfo. Also change the BailOutInfo from "shared" to "non-shared" so that
GenerateBailOut in Lowerer works correctly (it expects the "owner" of a BailOutInfo
to have already allocated the BailOutRecord in the case of a "shared" BailOutInfo).

TODO: There are a few other places where we use ReplaceBailOutInfo as well, and this
situation may very well happen again.