### PR TITLE
Fix #6133 nullptr deref for non-existant default import

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -691,9 +691,6 @@ namespace Js
 
         if (exportName == PropertyIds::default_)
         {
-            JavascriptError* errorObj = scriptContext->GetLibrary()->CreateSyntaxError();
-            JavascriptError::SetErrorMessage(errorObj, JSERR_ModuleResolveExport, scriptContext->GetPropertyName(exportName)->GetBuffer(), scriptContext);
-            this->errorObject = errorObj;
             return false;
         }
 
@@ -919,10 +916,6 @@ namespace Js
 
         if (this->errorObject != nullptr)
         {
-            OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentsAsNeeded (errorObject)\n"));
-            // Cleanup in case of error.
-            this->ReleaseParserResourcesForHierarchy();
-            NotifyParentsAsNeeded();
             return false;
         }
 

--- a/test/es6module/module-bugfixes.js
+++ b/test/es6module/module-bugfixes.js
@@ -120,6 +120,16 @@ var tests = [
                 assert.isTrue(aliasName());
             `);
         }
+    },
+    {
+        name : "Issue 6133: Child module imports non-existant export from another module",
+        body()
+        {
+            WScript.RegisterModuleSource("test6133a", 'import Default from "test6133b";');
+            WScript.RegisterModuleSource("test6133b", 'export function notDefault () {}');
+
+            testRunner.LoadModule('import "test6133a";', undefined, true);
+        }
     }
 ];
 


### PR DESCRIPTION
Properly check for a child module that errors in failing to find an import after previously having been parsed correctly.

This is a slightly weird bug I accidentally introduced whilst fixing circular imports a year ago - sorry about this.

Fixes #6133 