### PR TITLE
fix failure restoring arguments object when aliased in try block

### DIFF
--- a/test/Optimizer/argrestoreintry.js
+++ b/test/Optimizer/argrestoreintry.js
@@ -1,0 +1,20 @@
+function bar() {
+    throw new Error();
+}
+function foo() {
+    try {
+        x = arguments;
+        bar();
+    } catch (e) {
+        return x.length;
+    } 
+    var x = {
+        j: 1,
+        k: 2.2
+    };
+}
+foo();
+foo();
+let pass = foo() === 0;
+
+print(pass ? "Pass" : "Fail")

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1611,4 +1611,10 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>argrestoreintry.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
for stack args bailout needs to know if value we are restoring is arguments (or an alias), but we don't precisely track flow in try blocks, so if assignment is to a writethrough sym we should give up on stack args.

Fixes #6058