### PR TITLE
Implement Numeric Separator

### DIFF
--- a/bin/NativeTests/BigUIntTest.h
+++ b/bin/NativeTests/BigUIntTest.h
@@ -26,7 +26,7 @@ namespace Js
 }
 
 template <typename EncodedChar>
-double Js::NumberUtilities::StrToDbl(const EncodedChar *, const EncodedChar **, LikelyNumberType& , bool)
+double Js::NumberUtilities::StrToDbl(const EncodedChar *, const EncodedChar **, LikelyNumberType& , bool, bool)
 {
     Assert(false);
     return 0.0;// don't care

--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -540,10 +540,12 @@ LSkipZeroes:
         byte bExtra = 0;
         int cbit = 0;
         const EncodedChar* pszSave = psz;
+
         // Skip leading zeros.
 LSkipZeroes:
         while (*psz == '0')
             psz++;
+
         // Get the first digit.
         uT = *psz - '0';
         if (uT > 1)
@@ -553,11 +555,7 @@ LSkipZeroes:
             //  - we've walked past at least one zero character (ie: this isn't the first character in psz)
             //  - the previous character was a zero
             //  - the following character is a valid binary digit
-            if (*psz == '_' &&
-                isNumericSeparatorEnabled &&
-                pszSave < psz &&
-                psz[-1] == '0' &&
-                static_cast<uint>(psz[1] - '0') <= 1)
+            if (*psz == '_' && isNumericSeparatorEnabled && pszSave < psz && psz[-1] == '0' && static_cast<uint>(psz[1] - '0') <= 1)
             {
                 psz++;
                 goto LSkipZeroes;
@@ -566,6 +564,7 @@ LSkipZeroes:
             *ppchLim = psz;
             return dbl;
         }
+
         //Now that leading zeros are skipped first bit should be one so lets
         //go ahead and count it and increment psz
         cbit = 1;
@@ -583,7 +582,7 @@ LSkipZeroes:
         const uint leftShiftValue = 52;
 
 LGetBinaryDigit:
-        uT = (*psz - '0');
+        uT = *psz - '0';
         if (uT <= 1)
         {
             if (cbit <= rightShiftValue)
@@ -609,7 +608,7 @@ LGetBinaryDigit:
         }
         else if (*psz == '_')
         {
-            if (isNumericSeparatorEnabled && cbit > 0 && static_cast<uint>(psz[1] - '0') <= 1 && static_cast<uint>(psz[-1] - '0') <= 1)
+            if (isNumericSeparatorEnabled && cbit > 0 && psz[-1] != '_' && static_cast<uint>(psz[1] - '0') <= 1)
             {
                 psz++;
                 goto LGetBinaryDigit;

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -227,7 +227,7 @@ namespace Js
 
         // Implemented in lib\parser\common.  Should move to lib\common
         template<typename EncodedChar>
-        static double StrToDbl(const EncodedChar *psz, const EncodedChar **ppchLim, LikelyNumberType& likelyType, bool isESBigIntEnabled = false);
+        static double StrToDbl(const EncodedChar *psz, const EncodedChar **ppchLim, LikelyNumberType& likelyType, bool isESBigIntEnabled = false, bool isNumericSeparatorEnabled = false);
 
         static BOOL FDblToStr(double dbl, __out_ecount(nDstBufSize) char16 *psz, int nDstBufSize);
         static int FDblToStr(double dbl, NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) char16 *pchDst, int cchDst);

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -252,7 +252,7 @@ namespace Js
         template<typename EncodedChar>
         static double DblFromHex(const EncodedChar *psz, const EncodedChar **ppchLim);
         template <typename EncodedChar>
-        static double DblFromBinary(const EncodedChar *psz, const EncodedChar **ppchLim);
+        static double DblFromBinary(const EncodedChar *psz, const EncodedChar **ppchLim, bool isNumericSeparatorEnabled = false);
         template<typename EncodedChar>
         static double DblFromOctal(const EncodedChar *psz, const EncodedChar **ppchLim);
         template<typename EncodedChar>

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -254,7 +254,7 @@ namespace Js
         template <typename EncodedChar>
         static double DblFromBinary(const EncodedChar *psz, const EncodedChar **ppchLim, bool isNumericSeparatorEnabled = false);
         template<typename EncodedChar>
-        static double DblFromOctal(const EncodedChar *psz, const EncodedChar **ppchLim);
+        static double DblFromOctal(const EncodedChar *psz, const EncodedChar **ppchLim, bool isNumericSeparatorEnabled = false);
         template<typename EncodedChar>
         static double StrToDbl(const EncodedChar *psz, const EncodedChar **ppchLim, Js::ScriptContext *const scriptContext);
 

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -250,7 +250,7 @@ namespace Js
         static BOOL FDblIsInt32(double dbl, int32 *plw);
 
         template<typename EncodedChar>
-        static double DblFromHex(const EncodedChar *psz, const EncodedChar **ppchLim);
+        static double DblFromHex(const EncodedChar *psz, const EncodedChar **ppchLim, bool isNumericSeparatorEnabled = false);
         template <typename EncodedChar>
         static double DblFromBinary(const EncodedChar *psz, const EncodedChar **ppchLim, bool isNumericSeparatorEnabled = false);
         template<typename EncodedChar>

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -679,6 +679,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6RegExSticky          (true)
 #define DEFAULT_CONFIG_ES2018RegExDotAll       (true)
 #define DEFAULT_CONFIG_ESBigInt                (false)
+#define DEFAULT_CONFIG_ESNumericSeparator      (true)
 #define DEFAULT_CONFIG_ESSymbolDescription     (true)
 #define DEFAULT_CONFIG_ESGlobalThis            (true)
 #ifdef COMPILE_DISABLE_ES6RegExPrototypeProperties
@@ -1214,6 +1215,9 @@ FLAGR(Boolean, WinRTAdaptiveApps        , "Enable the adaptive apps feature, all
 
 // ES BigInt flag
 FLAGR(Boolean, ESBigInt, "Enable ESBigInt flag", DEFAULT_CONFIG_ESBigInt)
+
+// ES Numeric Separator support for numeric constants
+FLAGR(Boolean, ESNumericSeparator, "Enable Numeric Separator flag", DEFAULT_CONFIG_ESNumericSeparator)
 
 // ES Symbol.prototype.description flag
 FLAGR(Boolean, ESSymbolDescription, "Enable Symbol.prototype.description", DEFAULT_CONFIG_ESSymbolDescription)

--- a/lib/Common/DataStructures/BigUInt.cpp
+++ b/lib/Common/DataStructures/BigUInt.cpp
@@ -125,7 +125,7 @@ namespace Js
         luMul = 1;
         for (*pcchDig = cch; prgch < pchLim; prgch++)
         {
-            if (*prgch == '.')
+            if (*prgch == '.' || *prgch == '_')
             {
                 (*pcchDig)--;
                 continue;

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -641,7 +641,7 @@ typename Scanner<EncodingPolicy>::EncodedCharPtr Scanner<EncodingPolicy>::FScanN
         case 'o':
         case 'O':
             // Octal
-            *pdbl = Js::NumberUtilities::DblFromOctal(p + 2, &pchT);
+            *pdbl = Js::NumberUtilities::DblFromOctal(p + 2, &pchT, m_scriptContext->GetConfig()->IsESNumericSeparatorEnabled());
             baseSpecifierCheck();
             goto LIdCheck;
 

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -648,7 +648,7 @@ typename Scanner<EncodingPolicy>::EncodedCharPtr Scanner<EncodingPolicy>::FScanN
         case 'b':
         case 'B':
             // Binary
-            *pdbl = Js::NumberUtilities::DblFromBinary(p + 2, &pchT);
+            *pdbl = Js::NumberUtilities::DblFromBinary(p + 2, &pchT, m_scriptContext->GetConfig()->IsESNumericSeparatorEnabled());
             baseSpecifierCheck();
             goto LIdCheck;
 

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -679,7 +679,7 @@ typename Scanner<EncodingPolicy>::EncodedCharPtr Scanner<EncodingPolicy>::FScanN
     else
     {
 LFloat:
-        *pdbl = Js::NumberUtilities::StrToDbl(p, &pchT, likelyType, m_scriptContext->GetConfig()->IsESBigIntEnabled());
+        *pdbl = Js::NumberUtilities::StrToDbl(p, &pchT, likelyType, m_scriptContext->GetConfig()->IsESBigIntEnabled(), m_scriptContext->GetConfig()->IsESNumericSeparatorEnabled());
         Assert(pchT == p || !Js::NumberUtilities::IsNan(*pdbl));
         if (likelyType == LikelyNumberType::BigInt)
         {

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -635,7 +635,7 @@ typename Scanner<EncodingPolicy>::EncodedCharPtr Scanner<EncodingPolicy>::FScanN
         case 'x':
         case 'X':
             // Hex
-            *pdbl = Js::NumberUtilities::DblFromHex(p + 2, &pchT);
+            *pdbl = Js::NumberUtilities::DblFromHex(p + 2, &pchT, m_scriptContext->GetConfig()->IsESNumericSeparatorEnabled());
             baseSpecifierCheck();
             goto LIdCheck;
         case 'o':

--- a/lib/Runtime/Base/ThreadConfigFlagsList.h
+++ b/lib/Runtime/Base/ThreadConfigFlagsList.h
@@ -48,6 +48,7 @@ FLAG_RELEASE(IsESObjectGetOwnPropertyDescriptorsEnabled, ESObjectGetOwnPropertyD
 FLAG_RELEASE(IsESSharedArrayBufferEnabled, ESSharedArrayBuffer)
 FLAG_RELEASE(IsESDynamicImportEnabled, ESDynamicImport)
 FLAG_RELEASE(IsESBigIntEnabled, ESBigInt)
+FLAG_RELEASE(IsESNumericSeparatorEnabled, ESNumericSeparator)
 FLAG_RELEASE(IsESExportNsAsEnabled, ESExportNsAs)
 FLAG_RELEASE(IsESSymbolDescriptionEnabled, ESSymbolDescription)
 FLAG_RELEASE(IsESGlobalThisEnabled, ESGlobalThis)

--- a/test/Number/NumericSeparator.js
+++ b/test/Number/NumericSeparator.js
@@ -68,20 +68,20 @@ var tests = [
   {
     name: "Strings parsed as number do not support numeric separators for decimal literals",
     body: function () {
-		assert.areEqual(NaN, Number('12_34'), "NaN === Number('12_34')");
-		assert.areEqual(NaN, Number('12e3_4'), "NaN === Number('12e3_4')");
-		assert.areEqual(NaN, Number('1234.45_67'), "NaN === Number('1234.45_67')");
-		assert.areEqual(NaN, Number('1234.45e6_7'), "NaN === Number('1234.45e6_7')");
-		
-		assert.areEqual(1, parseInt('1_2'), "1 === parseInt('1_2')");
-		assert.areEqual(1, parseInt('1e2_3'), "1 === parseInt('1e2_3')");
-		assert.areEqual(12, parseInt('12.3_4'), "1 === parseInt('12.3_4')");
-		assert.areEqual(12, parseInt('12.34e5_6'), "1 === parseInt('12.34e5_6')");
-		
-		assert.areEqual(1, parseFloat('1_2'), "1 === parseFloat('1_2')");
-		assert.areEqual(1e2, parseFloat('1e2_3'), "1 === parseFloat('1e2_3')");
-		assert.areEqual(12.3, parseFloat('12.3_4'), "1 === parseFloat('12.3_4')");
-		assert.areEqual(12.34e5, parseFloat('12.34e5_6'), "1 === parseFloat('12.34e5_6')");
+        assert.areEqual(NaN, Number('12_34'), "NaN === Number('12_34')");
+        assert.areEqual(NaN, Number('12e3_4'), "NaN === Number('12e3_4')");
+        assert.areEqual(NaN, Number('1234.45_67'), "NaN === Number('1234.45_67')");
+        assert.areEqual(NaN, Number('1234.45e6_7'), "NaN === Number('1234.45e6_7')");
+
+        assert.areEqual(1, parseInt('1_2'), "1 === parseInt('1_2')");
+        assert.areEqual(1, parseInt('1e2_3'), "1 === parseInt('1e2_3')");
+        assert.areEqual(12, parseInt('12.3_4'), "1 === parseInt('12.3_4')");
+        assert.areEqual(12, parseInt('12.34e5_6'), "1 === parseInt('12.34e5_6')");
+
+        assert.areEqual(1, parseFloat('1_2'), "1 === parseFloat('1_2')");
+        assert.areEqual(1e2, parseFloat('1e2_3'), "1 === parseFloat('1e2_3')");
+        assert.areEqual(12.3, parseFloat('12.3_4'), "1 === parseFloat('12.3_4')");
+        assert.areEqual(12.34e5, parseFloat('12.34e5_6'), "1 === parseFloat('12.34e5_6')");
     }
   },
   {
@@ -92,41 +92,41 @@ var tests = [
         assert.areEqual(0b10, 0b1_0, "0b10 === 0b1_0");
         assert.areEqual(0b01, 0b0_1, "0b01 === 0b0_1");
         assert.areEqual(0b0001, 0b000_1, "0b0001 === 0b000_1");
-		assert.areEqual(0b0000, 0b000_0, "0b0000 === 0b000_0");
-		assert.areEqual(0b000011110000, 0b0000_1111_0000, "0b000011110000 === 0b0000_1111_0000");
-		assert.areEqual(0b000011110000, 0b0_0_0_0_1_111_00_00, "0b000011110000 === 0b0_0_0_0_1_111_00_00");
+        assert.areEqual(0b0000, 0b000_0, "0b0000 === 0b000_0");
+        assert.areEqual(0b000011110000, 0b0000_1111_0000, "0b000011110000 === 0b0000_1111_0000");
+        assert.areEqual(0b000011110000, 0b0_0_0_0_1_111_00_00, "0b000011110000 === 0b0_0_0_0_1_111_00_00");
     }
   },
   {
     name: "Binary literal bad syntax",
     body: function () {
-		assert.throws(()=>eval('0b_'), SyntaxError, "'_' cannot immediately follow 0b");
-		assert.throws(()=>eval('0b__'), SyntaxError, "'_' cannot immediately follow 0b");
-		assert.throws(()=>eval('0b_1'), SyntaxError, "Binary literal may not begin with numeric separator");
-		assert.throws(()=>eval('0b_0'), SyntaxError, "Binary literal may not begin with numeric separator");
-		assert.throws(()=>eval('0b__1'), SyntaxError, "Binary literal may not begin with numeric separator");
-		assert.throws(()=>eval('0b__0'), SyntaxError, "Binary literal may not begin with numeric separator");
-		assert.throws(()=>eval('0b1_'), SyntaxError, "Binary literal may not end with numeric separator");
-		assert.throws(()=>eval('0b0_'), SyntaxError, "Binary literal may not end with numeric separator");
-		assert.throws(()=>eval('0b1__'), SyntaxError, "Binary literal may not end with numeric separator");
-		assert.throws(()=>eval('0b0__'), SyntaxError, "Binary literal may not end with numeric separator");
-		assert.throws(()=>eval('0b1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0b0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0b000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0b000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
-	}
+        assert.throws(()=>eval('0b_'), SyntaxError, "'_' cannot immediately follow 0b");
+        assert.throws(()=>eval('0b__'), SyntaxError, "'_' cannot immediately follow 0b");
+        assert.throws(()=>eval('0b_1'), SyntaxError, "Binary literal may not begin with numeric separator");
+        assert.throws(()=>eval('0b_0'), SyntaxError, "Binary literal may not begin with numeric separator");
+        assert.throws(()=>eval('0b__1'), SyntaxError, "Binary literal may not begin with numeric separator");
+        assert.throws(()=>eval('0b__0'), SyntaxError, "Binary literal may not begin with numeric separator");
+        assert.throws(()=>eval('0b1_'), SyntaxError, "Binary literal may not end with numeric separator");
+        assert.throws(()=>eval('0b0_'), SyntaxError, "Binary literal may not end with numeric separator");
+        assert.throws(()=>eval('0b1__'), SyntaxError, "Binary literal may not end with numeric separator");
+        assert.throws(()=>eval('0b0__'), SyntaxError, "Binary literal may not end with numeric separator");
+        assert.throws(()=>eval('0b1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0b0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0b000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0b000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+    }
   },
   {
     name: "Strings parsed as number do not support numeric separators for binary literals",
     body: function () {
-		assert.areEqual(NaN, Number('0b0_1'), "NaN === Number('0b0_1')");
-		assert.areEqual(NaN, Number('0b1_0'), "NaN === Number('0b1_0')");
-		assert.areEqual(NaN, Number('0b0_0'), "NaN === Number('0b0_0')");
-		assert.areEqual(NaN, Number('0b1_1'), "NaN === Number('0b1_1')");
-		
-		assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
-		
-		assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
+        assert.areEqual(NaN, Number('0b0_1'), "NaN === Number('0b0_1')");
+        assert.areEqual(NaN, Number('0b1_0'), "NaN === Number('0b1_0')");
+        assert.areEqual(NaN, Number('0b0_0'), "NaN === Number('0b0_0')");
+        assert.areEqual(NaN, Number('0b1_1'), "NaN === Number('0b1_1')");
+
+        assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
+
+        assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
     }
   },
   {
@@ -135,39 +135,39 @@ var tests = [
         assert.areEqual(0x00, 0x0_0, "0x00 === 0x0_0");
         assert.areEqual(0x1f, 0x1_f, "0x1f === 0x1_f");
         assert.areEqual(0x000000Ae1, 0x00_0_000_A_e1, "0x000000Ae1 === 0x00_0_000_A_e1");
-		assert.areEqual(0xaabbccdd, 0xaa_bb_cc_dd, "0xaabbccdd === 0xaa_bb_cc_dd");
+        assert.areEqual(0xaabbccdd, 0xaa_bb_cc_dd, "0xaabbccdd === 0xaa_bb_cc_dd");
     }
   },
   {
     name: "Hex numeric literal bad syntax",
     body: function () {
-		assert.throws(()=>eval('0x_'), SyntaxError, "'_' cannot immediately follow 0x");
-		assert.throws(()=>eval('0x__'), SyntaxError, "'_' cannot immediately follow 0x");
-		assert.throws(()=>eval('0x_1'), SyntaxError, "Hex literal may not begin with numeric separator");
-		assert.throws(()=>eval('0x_0'), SyntaxError, "Hex literal may not begin with numeric separator");
-		assert.throws(()=>eval('0x__1'), SyntaxError, "Hex literal may not begin with numeric separator");
-		assert.throws(()=>eval('0x__0'), SyntaxError, "Hex literal may not begin with numeric separator");
-		assert.throws(()=>eval('0x1_'), SyntaxError, "Hex literal may not end with numeric separator");
-		assert.throws(()=>eval('0x0_'), SyntaxError, "Hex literal may not end with numeric separator");
-		assert.throws(()=>eval('0x1__'), SyntaxError, "Hex literal may not end with numeric separator");
-		assert.throws(()=>eval('0x0__'), SyntaxError, "Hex literal may not end with numeric separator");
-		assert.throws(()=>eval('0x1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0x0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0x000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0x000_q'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
-	}
+        assert.throws(()=>eval('0x_'), SyntaxError, "'_' cannot immediately follow 0x");
+        assert.throws(()=>eval('0x__'), SyntaxError, "'_' cannot immediately follow 0x");
+        assert.throws(()=>eval('0x_1'), SyntaxError, "Hex literal may not begin with numeric separator");
+        assert.throws(()=>eval('0x_0'), SyntaxError, "Hex literal may not begin with numeric separator");
+        assert.throws(()=>eval('0x__1'), SyntaxError, "Hex literal may not begin with numeric separator");
+        assert.throws(()=>eval('0x__0'), SyntaxError, "Hex literal may not begin with numeric separator");
+        assert.throws(()=>eval('0x1_'), SyntaxError, "Hex literal may not end with numeric separator");
+        assert.throws(()=>eval('0x0_'), SyntaxError, "Hex literal may not end with numeric separator");
+        assert.throws(()=>eval('0x1__'), SyntaxError, "Hex literal may not end with numeric separator");
+        assert.throws(()=>eval('0x0__'), SyntaxError, "Hex literal may not end with numeric separator");
+        assert.throws(()=>eval('0x1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0x0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0x000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0x000_q'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+    }
   },
   {
     name: "Strings parsed as number do not support numeric separators for hex literals",
     body: function () {
-		assert.areEqual(NaN, Number('0x0_ff'), "NaN === Number('0x0_ff')");
-		assert.areEqual(NaN, Number('0xF_F'), "NaN === Number('0xF_F')");
-		
-		assert.areEqual(0, parseInt('0x0_ff'), "0 === parseInt('0x0_ff')");
-		assert.areEqual(15, parseInt('0xf_00f'), "15 === parseInt('0xf_00f')");
-		
-		assert.areEqual(0, parseFloat('0x0_ff'), "0 === parseFloat('0x0_ff')");
-		assert.areEqual(0, parseFloat('0x1_fe'), "0 === parseFloat('0x1_fe')");
+        assert.areEqual(NaN, Number('0x0_ff'), "NaN === Number('0x0_ff')");
+        assert.areEqual(NaN, Number('0xF_F'), "NaN === Number('0xF_F')");
+
+        assert.areEqual(0, parseInt('0x0_ff'), "0 === parseInt('0x0_ff')");
+        assert.areEqual(15, parseInt('0xf_00f'), "15 === parseInt('0xf_00f')");
+
+        assert.areEqual(0, parseFloat('0x0_ff'), "0 === parseFloat('0x0_ff')");
+        assert.areEqual(0, parseFloat('0x1_fe'), "0 === parseFloat('0x1_fe')");
     }
   },
   {
@@ -178,49 +178,49 @@ var tests = [
         assert.areEqual(0o10, 0o1_0, "0o10 === 0o1_0");
         assert.areEqual(0o01, 0o0_1, "0o01 === 0o0_1");
         assert.areEqual(0o0001, 0o000_1, "0o0001 === 0o000_1");
-		assert.areEqual(0o0000, 0o000_0, "0o0000 === 0o000_0");
-		assert.areEqual(0o000011110000, 0o0000_1111_0000, "0o000011110000 === 0o0000_1111_0000");
-		assert.areEqual(0o000011110000, 0o0_0_0_0_1_111_00_00, "0o000011110000 === 0o0_0_0_0_1_111_00_00");
+        assert.areEqual(0o0000, 0o000_0, "0o0000 === 0o000_0");
+        assert.areEqual(0o000011110000, 0o0000_1111_0000, "0o000011110000 === 0o0000_1111_0000");
+        assert.areEqual(0o000011110000, 0o0_0_0_0_1_111_00_00, "0o000011110000 === 0o0_0_0_0_1_111_00_00");
     }
   },
   {
     name: "Octal literal bad syntax",
     body: function () {
-		assert.throws(()=>eval('0o_'), SyntaxError, "'_' cannot immediately follow 0o");
-		assert.throws(()=>eval('0o__'), SyntaxError, "'_' cannot immediately follow 0o");
-		assert.throws(()=>eval('0o_1'), SyntaxError, "Octal literal may not begin with numeric separator");
-		assert.throws(()=>eval('0o_0'), SyntaxError, "Octal literal may not begin with numeric separator");
-		assert.throws(()=>eval('0o__1'), SyntaxError, "Octal literal may not begin with numeric separator");
-		assert.throws(()=>eval('0o__0'), SyntaxError, "Octal literal may not begin with numeric separator");
-		assert.throws(()=>eval('0o1_'), SyntaxError, "Octal literal may not end with numeric separator");
-		assert.throws(()=>eval('0o0_'), SyntaxError, "Octal literal may not end with numeric separator");
-		assert.throws(()=>eval('0o1__'), SyntaxError, "Octal literal may not end with numeric separator");
-		assert.throws(()=>eval('0o0__'), SyntaxError, "Octal literal may not end with numeric separator");
-		assert.throws(()=>eval('0o1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0o0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0o000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
-		assert.throws(()=>eval('0o000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
-	}
+        assert.throws(()=>eval('0o_'), SyntaxError, "'_' cannot immediately follow 0o");
+        assert.throws(()=>eval('0o__'), SyntaxError, "'_' cannot immediately follow 0o");
+        assert.throws(()=>eval('0o_1'), SyntaxError, "Octal literal may not begin with numeric separator");
+        assert.throws(()=>eval('0o_0'), SyntaxError, "Octal literal may not begin with numeric separator");
+        assert.throws(()=>eval('0o__1'), SyntaxError, "Octal literal may not begin with numeric separator");
+        assert.throws(()=>eval('0o__0'), SyntaxError, "Octal literal may not begin with numeric separator");
+        assert.throws(()=>eval('0o1_'), SyntaxError, "Octal literal may not end with numeric separator");
+        assert.throws(()=>eval('0o0_'), SyntaxError, "Octal literal may not end with numeric separator");
+        assert.throws(()=>eval('0o1__'), SyntaxError, "Octal literal may not end with numeric separator");
+        assert.throws(()=>eval('0o0__'), SyntaxError, "Octal literal may not end with numeric separator");
+        assert.throws(()=>eval('0o1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0o0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0o000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+        assert.throws(()=>eval('0o000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+    }
   },
   {
     name: "Strings parsed as number do not support numeric separators for octal literals",
     body: function () {
-		assert.areEqual(NaN, Number('0o0_1'), "NaN === Number('0o0_1')");
-		assert.areEqual(NaN, Number('0o1_0'), "NaN === Number('0o1_0')");
-		assert.areEqual(NaN, Number('0o0_0'), "NaN === Number('0o0_0')");
-		assert.areEqual(NaN, Number('0o1_1'), "NaN === Number('0o1_1')");
-		
-		assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
-		
-		assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
+        assert.areEqual(NaN, Number('0o0_1'), "NaN === Number('0o0_1')");
+        assert.areEqual(NaN, Number('0o1_0'), "NaN === Number('0o1_0')");
+        assert.areEqual(NaN, Number('0o0_0'), "NaN === Number('0o0_0')");
+        assert.areEqual(NaN, Number('0o1_1'), "NaN === Number('0o1_1')");
+
+        assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
+
+        assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
     }
   },
   {
     name: "Legacy octal numeric literals do not support numeric separators",
     body: function () {
-		assert.throws(()=>eval('0_1'), SyntaxError, "'_' cannot immediately follow 0 in legacy octal numeric literal");
-		assert.throws(()=>eval('07_7'), SyntaxError, "Legacy octal numeric literals do not support numeric separator");
-	}
+        assert.throws(()=>eval('0_1'), SyntaxError, "'_' cannot immediately follow 0 in legacy octal numeric literal");
+        assert.throws(()=>eval('07_7'), SyntaxError, "Legacy octal numeric literals do not support numeric separator");
+    }
   },
 ];
 

--- a/test/Number/NumericSeparator.js
+++ b/test/Number/NumericSeparator.js
@@ -1,0 +1,70 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Basic decimal support",
+    body: function () {
+        assert.areEqual(1234, 1_234, "1234 === 1_234");
+        assert.areEqual(1234, 1_2_3_4, "1234 === 1_2_3_4");
+        assert.areEqual(1234.567, 1_2_3_4.5_6_7, "1234.567 === 1_2_3_4.5_6_7");
+
+        assert.areEqual(-1234, -1_2_34, "-1234 === -1_2_34");
+        assert.areEqual(-12.34, -1_2.3_4, "-12.34 === -1_2.3_4");
+    }
+  },
+  {
+    name: "Decimal with exponent",
+    body: function () {
+        assert.areEqual(1e100, 1e1_00, "1e100 === 1e1_00");
+        assert.areEqual(Infinity, 1e1_0_0_0, "Infinity === 1e1_0_0_0");
+
+        assert.areEqual(123.456e23, 1_2_3.4_5_6e2_3, "123.456e23 === 1_2_3.4_5_6e2_3");
+        assert.areEqual(123.456e001, 1_2_3.4_5_6e0_0_1, "123.456e001 === 1_2_3.4_5_6e0_0_1");
+    }
+  },
+  {
+    name: "Decimal bad syntax",
+    body: function () {
+        // Decimal left-part only with numeric separators
+        assert.throws(()=>eval('1__2'), SyntaxError, "Multiple numeric separators in a row are now allowed");
+        assert.throws(()=>eval('1_2____3'), SyntaxError, "Multiple numeric separators in a row are now allowed");
+        assert.throws(()=>eval('1_'), SyntaxError, "Decimal may not end in a numeric separator");
+        assert.throws(()=>eval('1__'), SyntaxError, "Decimal may not end in a numeric separator");
+        assert.throws(()=>eval('__1'), ReferenceError, "Decimal may not begin with a numeric separator");
+        assert.throws(()=>eval('_1'), ReferenceError, "Decimal may not begin with a numeric separator");
+
+        // Decimal with right-part with numeric separators
+        assert.throws(()=>eval('1.0__0'), SyntaxError, "Decimal right-part may not contain multiple contiguous numeric separators");
+        assert.throws(()=>eval('1.0_0__2'), SyntaxError, "Decimal right-part may not contain multiple contiguous numeric separators");
+        assert.throws(()=>eval('1._'), SyntaxError, "Decimal right-part may not be a single numeric separator");
+        assert.throws(()=>eval('1.__'), SyntaxError, "Decimal right-part may not be multiple numeric separators");
+        assert.throws(()=>eval('1._0'), SyntaxError, "Decimal right-part may not begin with a numeric separator");
+        assert.throws(()=>eval('1.__0'), SyntaxError, "Decimal right-part may not begin with a numeric separator");
+        assert.throws(()=>eval('1.0_'), SyntaxError, "Decimal right-part may not end with a numeric separator");
+        assert.throws(()=>eval('1.0__'), SyntaxError, "Decimal right-part may not end with a numeric separator");
+
+        // Decimal with both parts with numeric separators
+        assert.throws(()=>eval('1_.0'), SyntaxError, "Decimal left-part may not end in numeric separator");
+        assert.throws(()=>eval('1__.0'), SyntaxError, "Decimal left-part may not end in numeric separator");
+        assert.throws(()=>eval('1__2.0'), SyntaxError, "Decimal left-part may not contain multiple contiguous numeric separators");
+
+        // Decimal with exponent with numeric separators
+        assert.throws(()=>eval('1_e10'), SyntaxError, "Decimal left-part may not end in numeric separator");
+        assert.throws(()=>eval('1e_1'), SyntaxError, "Exponent may not begin with numeric separator");
+        assert.throws(()=>eval('1e__1'), SyntaxError, "Exponent may not begin with numeric separator");
+        assert.throws(()=>eval('1e1_'), SyntaxError, "Exponent may not end with numeric separator");
+        assert.throws(()=>eval('1e1__'), SyntaxError, "Exponent may not end with numeric separator");
+        assert.throws(()=>eval('1e1__2'), SyntaxError, "Exponent may not contain multiple contiguous numeric separators");
+
+        // Decimal big ints with numeric separators
+        assert.throws(()=>eval('1_n'), SyntaxError);
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Number/NumericSeparator.js
+++ b/test/Number/NumericSeparator.js
@@ -7,7 +7,7 @@ WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 var tests = [
   {
-    name: "Basic decimal support",
+    name: "Basic decimal literal support",
     body: function () {
         assert.areEqual(1234, 1_234, "1234 === 1_234");
         assert.areEqual(1234, 1_2_3_4, "1234 === 1_2_3_4");
@@ -18,7 +18,7 @@ var tests = [
     }
   },
   {
-    name: "Decimal with exponent",
+    name: "Decimal literal with exponent",
     body: function () {
         assert.areEqual(1e100, 1e1_00, "1e100 === 1e1_00");
         assert.areEqual(Infinity, 1e1_0_0_0, "Infinity === 1e1_0_0_0");
@@ -28,11 +28,11 @@ var tests = [
     }
   },
   {
-    name: "Decimal bad syntax",
+    name: "Decimal literal bad syntax",
     body: function () {
         // Decimal left-part only with numeric separators
-        assert.throws(()=>eval('1__2'), SyntaxError, "Multiple numeric separators in a row are now allowed");
-        assert.throws(()=>eval('1_2____3'), SyntaxError, "Multiple numeric separators in a row are now allowed");
+        assert.throws(()=>eval('1__2'), SyntaxError, "Multiple numeric separators in a row are not allowed");
+        assert.throws(()=>eval('1_2____3'), SyntaxError, "Multiple numeric separators in a row are not allowed");
         assert.throws(()=>eval('1_'), SyntaxError, "Decimal may not end in a numeric separator");
         assert.throws(()=>eval('1__'), SyntaxError, "Decimal may not end in a numeric separator");
         assert.throws(()=>eval('__1'), ReferenceError, "Decimal may not begin with a numeric separator");
@@ -63,6 +63,69 @@ var tests = [
 
         // Decimal big ints with numeric separators
         assert.throws(()=>eval('1_n'), SyntaxError);
+    }
+  },
+  {
+    name: "Strings parsed as number do not support numeric separators for decimal literals",
+    body: function () {
+		assert.areEqual(NaN, Number('12_34'), "NaN === Number('12_34')");
+		assert.areEqual(NaN, Number('12e3_4'), "NaN === Number('12e3_4')");
+		assert.areEqual(NaN, Number('1234.45_67'), "NaN === Number('1234.45_67')");
+		assert.areEqual(NaN, Number('1234.45e6_7'), "NaN === Number('1234.45e6_7')");
+		
+		assert.areEqual(1, parseInt('1_2'), "1 === parseInt('1_2')");
+		assert.areEqual(1, parseInt('1e2_3'), "1 === parseInt('1e2_3')");
+		assert.areEqual(12, parseInt('12.3_4'), "1 === parseInt('12.3_4')");
+		assert.areEqual(12, parseInt('12.34e5_6'), "1 === parseInt('12.34e5_6')");
+		
+		assert.areEqual(1, parseFloat('1_2'), "1 === parseFloat('1_2')");
+		assert.areEqual(1e2, parseFloat('1e2_3'), "1 === parseFloat('1e2_3')");
+		assert.areEqual(12.3, parseFloat('12.3_4'), "1 === parseFloat('12.3_4')");
+		assert.areEqual(12.34e5, parseFloat('12.34e5_6'), "1 === parseFloat('12.34e5_6')");
+    }
+  },
+  {
+    name: "Basic binary literal support",
+    body: function () {
+        assert.areEqual(0b00, 0b0_0, "0b00 === 0b0_0");
+        assert.areEqual(0b11, 0b1_1, "0b11 === 0b1_1");
+        assert.areEqual(0b10, 0b1_0, "0b10 === 0b1_0");
+        assert.areEqual(0b01, 0b0_1, "0b01 === 0b0_1");
+        assert.areEqual(0b0001, 0b000_1, "0b0001 === 0b000_1");
+		assert.areEqual(0b0000, 0b000_0, "0b0000 === 0b000_0");
+		assert.areEqual(0b000011110000, 0b0000_1111_0000, "0b000011110000 === 0b0000_1111_0000");
+    }
+  },
+  {
+    name: "Binary literal bad syntax",
+    body: function () {
+		assert.throws(()=>eval('0b_'), SyntaxError, "'_' cannot immediately follow 0b");
+		assert.throws(()=>eval('0b__'), SyntaxError, "'_' cannot immediately follow 0b");
+		assert.throws(()=>eval('0b_1'), SyntaxError, "Binary literal may not begin with numeric separator");
+		assert.throws(()=>eval('0b_0'), SyntaxError, "Binary literal may not begin with numeric separator");
+		assert.throws(()=>eval('0b__1'), SyntaxError, "Binary literal may not begin with numeric separator");
+		assert.throws(()=>eval('0b__0'), SyntaxError, "Binary literal may not begin with numeric separator");
+		assert.throws(()=>eval('0b1_'), SyntaxError, "Binary literal may not end with numeric separator");
+		assert.throws(()=>eval('0b0_'), SyntaxError, "Binary literal may not end with numeric separator");
+		assert.throws(()=>eval('0b1__'), SyntaxError, "Binary literal may not end with numeric separator");
+		assert.throws(()=>eval('0b0__'), SyntaxError, "Binary literal may not end with numeric separator");
+		assert.throws(()=>eval('0b1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0b0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0b000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0b000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+	}
+  },
+  {
+    name: "Strings parsed as number do not support numeric separators for binary literals",
+    body: function () {
+		assert.areEqual(NaN, Number('0b0_1'), "NaN === Number('0b0_1')");
+		assert.areEqual(NaN, Number('0b1_0'), "NaN === Number('0b1_0')");
+		assert.areEqual(NaN, Number('0b0_0'), "NaN === Number('0b0_0')");
+		assert.areEqual(NaN, Number('0b1_1'), "NaN === Number('0b1_1')");
+		
+		assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
+		
+		assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
     }
   },
 ];

--- a/test/Number/NumericSeparator.js
+++ b/test/Number/NumericSeparator.js
@@ -7,7 +7,7 @@ WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 var tests = [
   {
-    name: "Basic decimal literal support",
+    name: "Decimal literal support",
     body: function () {
         assert.areEqual(1234, 1_234, "1234 === 1_234");
         assert.areEqual(1234, 1_2_3_4, "1234 === 1_2_3_4");
@@ -85,7 +85,7 @@ var tests = [
     }
   },
   {
-    name: "Basic binary literal support",
+    name: "Binary literal support",
     body: function () {
         assert.areEqual(0b00, 0b0_0, "0b00 === 0b0_0");
         assert.areEqual(0b11, 0b1_1, "0b11 === 0b1_1");
@@ -94,6 +94,7 @@ var tests = [
         assert.areEqual(0b0001, 0b000_1, "0b0001 === 0b000_1");
 		assert.areEqual(0b0000, 0b000_0, "0b0000 === 0b000_0");
 		assert.areEqual(0b000011110000, 0b0000_1111_0000, "0b000011110000 === 0b0000_1111_0000");
+		assert.areEqual(0b000011110000, 0b0_0_0_0_1_111_00_00, "0b000011110000 === 0b0_0_0_0_1_111_00_00");
     }
   },
   {
@@ -126,6 +127,47 @@ var tests = [
 		assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
 		
 		assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
+    }
+  },
+  {
+    name: "Hex numeric literal support",
+    body: function () {
+        assert.areEqual(0x00, 0x0_0, "0x00 === 0x0_0");
+        assert.areEqual(0x1f, 0x1_f, "0x1f === 0x1_f");
+        assert.areEqual(0x000000Ae1, 0x00_0_000_A_e1, "0x000000Ae1 === 0x00_0_000_A_e1");
+		assert.areEqual(0xaabbccdd, 0xaa_bb_cc_dd, "0xaabbccdd === 0xaa_bb_cc_dd");
+    }
+  },
+  {
+    name: "Hex numeric literal bad syntax",
+    body: function () {
+		assert.throws(()=>eval('0x_'), SyntaxError, "'_' cannot immediately follow 0x");
+		assert.throws(()=>eval('0x__'), SyntaxError, "'_' cannot immediately follow 0x");
+		assert.throws(()=>eval('0x_1'), SyntaxError, "Hex literal may not begin with numeric separator");
+		assert.throws(()=>eval('0x_0'), SyntaxError, "Hex literal may not begin with numeric separator");
+		assert.throws(()=>eval('0x__1'), SyntaxError, "Hex literal may not begin with numeric separator");
+		assert.throws(()=>eval('0x__0'), SyntaxError, "Hex literal may not begin with numeric separator");
+		assert.throws(()=>eval('0x1_'), SyntaxError, "Hex literal may not end with numeric separator");
+		assert.throws(()=>eval('0x0_'), SyntaxError, "Hex literal may not end with numeric separator");
+		assert.throws(()=>eval('0x1__'), SyntaxError, "Hex literal may not end with numeric separator");
+		assert.throws(()=>eval('0x0__'), SyntaxError, "Hex literal may not end with numeric separator");
+		assert.throws(()=>eval('0x1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0x0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0x000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0x000_q'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+	}
+  },
+  {
+    name: "Strings parsed as number do not support numeric separators for hex literals",
+    body: function () {
+		assert.areEqual(NaN, Number('0x0_ff'), "NaN === Number('0x0_ff')");
+		assert.areEqual(NaN, Number('0xF_F'), "NaN === Number('0xF_F')");
+		
+		assert.areEqual(0, parseInt('0x0_ff'), "0 === parseInt('0x0_ff')");
+		assert.areEqual(15, parseInt('0xf_00f'), "15 === parseInt('0xf_00f')");
+		
+		assert.areEqual(0, parseFloat('0x0_ff'), "0 === parseFloat('0x0_ff')");
+		assert.areEqual(0, parseFloat('0x1_fe'), "0 === parseFloat('0x1_fe')");
     }
   },
 ];

--- a/test/Number/NumericSeparator.js
+++ b/test/Number/NumericSeparator.js
@@ -170,6 +170,58 @@ var tests = [
 		assert.areEqual(0, parseFloat('0x1_fe'), "0 === parseFloat('0x1_fe')");
     }
   },
+  {
+    name: "Octal literal support",
+    body: function () {
+        assert.areEqual(0o00, 0o0_0, "0o00 === 0o0_0");
+        assert.areEqual(0o11, 0o1_1, "0o11 === 0o1_1");
+        assert.areEqual(0o10, 0o1_0, "0o10 === 0o1_0");
+        assert.areEqual(0o01, 0o0_1, "0o01 === 0o0_1");
+        assert.areEqual(0o0001, 0o000_1, "0o0001 === 0o000_1");
+		assert.areEqual(0o0000, 0o000_0, "0o0000 === 0o000_0");
+		assert.areEqual(0o000011110000, 0o0000_1111_0000, "0o000011110000 === 0o0000_1111_0000");
+		assert.areEqual(0o000011110000, 0o0_0_0_0_1_111_00_00, "0o000011110000 === 0o0_0_0_0_1_111_00_00");
+    }
+  },
+  {
+    name: "Octal literal bad syntax",
+    body: function () {
+		assert.throws(()=>eval('0o_'), SyntaxError, "'_' cannot immediately follow 0o");
+		assert.throws(()=>eval('0o__'), SyntaxError, "'_' cannot immediately follow 0o");
+		assert.throws(()=>eval('0o_1'), SyntaxError, "Octal literal may not begin with numeric separator");
+		assert.throws(()=>eval('0o_0'), SyntaxError, "Octal literal may not begin with numeric separator");
+		assert.throws(()=>eval('0o__1'), SyntaxError, "Octal literal may not begin with numeric separator");
+		assert.throws(()=>eval('0o__0'), SyntaxError, "Octal literal may not begin with numeric separator");
+		assert.throws(()=>eval('0o1_'), SyntaxError, "Octal literal may not end with numeric separator");
+		assert.throws(()=>eval('0o0_'), SyntaxError, "Octal literal may not end with numeric separator");
+		assert.throws(()=>eval('0o1__'), SyntaxError, "Octal literal may not end with numeric separator");
+		assert.throws(()=>eval('0o0__'), SyntaxError, "Octal literal may not end with numeric separator");
+		assert.throws(()=>eval('0o1__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0o0__0'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0o000__1'), SyntaxError, "Multiple numeric separator characters may not follow each other");
+		assert.throws(()=>eval('0o000_a'), SyntaxError, "After initial zeroes, a numeric separator followed by an invalid character");
+	}
+  },
+  {
+    name: "Strings parsed as number do not support numeric separators for octal literals",
+    body: function () {
+		assert.areEqual(NaN, Number('0o0_1'), "NaN === Number('0o0_1')");
+		assert.areEqual(NaN, Number('0o1_0'), "NaN === Number('0o1_0')");
+		assert.areEqual(NaN, Number('0o0_0'), "NaN === Number('0o0_0')");
+		assert.areEqual(NaN, Number('0o1_1'), "NaN === Number('0o1_1')");
+		
+		assert.areEqual(0, parseInt('0b1_0'), "0 === parseInt('0b1_0')");
+		
+		assert.areEqual(0, parseFloat('0b1_0'), "0 === parseFloat('0b1_0')");
+    }
+  },
+  {
+    name: "Legacy octal numeric literals do not support numeric separators",
+    body: function () {
+		assert.throws(()=>eval('0_1'), SyntaxError, "'_' cannot immediately follow 0 in legacy octal numeric literal");
+		assert.throws(()=>eval('07_7'), SyntaxError, "Legacy octal numeric literals do not support numeric separator");
+	}
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Number/rlexe.xml
+++ b/test/Number/rlexe.xml
@@ -63,4 +63,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>NumericSeparator.js</files>
+      <compile-flags>-ESNumericSeparator -args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Implement Numeric Separator
    
Add support for numeric separator characters in numeric literals. These are just syntactic sugar which improve readability of numeric constants in source. They desugar completely out of the numbers when parsed.
    
Numeric digits in the constant may have a single `'_'` character between them. The constant may not begin or end with a `'_'` character and there may not be multiple numeric separators in a row. All numeric constants are supported. Includes decimal, hex, octal and binary numeric constants.

Legacy octal integer constants do not support numeric separators. Numeric values parsed from string functions (like ToNumber or parseInt) also do not support numeric separators. 
    
```javascript
    1234 === 1_2_3_4; // true
    12.34e56 === 1_2.3_4e5_6; // true
    0xff === 0xf_f; // true
    0o17 === 0o1_7; // true
    0b11 === 0b1_1; // true
```
    
Numeric Separator proposal is in stage 3 and implemented by JSC and V8. See proposal:
https://github.com/tc39/proposal-numeric-separator
    
Fixes: #6060
