### PR TITLE
async generator object method and minor misc

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4688,9 +4688,9 @@ ParseNodePtr Parser::ParseMemberList(LPCOLESTR pNameHint, uint32* pNameHintLengt
         ushort fncDeclFlags = fFncNoName | fFncMethod;
         if (isGenerator)
         {
-            if (isAsyncMethod)
+            if (isAsyncMethod && !m_scriptContext->GetConfig()->IsES2018AsyncIterationEnabled())
             {
-                Error(ERRsyntax);
+                Error(ERRExperimental);
             }
 
             // Include star character in the function extents

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -10260,7 +10260,8 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
         // 7. Let onRejected be CreateBuiltinFunction(stepsRejected, << [[AsyncContext]] >>).
         // 8. Set onRejected.[[AsyncContext]] to asyncContext.
         // 9. Perform ! PerformPromiseThen(promise, onFulfilled, onRejected).
-        JavascriptPromise::CreateThenPromise(promise, generator->GetAwaitNextFunction(), generator->GetAwaitThrowFunction(), scriptContext);
+        JavascriptPromiseCapability* unused = JavascriptPromise::UnusedPromiseCapability(scriptContext);
+        JavascriptPromise::PerformPromiseThen(promise, unused, generator->GetAwaitNextFunction(), generator->GetAwaitThrowFunction(), scriptContext);
         // 10. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
         // 11. Set the code evaluation state of asyncContext such that when evaluation is resumed with a Completion completion, the following steps of the algorithm that invoked Await will be performed, with completion available.   
     }
@@ -10270,14 +10271,16 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
     {
         JavascriptPromise* promise = JavascriptPromise::InternalPromiseResolve(value, scriptContext);
 
-        JavascriptPromise::CreateThenPromise(promise, generator->EnsureAwaitYieldStarFunction(), generator->GetAwaitThrowFunction(), scriptContext);   
+        JavascriptPromiseCapability* unused = JavascriptPromise::UnusedPromiseCapability(scriptContext);
+        JavascriptPromise::PerformPromiseThen(promise, unused, generator->EnsureAwaitYieldStarFunction(), generator->GetAwaitThrowFunction(), scriptContext);
     }
 
     void JavascriptOperators::OP_AsyncYield(JavascriptGenerator* generator, Var value, ScriptContext* scriptContext)
     {
         JavascriptPromise* promise = JavascriptPromise::InternalPromiseResolve(value, scriptContext);
 
-        JavascriptPromise::CreateThenPromise(promise, generator->GetAwaitYieldFunction(), generator->GetAwaitThrowFunction(), scriptContext);   
+        JavascriptPromiseCapability* unused = JavascriptPromise::UnusedPromiseCapability(scriptContext);
+        JavascriptPromise::PerformPromiseThen(promise, unused, generator->GetAwaitYieldFunction(), generator->GetAwaitThrowFunction(), scriptContext);
     }
 
     Var JavascriptOperators::OP_AsyncYieldIsReturn(ResumeYieldData* yieldData)

--- a/lib/Runtime/Library/JavascriptGenerator.cpp
+++ b/lib/Runtime/Library/JavascriptGenerator.cpp
@@ -569,7 +569,8 @@ namespace Js
         RecyclableObject* onFulfilled = library->CreateAsyncGeneratorResumeNextReturnProcessorFunction(this, false);
         RecyclableObject* onRejected = library->CreateAsyncGeneratorResumeNextReturnProcessorFunction(this, true);
 
-        JavascriptPromise::CreateThenPromise(promise, onFulfilled, onRejected, scriptContext);
+        JavascriptPromiseCapability* unused = JavascriptPromise::UnusedPromiseCapability(scriptContext);
+        JavascriptPromise::PerformPromiseThen(promise, unused, onFulfilled, onRejected, scriptContext);
     }
 
     RuntimeFunction* JavascriptGenerator::EnsureAwaitYieldStarFunction()

--- a/test/es7/async-generator-apis.js
+++ b/test/es7/async-generator-apis.js
@@ -141,7 +141,7 @@ const tests = [
         }
     },
     {
-        name : "Async Generaotr function instances have the correct prototype object",
+        name : "Async Generator function instances have the correct prototype object",
         body () {
             async function* agf () {}
             const prototype = agf.prototype;
@@ -211,6 +211,26 @@ const tests = [
             // found in async-generator-functionality.js test.
         }
     },
+    {
+        name: "Other forms of Async Generator",
+        body: function () {
+            const obj = {
+                async *oagf() {}
+            }
+            class cla {
+                async *cagf() {}
+                static async *scagf() {}
+            }
+
+            const instance = new cla();
+
+            const asyncGeneratorFunctionPrototype = Object.getPrototypeOf(async function* () { });
+
+            assert.areEqual(asyncGeneratorFunctionPrototype, Object.getPrototypeOf(instance.cagf), "Async generator class method should have the same prototype as async generator function");
+            assert.areEqual(asyncGeneratorFunctionPrototype, Object.getPrototypeOf(cla.scagf), "Async generator class static method should have the same prototype as async generator function");
+            assert.areEqual(asyncGeneratorFunctionPrototype, Object.getPrototypeOf(obj.oagf), "Async generator object method should have the same prototype as async generator function");
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
I missed async generator properties of objects when updating the parser in #5834 

This PR:
1. fixes that omission enabling async generator properties of objects when async generators are enabled
2. adds tests for a couple of async generator syntax options that were not currently tested (including for point 1)
3. updates the async generator continue methods to use the new PerformPromiseThen from #6163 - this has no observable effect but improves internal consistency

@zenparsing please could you take a look at this?