### PR TITLE
Move type transition before use processing in backward pass.

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -3062,6 +3062,11 @@ BackwardPass::ProcessBlock(BasicBlock * block)
             TrackFloatSymEquivalence(instr);
         }
 
+        if (this->tag == Js::DeadStorePhase && block->stackSymToFinalType != nullptr)
+        {
+            this->InsertTypeTransitionsAtPotentialKills();
+        }
+
         opnd = instr->GetSrc1();
         if (opnd != nullptr)
         {
@@ -3737,11 +3742,6 @@ BackwardPass::ProcessBlock(BasicBlock * block)
                 this->IsPrePass() || (needsLazyBailOut || !instr->HasLazyBailOut()),
                 "We didn't remove lazy bailout after prepass even though we don't need it?"
             );
-
-            if (block->stackSymToFinalType != nullptr)
-            {
-                this->InsertTypeTransitionsAtPotentialKills();
-            }
 
             // NoImplicitCallUses transfers need to be processed after determining whether implicit calls need to be disabled
             // for the current instruction, because the instruction where the def occurs also needs implicit calls disabled.

--- a/test/Optimizer/aux_slot_type_transition.js
+++ b/test/Optimizer/aux_slot_type_transition.js
@@ -1,0 +1,25 @@
+function test0(){
+  function f() { obj.p9 = obj.p1 }
+  let obj = {};
+  obj.p1 = null;
+  obj.p2 = null;
+  obj.p3 = null;
+  obj.p4 = null;
+  obj.p5 = null;
+  obj.p6 = null;
+  obj.p7 = null;
+  obj.p8 = null;
+  f();
+  +obj.p9;
+};
+
+// generate profile
+test0();
+
+// Run Simple JIT
+test0();
+
+// run JITted code
+test0();
+
+print("Pass");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1605,4 +1605,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -force:inline</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>aux_slot_type_transition.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When we insert type transitions, we need to know whether an aux slot pointer is in use so that we can correctly generate AdjustObjTypeReloadAuxSlotPtr intrs. Since use processing can clear aux slot syms from the upward exposed set, we move type transitions before use processing.
