### PR TITLE
Fix backwardpass assert and sccliveness crashes

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -309,9 +309,11 @@ void
 BackwardPass::MarkScopeObjSymUseForStackArgOpt()
 {
     IR::Instr * instr = this->currentInstr;
+    BasicBlock *block = this->currentBlock;
+
     if (tag == Js::DeadStorePhase)
     {
-        if (instr->DoStackArgsOpt() && instr->m_func->GetScopeObjSym() != nullptr && this->DoByteCodeUpwardExposedUsed())
+        if (instr->DoStackArgsOpt() && !block->IsLandingPad() && instr->m_func->GetScopeObjSym() != nullptr && this->DoByteCodeUpwardExposedUsed())
         {
             this->currentBlock->byteCodeUpwardExposedUsed->Set(instr->m_func->GetScopeObjSym()->m_id);
         }


### PR DESCRIPTION
Inlined instruction can get hoisted out of an inliner loop.
This caused MarkScopeObjSymUseForStackArgOpt() to added bytecodeUses for the inlinee's scope object outside the scope of the inlinee, which was wrong.
Changed the code to ignore instrs inside the landingPad block.
VSO bug: 21627404, 19979778 and 20850710
