### PR TITLE
use RPC handle marshalling when running on win8.1+

### DIFF
--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -85,6 +85,7 @@ AutoSystemInfo::Initialize()
     allocationGranularityPageCount = dwAllocationGranularity / dwPageSize;
 
     isWindows8OrGreater = IsWindows8OrGreater();
+    isWindows8Point1OrGreater = IsWindows8Point1OrGreater();
 
     binaryName[0] = _u('\0');
 
@@ -364,6 +365,12 @@ bool
 AutoSystemInfo::IsWin8OrLater()
 {
     return isWindows8OrGreater;
+}
+
+bool
+AutoSystemInfo::IsWin8Point1OrLater()
+{
+    return isWindows8Point1OrGreater;
 }
 
 #if defined(_CONTROL_FLOW_GUARD)

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -16,6 +16,7 @@ public:
 
     bool DisableDebugScopeCapture() const { return this->disableDebugScopeCapture; }
     bool IsWin8OrLater();
+    bool IsWin8Point1OrLater();
 #if defined(_CONTROL_FLOW_GUARD)
     bool IsWinThresholdOrLater();
 #endif
@@ -88,6 +89,7 @@ private:
     AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0), crtSize(0) { Initialize(); }
     void Initialize();
     bool isWindows8OrGreater;
+    bool isWindows8Point1OrGreater;
     uint allocationGranularityPageCount;
     HANDLE processHandle;
     DWORD crtSize;

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -28,9 +28,7 @@ interface IChakraJIT
 
     HRESULT ConnectProcess(
         [in] handle_t binding,
-#ifdef USE_RPC_HANDLE_MARSHALLING
         [in, system_handle(sh_process, PROCESS_VM_OPERATION | PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_QUERY_LIMITED_INFORMATION)] HANDLE processHandle,
-#endif
         [in] CHAKRA_PTR chakraBaseAddress,
         [in] CHAKRA_PTR crtBaseAddress
     );

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -12,14 +12,6 @@ import "wtypes.idl";
 #include "sdkddkver.h"
 #endif
 
-
-#if defined(WINVER) && WINVER >= _WIN32_WINNT_WINBLUE // on 8.1+, RPC can marshal process handle for us
-#ifdef __midl
-cpp_quote("#define USE_RPC_HANDLE_MARSHALLING 1")
-#endif
-#define USE_RPC_HANDLE_MARSHALLING 1
-#endif
-
 #if defined(TARGET_32)
 #ifdef __midl
 #define CHAKRA_WB_PTR int


### PR DESCRIPTION
this was compile time check before and we would use RPC handle marshalling when target platform was win8.1+. Now it will be used if running on 8.1+ regardless of target platform.