### PR TITLE
Unflag object rest/spread.

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -659,7 +659,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6Spread               (true)
 #define DEFAULT_CONFIG_ES6String               (true)
 #define DEFAULT_CONFIG_ES6StringPrototypeFixes (true)
-#define DEFAULT_CONFIG_ES2018ObjectRestSpread  (false)
+#define DEFAULT_CONFIG_ES2018ObjectRestSpread  (true)
 
 #ifndef DEFAULT_CONFIG_ES6PrototypeChain
 #ifdef COMPILE_DISABLE_ES6PrototypeChain


### PR DESCRIPTION
For reference:

- Object spread PR: #5268
- Object rest PR: #5498 

The functionality is implemented in the JIT using helper calls. For destructuring rest, it uses GC'd arrays for tracking which computed property names have already been pulled out of the object.

A PR exists for updating our fuzzers to generate the new syntax.