### PR TITLE
Fix for TypedArray.prototype.fill

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9391,9 +9391,10 @@ Case0:
         Assert(args.Info.Count > 0);
 
         JavascriptLibrary* library = scriptContext->GetLibrary();
+        bool isTypedArrayEntryPoint = typedArrayBase != nullptr;
 
         // If we came from Array.prototype.fill and source object is not a JavascriptArray, source could be a TypedArray
-        if (typedArrayBase == nullptr && pArr == nullptr && VarIs<TypedArrayBase>(obj))
+        if (!isTypedArrayEntryPoint && pArr == nullptr && VarIs<TypedArrayBase>(obj))
         {
             typedArrayBase = UnsafeVarTo<TypedArrayBase>(obj);
         }
@@ -9403,6 +9404,10 @@ Case0:
         if (args.Info.Count > 1)
         {
             fillValue = args[1];
+            if (isTypedArrayEntryPoint)
+            {
+                JS_REENTRANT_UNLOCK(jsReentLock, fillValue = JavascriptNumber::ToVarNoCheck(JavascriptConversion::ToNumber(fillValue, scriptContext), scriptContext));
+            }
         }
         else
         {

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -272,6 +272,23 @@ var tests = [
       }
   },
   {
+    name: "issue : 6174 : calling ToNumber for the fill value for typedarray.prototype.fill",
+    body: function () {
+        let arr1 = new Uint32Array(5);
+        let valueOfCalled = false;
+        let p1 = new Proxy([], {
+            get: function(oTarget, sKey) {
+                if (sKey.toString() == 'valueOf') {
+                    valueOfCalled = true;
+                }
+                return Reflect.get(oTarget, sKey);
+            }
+        });
+        Uint32Array.prototype.fill.call(arr1, p1, 5, 1);
+        assert.isTrue(valueOfCalled);
+    }
+  },
+  {
     name: "class name should not change if calling multiple times",
     body: function () {
         function getClass() {


### PR DESCRIPTION
We need to call ToNumber for the fill value first before go for filling values for TypedArray.prototype.fill case.
