### PR TITLE
Allow SAFE_RUN to correctly run and check results

### DIFF
--- a/test/native-tests/test_native.sh
+++ b/test/native-tests/test_native.sh
@@ -28,10 +28,11 @@ FIND_CLANG() {
 }
 
 SAFE_RUN() {
-    local SF_RETURN_VALUE=$($1 2>&1)
+    local SF_OUTPUT
+    SF_OUTPUT=$(eval "( $1 )" 2>&1)
 
     if [[ $? != 0 ]]; then
-        >&2 echo $SF_RETURN_VALUE
+        >&2 echo "$SF_OUTPUT"
         exit 1
     fi
 }
@@ -57,16 +58,16 @@ fi
 RUN () {
     TEST_PATH=$1
     echo "Testing $TEST_PATH"
-    SAFE_RUN `cd $TEST_PATH; ${CH_DIR} Platform.js > Makefile`
+    SAFE_RUN "cd $TEST_PATH && ${CH_DIR} Platform.js > Makefile"
     RES=$(cd $TEST_PATH; cat Makefile)
 
     if [[ $RES =~ "# IGNORE_THIS_TEST" ]]; then
         echo "Ignoring $TEST_PATH"
     else
-        SAFE_RUN `cd $TEST_PATH; make CC=${CC} CXX=${CXX}`
+        SAFE_RUN "cd $TEST_PATH && make CC=${CC} CXX=${CXX}"
         RES=$(cd $TEST_PATH; ./sample.o)
         TEST "SUCCESS"
-        SAFE_RUN `cd $TEST_PATH; rm -rf ./sample.o`
+        SAFE_RUN "cd $TEST_PATH && rm -rf ./sample.o"
     fi
 }
 
@@ -74,7 +75,7 @@ RUN_CMD () {
     TEST_PATH=$1
     CMD=$2
     echo "Testing $TEST_PATH"
-    SAFE_RUN `cd $TEST_PATH; $CMD`
+    SAFE_RUN "cd $TEST_PATH && $CMD"
 }
 
 # static lib tests
@@ -100,4 +101,4 @@ RUN "test-shared-basic"
 # test python
 RUN_CMD "test-python" "python helloWorld.py ${BUILD_TYPE}"
 
-SAFE_RUN `rm -rf Makefile`
+SAFE_RUN "rm -rf Makefile"


### PR DESCRIPTION
Hi, I came across [this shell function](https://github.com/microsoft/ChakraCore/blob/68d19b73e4c796540d2d44cc17ac2320c7576cd0/test/native-tests/test_native.sh#L30) in `test/native-tests/test_native.sh`:

```
SAFE_RUN() {
    local SF_RETURN_VALUE=$($1 2>&1)

    if [[ $? != 0 ]]; then
        >&2 echo $SF_RETURN_VALUE
        exit 1
    fi
}
```

invoked as e.g.

```
SAFE_RUN `cd $TEST_PATH; ${CH_DIR} Platform.js > Makefile`
```

There are multiple issues that prevent it from living up to its name:

1.  The code to run is executed by the backticks before the function ever starts:
```
$ test_run() { true; }
$ test_run `ls /doesnotexist`
ls: cannot access '/doesnotexist': No such file or directory
```

2. If the invocation is changed to pass the command directly, the invocation fails for metacharacters like `;` and `>`. Here they are both treated as literal text:
```
$ test_run() { local var=$($1 >&2); echo "$var"; }
$ test_run "echo Hello; ls > filelist"
Hello; ls > filelist
```

3. If passed a valid invocation, `local` [masks all exit codes](https://github.com/koalaman/shellcheck/wiki/SC2155) and returns success, even when the command fails:

```
$ test_run() { local foo=$($1); echo  "$1 returned $?"; }
$ test_run true
true returned 0
$ test_run false
false returned 0
```

The suggested commits fixes all these issues. 

I was unable to verify the fix locally as the tests appeared to hang when run overnight with and without these fixes. I'm not quite sure how they're used, but there is some possibility that this commit uncovers failures that were previously hidden.