### PR TITLE
Await should only get the promise's constructor property once

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -471,7 +471,16 @@ namespace Js
         static Var CreateResolvedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor = nullptr);
         static Var CreatePassThroughPromise(JavascriptPromise* sourcePromise, ScriptContext* scriptContext);
         static Var CreateThenPromise(JavascriptPromise* sourcePromise, RecyclableObject* fulfillmentHandler, RecyclableObject* rejectionHandler, ScriptContext* scriptContext);
+        
         static JavascriptPromise* InternalPromiseResolve(Var value, ScriptContext* scriptContext);
+        static Var PromiseResolve(Var constructor, Var value, ScriptContext* scriptContext);
+        
+        static void PerformPromiseThen(
+            JavascriptPromise* sourcePromise,
+            JavascriptPromiseCapability* capability,
+            RecyclableObject* fulfillmentHandler,
+            RecyclableObject* rejectionHandler,
+            ScriptContext* scriptContext);
 
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
@@ -480,6 +489,7 @@ namespace Js
 
 
         static JavascriptPromiseCapability* NewPromiseCapability(Var constructor, ScriptContext* scriptContext);
+        static JavascriptPromiseCapability* UnusedPromiseCapability(ScriptContext* scriptContext);
         static JavascriptPromiseCapability* CreatePromiseCapabilityRecord(RecyclableObject* constructor, ScriptContext* scriptContext);
         static Var TriggerPromiseReactions(JavascriptPromiseReactionList* reactions, bool isReject, Var resolution, ScriptContext* scriptContext);
         static void EnqueuePromiseReactionTask(JavascriptPromiseReaction* reaction, Var resolution, ScriptContext* scriptContext);

--- a/test/es7/asyncawait-functionality.baseline
+++ b/test/es7/asyncawait-functionality.baseline
@@ -40,6 +40,8 @@ Test #32 - Success initial value of the body symbol is the same as the default p
 Executing test #33 - `then` is not called when awaiting a non-promise or native promise
 Executing test #34 - `then` is called when awaiting a promise subclass
 Executing test #35 - `then` is called when awaiting a non-promise thenable
+Executing test #36 - The constructor property is only accessed once by await
+Test #36 - constructor property accessed
 
 Completion Results:
 Test #1 - Success lambda expression with no argument called with result = 'true'

--- a/test/es7/asyncawait-functionality.js
+++ b/test/es7/asyncawait-functionality.js
@@ -1091,6 +1091,23 @@ var tests = [
 
             f();
         }
+    },
+    {
+        name: "The constructor property is only accessed once by await",
+        body: function (index) {
+            async function f() {
+                let p = Promise.resolve(0);
+                Object.defineProperty(p, 'constructor', {
+                    get: function() {
+                        echo(`Test #${index} - constructor property accessed`);
+                        return Promise;
+                    }
+                });
+                await p;
+            }
+
+            f();
+        }
     }
 ];
 


### PR DESCRIPTION
Fixes #6162 

Currently, `await` will trigger two gets for the operand's "constructor" property: once when doing `Promise.resolve` and then again in the call to `CreateThenPromise`.

This change introduces `PerformPromiseThen`, a new function parallel to the spec's abstract operation of the same name, that takes a promise capability instead of creating a new one, along with:

- Some refactorings around "resolve"-type internal functions.
- A new `UnunsedPromiseCapability` function, which can be optimized in the future for await scenarios.
- Formatting changes for readability (writing and reviewing code is much easier for those working on laptops if line lengths are kept under 120).