### PR TITLE
Clean up Func's unused StackSyms and use getters/setters where appropriate

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -51,7 +51,6 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     m_cloner(nullptr),
     m_cloneMap(nullptr),
     m_loopParamSym(nullptr),
-    m_funcObjSym(nullptr),
     m_localClosureSym(nullptr),
     m_paramClosureSym(nullptr),
     m_localFrameDisplaySym(nullptr),
@@ -1359,6 +1358,30 @@ Func::EndPhase(Js::Phase tag, bool dump)
     }
     this->m_alloc->MergeDelayFreeList();
 #endif
+}
+
+StackSym *
+Func::EnsureBailoutReturnValueSym()
+{
+    if (m_bailoutReturnValueSym == nullptr)
+    {
+        m_bailoutReturnValueSym = StackSym::New(TyVar, this);
+        StackAllocate(m_bailoutReturnValueSym, sizeof(Js::Var));
+    }
+
+    return m_bailoutReturnValueSym;
+}
+
+StackSym *
+Func::EnsureHasBailedOutSym()
+{
+    if (m_hasBailedOutSym == nullptr)
+    {
+        m_hasBailedOutSym = StackSym::New(TyUint32, this);
+        StackAllocate(m_hasBailedOutSym, MachRegInt);
+    }
+
+    return m_hasBailedOutSym;
 }
 
 StackSym *

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -416,31 +416,8 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
         return !GetHasCalls() && !GetHasImplicitCalls();
     }
 
-    StackSym *EnsureLoopParamSym();
-
     void UpdateForInLoopMaxDepth(uint forInLoopMaxDepth);
     int GetForInEnumeratorArrayOffset() const;
-
-    StackSym *GetFuncObjSym() const { return m_funcObjSym; }
-    void SetFuncObjSym(StackSym *sym) { m_funcObjSym = sym; }
-
-    StackSym *GetJavascriptLibrarySym() const { return m_javascriptLibrarySym; }
-    void SetJavascriptLibrarySym(StackSym *sym) { m_javascriptLibrarySym = sym; }
-
-    StackSym *GetScriptContextSym() const { return m_scriptContextSym; }
-    void SetScriptContextSym(StackSym *sym) { m_scriptContextSym = sym; }
-
-    StackSym *GetFunctionBodySym() const { return m_functionBodySym; }
-    void SetFunctionBodySym(StackSym *sym) { m_functionBodySym = sym; }
-
-    StackSym *GetLocalClosureSym() const { return m_localClosureSym; }
-    void SetLocalClosureSym(StackSym *sym) { m_localClosureSym = sym; }
-
-    StackSym *GetParamClosureSym() const { return m_paramClosureSym; }
-    void SetParamClosureSym(StackSym *sym) { m_paramClosureSym = sym; }
-
-    StackSym *GetLocalFrameDisplaySym() const { return m_localFrameDisplaySym; }
-    void SetLocalFrameDisplaySym(StackSym *sym) { m_localFrameDisplaySym = sym; }
 
     intptr_t GetJittedLoopIterationsSinceLastBailoutAddress() const;
     void EnsurePinnedTypeRefs();
@@ -509,12 +486,6 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
     {
         Assert(m_inlineeFrameStartSym ? (m_inlineeFrameStartSym->m_offset != -1) : true);
         return m_inlineeFrameStartSym != nullptr;
-    }
-
-    void SetInlineeFrameStartSym(StackSym *sym)
-    {
-        Assert(m_inlineeFrameStartSym == nullptr);
-        m_inlineeFrameStartSym = sym;
     }
 
     void SetInlineeStart(IR::Instr *inlineeStartInstr)
@@ -678,16 +649,7 @@ public:
 #endif
 
     SymTable *          m_symTable;
-    StackSym *          m_loopParamSym;
-    StackSym *          m_funcObjSym;
-    StackSym *          m_javascriptLibrarySym;
-    StackSym *          m_scriptContextSym;
-    StackSym *          m_functionBodySym;
-    StackSym *          m_localClosureSym;
-    StackSym *          m_paramClosureSym;
-    StackSym *          m_localFrameDisplaySym;
-    StackSym *          m_bailoutReturnValueSym;
-    StackSym *          m_hasBailedOutSym;
+
     uint                m_forInLoopMaxDepth;
     uint                m_forInLoopBaseDepth;
     int32               m_forInEnumeratorArrayOffset;
@@ -721,8 +683,6 @@ public:
     FlowGraph *         m_fg;
     unsigned int        m_labelCount;
     BitVector           m_regsUsed;
-    StackSym *          tempSymDouble;
-    StackSym *          tempSymBool;
     uint32              loopCount;
     uint32              unoptimizableArgumentsObjReference;
     uint32              unoptimizableArgumentsObjReferenceInInlinees;
@@ -1005,8 +965,6 @@ public:
     StackSym* GetStackSymForFormal(Js::ArgSlot formalsIndex);
     bool HasStackSymForFormal(Js::ArgSlot formalsIndex);
 
-    void SetScopeObjSym(StackSym * sym);
-    StackSym * GetScopeObjSym();
     bool IsTrackCompoundedIntOverflowDisabled() const;
     bool IsArrayCheckHoistDisabled() const;
     bool IsStackArgOptDisabled() const;
@@ -1039,9 +997,6 @@ public:
 
     IR::LabelInstr *    m_bailOutNoSaveLabel;
 
-    StackSym * GetNativeCodeDataSym() const;
-    void SetNativeCodeDataSym(StackSym * sym);
-
 private:
     Js::EntryPointInfo* m_entryPointInfo; // for in-proc JIT only
 
@@ -1051,7 +1006,6 @@ private:
 #endif
     Func * const        topFunc;
     Func * const        parentFunc;
-    StackSym *          m_inlineeFrameStartSym;
     IR::Instr *         inlineeStart;
     uint                maxInlineeArgOutSize;
     const bool          m_isBackgroundJIT;
@@ -1078,11 +1032,9 @@ private:
     YieldOffsetResumeLabelList * m_yieldOffsetResumeLabelList;
     StackArgWithFormalsTracker * stackArgWithFormalsTracker;
     ObjTypeSpecFldInfo ** m_globalObjTypeSpecFldInfoArray;
-    StackSym *CreateInlineeStackSym();
     IR::SymOpnd *GetInlineeOpndAtOffset(int32 offset);
     bool HasLocalVarSlotCreated() const { return m_localVarSlotsOffset != Js::Constants::InvalidOffset; }
     void EnsureLocalVarSlots();
-    StackSym * m_nativeCodeDataSym;
     SList<IR::RegOpnd *> constantAddressRegOpnd;
     IR::Instr * lastConstantAddressRegLoadInstr;
     bool canHoistConstantAddressLoad;
@@ -1100,7 +1052,56 @@ public:
     Lowerer* m_lowerer;
 #endif
 
+private:
+    StackSym* m_localClosureSym;
+    StackSym* m_paramClosureSym;
+    StackSym* m_localFrameDisplaySym;
+    StackSym* m_nativeCodeDataSym;
+    StackSym* m_inlineeFrameStartSym;
+    StackSym* m_loopParamSym;
+    StackSym* m_bailoutReturnValueSym;
+    StackSym* m_hasBailedOutSym;
+
+public:
+    StackSym* tempSymDouble;
+    StackSym* tempSymBool;
+
+    // StackSyms' corresponding getters/setters
+    void SetInlineeFrameStartSym(StackSym* sym)
+    {
+        Assert(m_inlineeFrameStartSym == nullptr);
+        m_inlineeFrameStartSym = sym;
+    }
+
+    StackSym* EnsureHasBailedOutSym();
+    StackSym* GetHasBailedOutSym() const { return m_hasBailedOutSym; }
+
+    StackSym* EnsureBailoutReturnValueSym();
+    StackSym* GetBailoutReturnValueSym() const { return m_bailoutReturnValueSym; }
+
+    StackSym* EnsureLoopParamSym();
+    StackSym* GetLoopParamSym() const { return m_loopParamSym; }
+
+    StackSym* GetLocalClosureSym() const { return m_localClosureSym; }
+    void SetLocalClosureSym(StackSym* sym) { m_localClosureSym = sym; }
+
+    StackSym* GetParamClosureSym() const { return m_paramClosureSym; }
+    void SetParamClosureSym(StackSym* sym) { m_paramClosureSym = sym; }
+
+    StackSym* GetLocalFrameDisplaySym() const { return m_localFrameDisplaySym; }
+    void SetLocalFrameDisplaySym(StackSym* sym) { m_localFrameDisplaySym = sym; }
+
+    void SetScopeObjSym(StackSym* sym);
+    StackSym* GetScopeObjSym();
+
+    StackSym* GetNativeCodeDataSym() const;
+    void SetNativeCodeDataSym(StackSym* sym);
+
+    StackSym* CreateInlineeStackSym();
+
     // Lazy bailout
+    // The stack sym is used to store the pointer to
+    // the BailOutRecord associated with the lazy bailout point
 private:
     bool                hasLazyBailOut : 1;
     StackSym *          m_lazyBailOutRecordSlot;

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -785,8 +785,6 @@ private:
     IR::Instr*      LowerTry(IR::Instr* instr, bool tryCatch);
     IR::Instr *     LowerCatch(IR::Instr *instr);
     IR::Instr *     LowerLeave(IR::Instr *instr, IR::LabelInstr * targetInstr, bool fromFinalLower, bool isOrphanedLeave = false);
-    void            EnsureBailoutReturnValueSym();
-    void            EnsureHasBailedOutSym();
     void            InsertReturnThunkForRegion(Region* region, IR::LabelInstr* restoreLabel);
     void            SetHasBailedOut(IR::Instr * bailoutInstr);
     IR::Instr*      EmitEHBailoutStackRestore(IR::Instr * bailoutInstr);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -399,7 +399,7 @@ LowererMD::LowerTry(IR::Instr *tryInstr, IR::JnHelperMethod helperMethod)
     if (tryInstr->m_opcode == Js::OpCode::TryCatch || (this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout)))
     {
         // Arg 4 : hasBailedOutOffset
-        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->m_hasBailedOutSym->m_offset, TyInt32, this->m_func);
+        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->GetHasBailedOutSym()->m_offset, TyInt32, this->m_func);
         this->LoadHelperArgument(tryAddr, hasBailedOutOffset);
     }
 #ifdef _M_X64
@@ -571,8 +571,8 @@ LowererMD::LoadStackArgPtr(IR::Instr * instr)
         // t1 = MOV [prm1 + m_inParams]
         // dst = LEA &[t1 + sizeof(var)]
 
-        Assert(this->m_func->m_loopParamSym);
-        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         size_t offset = Js::InterpreterStackFrame::GetOffsetOfInParams();
         IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, (int32)offset, TyMachReg, this->m_func);
         IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
@@ -597,8 +597,8 @@ LowererMD::LoadArgumentsFromFrame(IR::Instr * instr)
     if (this->m_func->IsLoopBody())
     {
         // Get the arguments ptr from the interpreter frame instance that was passed in.
-        Assert(this->m_func->m_loopParamSym);
-        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         int32 offset = (int32)Js::InterpreterStackFrame::GetOffsetOfArguments();
         instr->SetSrc1(IR::IndirOpnd::New(baseOpnd, offset, TyMachReg, this->m_func));
     }
@@ -620,8 +620,8 @@ LowererMD::LoadArgumentCount(IR::Instr * instr)
     {
         // Pull the arg count from the interpreter frame instance that was passed in.
         // (The callinfo in the loop body's frame just shows the single parameter, the interpreter frame.)
-        Assert(this->m_func->m_loopParamSym);
-        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         size_t offset = Js::InterpreterStackFrame::GetOffsetOfInSlotsCount();
         instr->SetSrc1(IR::IndirOpnd::New(baseOpnd, (int32)offset, TyInt32, this->m_func));
     }

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -3302,22 +3302,7 @@ Opnd::Dump(IRDumpFlags flags, Func *func)
             {
                 Output::Print(_u("[isTempLastUse]"));
             }
-            StackSym *sym = regOpnd->GetStackSym();
-            if (sym && func)
-            {
-                if (sym == func->GetScriptContextSym())
-                {
-                    Output::Print(_u("[ScriptContext]"));
-                }
-                else if (sym == func->GetFuncObjSym())
-                {
-                    Output::Print(_u("[FuncObj]"));
-                }
-                else if (sym == func->GetFunctionBodySym())
-                {
-                    Output::Print(_u("[FunctionBody]"));
-                }
-            }
+
             if(regOpnd->IsArrayRegOpnd())
             {
                 if(dumpValueType)

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -1740,7 +1740,7 @@ LowererMD::LowerTry(IR::Instr * tryInstr, IR::JnHelperMethod helperMethod)
     if (tryInstr->m_opcode == Js::OpCode::TryCatch || this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))
     {
         // Arg 6 : hasBailedOutOffset
-        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->m_hasBailedOutSym->m_offset + tryInstr->m_func->GetInlineeArgumentStackSize(), TyInt32, this->m_func);
+        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->GetHasBailedOutSym()->m_offset + tryInstr->m_func->GetInlineeArgumentStackSize(), TyInt32, this->m_func);
         this->LoadHelperArgument(tryAddr, hasBailedOutOffset);
     }
 
@@ -1902,8 +1902,8 @@ LowererMD::LoadStackArgPtr(IR::Instr * instr)
         // t1 = LDR [prm1 + m_inParams]
         // dst = ADD t1, sizeof(var)
 
-        Assert(this->m_func->m_loopParamSym);
-        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         size_t offset = Js::InterpreterStackFrame::GetOffsetOfInParams();
         IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, (int32)offset, TyMachReg, this->m_func);
         IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
@@ -1943,8 +1943,8 @@ LowererMD::LoadArgumentsFromFrame(IR::Instr * instr)
     if (this->m_func->IsLoopBody())
     {
         // Get the arguments ptr from the interpreter frame instance that was passed in.
-        Assert(this->m_func->m_loopParamSym);
-        baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         offset = Js::InterpreterStackFrame::GetOffsetOfArguments();
     }
     else
@@ -1971,8 +1971,8 @@ LowererMD::LoadArgumentCount(IR::Instr * instr)
     {
         // Pull the arg count from the interpreter frame instance that was passed in.
         // (The callinfo in the loop body's frame just shows the single parameter, the interpreter frame.)
-        Assert(this->m_func->m_loopParamSym);
-        baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         offset = Js::InterpreterStackFrame::GetOffsetOfInSlotsCount();
     }
     else

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -1531,7 +1531,7 @@ LowererMD::LowerTry(IR::Instr * tryInstr, IR::JnHelperMethod helperMethod)
     if (tryInstr->m_opcode == Js::OpCode::TryCatch || this->m_func->DoOptimizeTry() || (this->m_func->IsSimpleJit() && this->m_func->hasBailout))
     {
         // Arg 6 : hasBailedOutOffset
-        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->m_hasBailedOutSym->m_offset + tryInstr->m_func->GetInlineeArgumentStackSize(), TyInt32, this->m_func);
+        IR::Opnd * hasBailedOutOffset = IR::IntConstOpnd::New(this->m_func->GetHasBailedOutSym()->m_offset + tryInstr->m_func->GetInlineeArgumentStackSize(), TyInt32, this->m_func);
         this->LoadHelperArgument(tryAddr, hasBailedOutOffset);
     }
 
@@ -1681,8 +1681,8 @@ LowererMD::LoadStackArgPtr(IR::Instr * instr)
         // t1 = LDR [prm1 + m_inParams]
         // dst = ADD t1, sizeof(var)
 
-        Assert(this->m_func->m_loopParamSym);
-        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        IR::RegOpnd *baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         size_t offset = Js::InterpreterStackFrame::GetOffsetOfInParams();
         IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, (int32)offset, TyMachReg, this->m_func);
         IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
@@ -1723,8 +1723,8 @@ LowererMD::LoadArgumentsFromFrame(IR::Instr * instr)
     if (this->m_func->IsLoopBody())
     {
         // Get the arguments ptr from the interpreter frame instance that was passed in.
-        Assert(this->m_func->m_loopParamSym);
-        baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         offset = Js::InterpreterStackFrame::GetOffsetOfArguments();
     }
     else
@@ -1751,8 +1751,8 @@ LowererMD::LoadArgumentCount(IR::Instr * instr)
     {
         // Pull the arg count from the interpreter frame instance that was passed in.
         // (The callinfo in the loop body's frame just shows the single parameter, the interpreter frame.)
-        Assert(this->m_func->m_loopParamSym);
-        baseOpnd = IR::RegOpnd::New(this->m_func->m_loopParamSym, TyMachReg, this->m_func);
+        Assert(this->m_func->GetLoopParamSym());
+        baseOpnd = IR::RegOpnd::New(this->m_func->GetLoopParamSym(), TyMachReg, this->m_func);
         offset = Js::InterpreterStackFrame::GetOffsetOfInSlotsCount();
     }
     else


### PR DESCRIPTION
I will clean up `StackSym* tempSymDouble` and `StackSym* tempSymBool` in a separate PR.