### PR TITLE
Hoist Module Function Exports

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7128,6 +7128,8 @@ template<bool buildAST>
 ParseNodePtr Parser::GenerateModuleFunctionWrapper()
 {
     ParseNodePtr pnodeFnc = ParseFncDeclNoCheckScope<buildAST>(fFncModule, SuperRestrictionState::Disallowed, nullptr, /* needsPIDOnRCurlyScan */ false, /* fUnaryOrParen */ true);
+    // mark modules as generators after parsing - this is to enable cross-module hoisting of exported functions
+    pnodeFnc->AsParseNodeFnc()->SetIsGenerator(true);
     ParseNodePtr callNode = CreateCallNode(knopCall, pnodeFnc, nullptr);
 
     return callNode;

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -35,6 +35,7 @@ namespace Js
         bool ModuleDeclarationInstantiation() override;
         void GenerateRootFunction();
         Var ModuleEvaluation() override;
+        bool ModuleEvaluationPrepass();
         virtual ModuleNamespace* GetNamespace();
         virtual void SetNamespace(ModuleNamespace* moduleNamespace);
 
@@ -61,6 +62,8 @@ namespace Js
 
         bool WasParsed() const { return wasParsed; }
         void SetWasParsed() { wasParsed = true; }
+        bool WasEvaluationPrepassed() const { return wasPrepassed; }
+        void SetEvaluationPrepassed() { wasPrepassed = true; }
         bool WasDeclarationInitialized() const { return wasDeclarationInitialized; }
         void SetWasDeclarationInitialized() { wasDeclarationInitialized = true; }
         void SetIsRootModule() { isRootModule = true; }
@@ -122,11 +125,13 @@ namespace Js
         // This is the parsed tree resulted from compilation.
         Field(bool) confirmedReady = false;
         Field(bool) notifying = false;
+        Field(bool) wasPrepassed = false;
         Field(bool) wasParsed;
         Field(bool) wasDeclarationInitialized;
         Field(bool) parentsNotified;
         Field(bool) isRootModule;
         Field(bool) hadNotifyHostReady;
+        Field(JavascriptGenerator*) generator;
         Field(ParseNodeProg *) parseTree;
         Field(Utf8SourceInfo*) pSourceInfo;
         Field(uint) sourceIndex;

--- a/lib/Runtime/Library/JavascriptGenerator.h
+++ b/lib/Runtime/Library/JavascriptGenerator.h
@@ -57,6 +57,8 @@ namespace Js
             }
         }
 
+        Var CallGenerator(ResumeYieldData* yieldData, const char16* apiNameForErrorMessage);
+
     private:
         Field(InterpreterStackFrame*) frame;
         Field(GeneratorState) state;
@@ -74,7 +76,6 @@ namespace Js
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptGenerator, DynamicObject, args);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptGenerator);
 
-        Var CallGenerator(ResumeYieldData* yieldData, const char16* apiNameForErrorMessage);
         JavascriptGenerator(DynamicType* type, Arguments& args, ScriptFunction* scriptFunction);
 
     public:

--- a/test/es6module/module-bugfixes.js
+++ b/test/es6module/module-bugfixes.js
@@ -130,6 +130,43 @@ var tests = [
 
             testRunner.LoadModule('import "test6133a";', undefined, true);
         }
+    },
+    {
+        name : "Issue 5236: Module function exports not hoisted test",
+        body()
+        {
+            WScript.RegisterModuleSource("test5236a", `
+                import {default as Default, bar, foo} from "test5236b";
+                export default function () {}
+                export function one() {}
+                export var two = function () {}
+
+                bar();
+                assert.isNotUndefined(Default);
+                foo();
+                `);
+            WScript.RegisterModuleSource("test5236b", `
+                import Default from "test5236c";
+
+                export function bar() {}
+                export default class {}
+                export var foo = function () {}
+
+                Default();
+                `);
+            WScript.RegisterModuleSource("test5236c", `
+                import {default as Default, one, two} from "test5236a";
+                import otherDefault from "test5236b";
+                export default function bar() {}
+
+                Default();
+                one();
+                assert.isUndefined(two);
+                assert.isUndefined(otherDefault);
+                `);
+
+            testRunner.LoadModule('import "test5236a";', undefined, false);
+        }
     }
 ];
 


### PR DESCRIPTION
This PR enables function exports to be hoisted across modules as per  https://tc39.es/ecma262/#sec-source-text-module-record-initialize-environment

I believe this is the last significant bug in the module implementation (there remain two issues with not getting the right errors thrown but those don't impact correct code)

This is done by following @guybedford's advice of converting module root functions into generator functions with a yield at the top after functions are defined they are then executed in two steps so that all functions are declared first.

**Side effects of this change:**
1. The bottom line of the stack trace for errors thrown in modules  `at module` which was in all module error stack traces has been removed - could probably revert this but saw no value to the line
2. Any loops in the module global will now NOT be eligible for jitting - as JitLoopBody is disabled in generator functions - this is probably fixable for modules with some special casing but not currently sure which conditions to edit

@boingoing please could you take a look at this?

fixes: #5236 