### PR TITLE
OSG:21628239 Do not assign slot indices to objtypespec field info during the prepass

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1326,12 +1326,6 @@ GlobOpt::ProcessPropOpInTypeCheckSeq(IR::Instr* instr, IR::PropertySymOpnd *opnd
             {
                 // Indicates we can optimize, as all upstream types are equivalent here.
 
-                opnd->SetSlotIndex(slotIndex);
-                opnd->SetUsesAuxSlot(auxSlot);
-
-                opnd->GetObjTypeSpecInfo()->SetSlotIndex(slotIndex);
-                opnd->GetObjTypeSpecInfo()->SetUsesAuxSlot(auxSlot);
-
                 isSpecialized = true;
                 if (isTypeCheckedOut)
                 {
@@ -1340,10 +1334,17 @@ GlobOpt::ProcessPropOpInTypeCheckSeq(IR::Instr* instr, IR::PropertySymOpnd *opnd
                 if (consumeType)
                 {
                     opnd->SetTypeChecked(true);
-                }
-                if (checkedTypeSetIndex != (uint16)-1)
-                {
-                    opnd->SetCheckedTypeSetIndex(checkedTypeSetIndex);
+
+                    opnd->SetSlotIndex(slotIndex);
+                    opnd->SetUsesAuxSlot(auxSlot);
+
+                    opnd->GetObjTypeSpecInfo()->SetSlotIndex(slotIndex);
+                    opnd->GetObjTypeSpecInfo()->SetUsesAuxSlot(auxSlot);
+
+                    if (checkedTypeSetIndex != (uint16)-1)
+                    {
+                        opnd->SetCheckedTypeSetIndex(checkedTypeSetIndex);
+                    }
                 }
             }
         }

--- a/test/fieldopts/depolymorph01.js
+++ b/test/fieldopts/depolymorph01.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var obj0 = {};
+  var arrObj0 = {};
+  var litObj0 = { prop1: 3.14159265358979 };
+  var func1 = function (argMath1 = func0(), argMath3) {
+    protoObj0.prop0 = ++this.prop0;
+    this.prop0 = argMath3;
+  };
+  obj0.method0 = func1;
+  obj0.method1 = obj0.method0;
+  var IntArr0 = Array();
+  var protoObj0 = Object.create(obj0);
+  prop0 = 1;
+  protoObj0.method0.call(litObj0, arrObj0);
+  while (prop0) {
+    protoObj0.method1(arrObj0);
+    obj0.method0(obj0);
+    prop0 = IntArr0.shift();
+  }
+  obj0.method0('');
+}
+test0();
+test0();
+test0();
+WScript.Echo('pass');

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -2,6 +2,11 @@
 <regress-exe>
   <test>
     <default>
+      <files>depolymorph01.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>equiv-finaltypeandpoly.js</files>
       <compile-flags>-maxSimpleJitRunCount:2</compile-flags>
     </default>


### PR DESCRIPTION
Object pointer copy prop + depolymorphication may cause these indices to change between passes.