### PR TITLE
fix potentially bad merge from 1.11 to master

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -4865,11 +4865,11 @@ bool Lowerer::TryLowerNewScObjectWithFixedCtorCache(IR::Instr* newObjInstr, IR::
 
     JITTimeConstructorCache * ctorCache;
 
-    if (newObjInstr->HasBailOutInfo() && !newObjInstr->HasLazyBailOut() && newObjInstr->GetBailOutKindNoBits() == IR::BailOutFailedCtorGuardCheck)
+    if (newObjInstr->HasBailOutInfo() && newObjInstr->GetBailOutKindNoBits() == IR::BailOutFailedCtorGuardCheck)
     {
         Assert(newObjInstr->IsNewScObjectInstr());
         Assert(newObjInstr->IsProfiledInstr());
-        Assert(newObjInstr->GetBailOutKindNoBits() == IR::BailOutFailedCtorGuardCheck || newObjInstr->HasLazyBailOut());
+        Assert(newObjInstr->GetBailOutKind() == IR::BailOutFailedCtorGuardCheck);
 
         emitBailOut = true;
 


### PR DESCRIPTION
There was extra condition for lazy bailout in master. When merging servicing update into unreleased/future, I noticed that the condition was handled different than how I merged it in master.