### PR TITLE
OS#18260560 - ASSERTION : scope at GetEnclosingFunc

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2096,7 +2096,10 @@ void ByteCodeGenerator::CheckDeferParseHasMaybeEscapedNestedFunc()
     else
     {
         // We have to wait until it is parsed before we populate the stack nested func parent.
-        FuncInfo * parentFunc = top->GetParamScope() ? top->GetParamScope()->GetEnclosingFunc() : top->GetBodyScope()->GetEnclosingFunc();
+        Scope * enclosingScope = top->GetParamScope() ? top->GetParamScope() :
+                                 top->GetBodyScope() ? top->GetBodyScope() :
+                                 top->GetFuncExprScope();
+        FuncInfo * parentFunc = enclosingScope->GetEnclosingFunc();
         if (!parentFunc->IsGlobalFunction())
         {
             Assert(parentFunc->byteCodeFunction != rootFuncBody);

--- a/test/Bugs/bug_OS18260560.js
+++ b/test/Bugs/bug_OS18260560.js
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+(function foo(a = function bar() {
+  with ({}) {
+      foo;
+  }
+}()) {})();
+
+console.log("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -570,4 +570,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport  -bgjit- -loopinterpretcount:1</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS18260560.js</files>
+      <compile-flags>-force:deferparse</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Named function expression with nested-function declared in default arguments containing a with statement referencing the parent function expression by name results in a null dereference of the enclosing scope.

```javascript
(function foo(a = function bar() {
  with ({}) {
      foo;
  }
}()) {})();
```

We try and look at the param scope and body scope but we don't check the function expression scope in `ByteCodeGenerator::CheckDeferParseHasMaybeEscapedNestedFunc`. Simple fix is to check function expression scope if param and body scope are nullptr.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/18260560

Found vis oss-fuzz
