### PR TITLE
Correctly handle named function expressions when saving ScopeInfo

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3481,8 +3481,6 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodySc
                 }
                 this->StartEmitFunction(pnode->AsParseNodeFnc());
 
-                PushFuncInfo(_u("StartEmitFunction"), funcInfo);
-
                 if (!funcInfo->IsBodyAndParamScopeMerged())
                 {
                     this->EmitScopeList(pnode->AsParseNodeFnc()->pnodeBodyScope->pnodeScopes);
@@ -3885,6 +3883,8 @@ void ByteCodeGenerator::StartEmitFunction(ParseNodeFnc *pnodeFnc)
             }
         }
     }
+
+    PushFuncInfo(_u("StartEmitFunction"), funcInfo);
 
     if (!funcInfo->IsBodyAndParamScopeMerged())
     {

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1840,7 +1840,7 @@ FuncInfo *ByteCodeGenerator::FindEnclosingNonLambda()
     return nullptr;
 }
 
-FuncInfo* GetParentFuncInfo(FuncInfo* child)
+FuncInfo* ByteCodeGenerator::GetParentFuncInfo(FuncInfo* child)
 {
     for (Scope* scope = child->GetBodyScope(); scope; scope = scope->GetEnclosingScope())
     {
@@ -1851,6 +1851,19 @@ FuncInfo* GetParentFuncInfo(FuncInfo* child)
     }
     Assert(0);
     return nullptr;
+}
+
+FuncInfo* ByteCodeGenerator::GetEnclosingFuncInfo()
+{
+    FuncInfo* top = this->funcInfoStack->Pop();
+
+    Assert(!this->funcInfoStack->Empty());
+
+    FuncInfo* second = this->funcInfoStack->Top();
+
+    this->funcInfoStack->Push(top);
+
+    return second;
 }
 
 bool ByteCodeGenerator::CanStackNestedFunc(FuncInfo * funcInfo, bool trace)
@@ -2634,7 +2647,7 @@ void AssignFuncSymRegister(ParseNodeFnc * pnodeFnc, ByteCodeGenerator * byteCode
                 Assert(byteCodeGenerator->GetCurrentScope()->GetFunc() == sym->GetScope()->GetFunc());
                 if (byteCodeGenerator->GetCurrentScope()->GetFunc() != sym->GetScope()->GetFunc())
                 {
-                    Assert(GetParentFuncInfo(byteCodeGenerator->GetCurrentScope()->GetFunc()) == sym->GetScope()->GetFunc());
+                    Assert(ByteCodeGenerator::GetParentFuncInfo(byteCodeGenerator->GetCurrentScope()->GetFunc()) == sym->GetScope()->GetFunc());
                     sym->GetScope()->SetMustInstantiate(true);
                     byteCodeGenerator->ProcessCapturedSym(sym);
                     sym->GetScope()->GetFunc()->SetHasLocalInClosure(true);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -402,6 +402,8 @@ public:
     void PopulateFormalsScope(uint beginOffset, FuncInfo *funcInfo, ParseNodeFnc *pnodeFnc);
     void InsertPropertyToDebuggerScope(FuncInfo* funcInfo, Js::DebuggerScope* debuggerScope, Symbol* sym);
     FuncInfo *FindEnclosingNonLambda();
+    static FuncInfo* GetParentFuncInfo(FuncInfo* child);
+    FuncInfo* GetEnclosingFuncInfo();
 
     bool CanStackNestedFunc(FuncInfo * funcInfo, bool trace = false);
     void CheckDeferParseHasMaybeEscapedNestedFunc();

--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -41,6 +41,7 @@ private:
     BYTE canMergeWithBodyScope : 1;
     BYTE hasLocalInClosure : 1;
     BYTE isBlockInLoop : 1;
+    BYTE hasNestedParamFunc : 1;
 public:
 #if DBG
     BYTE isRestored : 1;
@@ -60,6 +61,7 @@ public:
         canMergeWithBodyScope(true),
         hasLocalInClosure(false),
         isBlockInLoop(false),
+        hasNestedParamFunc(false),
         location(Js::Constants::NoRegister),
         m_symList(nullptr),
         m_count(0),
@@ -251,6 +253,9 @@ public:
 
     void SetIsBlockInLoop(bool is = true) { isBlockInLoop = is; }
     bool IsBlockInLoop() const { return isBlockInLoop; }
+
+    void SetHasNestedParamFunc(bool is = true) { hasNestedParamFunc = is; }
+    bool GetHasNestedParamFunc() const { return hasNestedParamFunc; }
 
     bool HasInnerScopeIndex() const { return innerScopeIndex != (uint)-1; }
     uint GetInnerScopeIndex() const { return innerScopeIndex; }

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -112,8 +112,17 @@ namespace Js
     ScopeInfo * ScopeInfo::SaveScopeInfo(ByteCodeGenerator* byteCodeGenerator, Scope * scope, ScriptContext * scriptContext)
     {
         // Advance past scopes that will be excluded from the closure environment. (But note that we always want the body scope.)
-        while (scope && (!scope->GetMustInstantiate() && scope != scope->GetFunc()->GetBodyScope()))
+        while (scope)
         {
+            FuncInfo* func = scope->GetFunc();
+
+            if (scope->GetMustInstantiate() ||
+                func->GetBodyScope() == scope ||
+                (func->GetParamScope() == scope && func->IsBodyAndParamScopeMerged() && scope->GetHasNestedParamFunc()))
+            {
+                break;
+            }
+
             scope = scope->GetEnclosingScope();
         }
 
@@ -162,14 +171,15 @@ namespace Js
         Scope* currentScope = byteCodeGenerator->GetCurrentScope();
         Assert(currentScope->GetFunc() == funcInfo);
 
-        if (funcInfo->root->IsDeclaredInParamScope()) {
+        if (funcInfo->root->IsDeclaredInParamScope())
+        {
             Assert(currentScope->GetScopeType() == ScopeType_FunctionBody);
             Assert(currentScope->GetEnclosingScope());
 
             FuncInfo* func = byteCodeGenerator->GetEnclosingFuncInfo();
             Assert(func);
 
-            if (func->IsBodyAndParamScopeMerged() && !(func->funcExprScope && func->funcExprScope->GetCanMerge()))
+            if (func->IsBodyAndParamScopeMerged())
             {
                 currentScope = func->GetParamScope();
                 Assert(currentScope->GetScopeType() == ScopeType_Parameter);

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -162,8 +162,6 @@ namespace Js
         Scope* currentScope = byteCodeGenerator->GetCurrentScope();
         Assert(currentScope->GetFunc() == funcInfo);
 
-// Disable the below temporarily because of bad interaction with named function expressions
-#if 0
         if (funcInfo->root->IsDeclaredInParamScope()) {
             Assert(currentScope->GetScopeType() == ScopeType_FunctionBody);
             Assert(currentScope->GetEnclosingScope());
@@ -171,14 +169,13 @@ namespace Js
             FuncInfo* func = currentScope->GetEnclosingScope()->GetFunc();
             Assert(func);
 
-            if (func->IsBodyAndParamScopeMerged())
+            if (func->IsBodyAndParamScopeMerged() && !(func->funcExprScope && func->funcExprScope->GetCanMerge()))
             {
                 currentScope = func->GetParamScope();
                 Assert(currentScope->GetScopeType() == ScopeType_Parameter);
                 Assert(!currentScope->GetMustInstantiate());
             }
         }
-#endif
 
         while (currentScope->GetFunc() == funcInfo)
         {

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -166,7 +166,7 @@ namespace Js
             Assert(currentScope->GetScopeType() == ScopeType_FunctionBody);
             Assert(currentScope->GetEnclosingScope());
 
-            FuncInfo* func = currentScope->GetEnclosingScope()->GetFunc();
+            FuncInfo* func = byteCodeGenerator->GetEnclosingFuncInfo();
             Assert(func);
 
             if (func->IsBodyAndParamScopeMerged() && !(func->funcExprScope && func->funcExprScope->GetCanMerge()))

--- a/test/Bugs/bug_OS18926499.js
+++ b/test/Bugs/bug_OS18926499.js
@@ -24,7 +24,7 @@ try {
     console.log('pass');
 }
 
-var foo3 = function foo3a(a = (function foo3b() { foo3a; })()) {
+var foo3 = function foo3a(a = (function foo3b() { +foo3a; })()) {
     a;
 };
 
@@ -45,4 +45,50 @@ try {
     console.log('fail');
 } catch {
     console.log('pass');
+}
+
+var foo5 = function foo5a(a = (function(){(function(b = 123) { +x; })()})()) {
+    function bar() { eval(''); }
+    var x;
+};
+
+try {
+    foo5();
+    console.log('fail');
+} catch {
+    console.log('pass');
+}
+
+function foo6(a, b = (function() {a; +x;})()) {
+    function bar() { eval(''); }
+    var x;
+};
+
+try {
+    foo6();
+    console.log('fail');
+} catch {
+    console.log('pass');
+}
+
+var foo8 = function foo8a(b, a = (function foo8b() { console.log(x); })()) {
+    a;
+    var x = 'fail';
+};
+
+try {
+    foo8()
+    console.log('fail');
+} catch {
+    console.log('pass');
+}
+
+var foo9 = function foo9a(b = 'pass', a = (function foo9b() { console.log(b); })()) {
+};
+
+try {
+    foo9()
+    console.log('pass');
+} catch {
+    console.log('fail');
 }

--- a/test/Bugs/bug_OS18926499.js
+++ b/test/Bugs/bug_OS18926499.js
@@ -23,3 +23,26 @@ try {
 } catch {
     console.log('pass');
 }
+
+var foo3 = function foo3a(a = (function foo3b() { foo3a; })()) {
+    a;
+};
+
+try {
+    foo3()
+    console.log('pass');
+} catch {
+    console.log('fail');
+}
+
+var foo4 = function foo4a(a = (function() { +x; })()) {
+    function bar() { eval(''); }
+    var x;
+};
+
+try {
+    foo4()
+    console.log('fail');
+} catch {
+    console.log('pass');
+}

--- a/test/Bugs/bug_OS18926499.js
+++ b/test/Bugs/bug_OS18926499.js
@@ -3,92 +3,130 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-function foo(a = (()=>+x)()) {
-    function bar() { eval(''); }
-    var x;
+let throwingFunctions = [{
+    msg: "Split-scope parent, param-scope child capturing symbol from parent body scope",
+    body: function foo(a = (()=>+x)()) {
+            function bar() { eval(''); }
+            var x;
+          }
+},
+{
+    msg: "Split-scope parent, param-scope child capturing symbol from parent body scope",
+    body: function foo(a = (()=>+x)()) {
+            eval('');
+            var x;
+          }
+},
+{
+    msg: "Merged-scope parent, param-scope child capturing symbol from parent body scope",
+    body: function foo(a = () => +x) {
+            var x = 1;
+            return a();
+          }
+},
+{
+    msg: "Merged-scope parent, param-scope child capturing symbol from parent body scope",
+    body: function foo(a = (()=>+x)()) {
+            var x;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing symbol from parent body scope",
+    body: foo3 = function foo3a(a = (function foo3b() { return +x; })()) {
+            var x = 123;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing symbol from parent body scope",
+    body: foo3 = function foo3a(a = (function foo3b() { return +x; })()) {
+            eval('');
+            var x = 123;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing symbol from parent body scope",
+    body: foo3 = function foo3a(a = (function foo3b() { return +x; })()) {
+            function bar() { eval(''); }
+            var x = 123;
+          }
+},
+{
+    msg: "Param-scope func expr child with nested func expr capturing symbol from parent body scope",
+    body: foo5 = function foo5a(a = (function(){(function(b = 123) { +x; })()})()) {
+                    function bar() { eval(''); }
+                    var x;
+                 }
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { +x; })()){})()){})()){ var x;}
+}];
+
+let nonThrowingFunctions = [{
+    msg: "Func expr parent, param-scope func expr child capturing parent func expr name",
+    body: foo3 = function foo3a(a = (function foo3b() { +foo3a; })()) {
+            return +a;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing own func expr name",
+    body: foo3 = function foo3a(a = (function foo3b() { +foo3b; })()) {
+            return +a;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing expression name hint",
+    body: foo3 = function foo3a(a = (function foo3b() { +foo3; })()) {
+            return +a;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing parent argument name",
+    body: foo3 = function foo3a(b = 123, a = (function foo3b() { return +b; })()) {
+            if (123 !== a) throw 123;
+          }
+},
+{
+    msg: "Func expr parent, param-scope func expr child capturing symbol from parent body scope",
+    body: foo3 = function foo3a(b = 123, a = (function foo3b() { return +b; })()) {
+            if (123 !== a) throw 123;
+          }
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { foo3d; })()){})()){})()){}
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { foo3c; })()){})()){})()){}
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { foo3b; })()){})()){})()){}
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { foo3a; })()){})()){})()){}
+},
+{
+    msg: "Multiple nested func expr, inner param-scope function capturing outer func expr name",
+    body: foo3 = function foo3a(a = (function foo3b(b = (function foo3c(c = (function foo3d() { foo3; })()){})()){})()){}
+}];
+
+for (let fn of throwingFunctions) {
+    try {
+        fn.body();
+        console.log(`fail: ${fn.msg}`);
+    } catch {
+        console.log("pass");
+    }
 }
 
-try {
-    foo();
-    console.log('fail');
-} catch {
-    console.log("pass");
-}
-
-function foo2(a = () => x) { var x = 1; return a(); }
-
-try {
-    foo2()
-    console.log('fail');
-} catch {
-    console.log('pass');
-}
-
-var foo3 = function foo3a(a = (function foo3b() { +foo3a; })()) {
-    a;
-};
-
-try {
-    foo3()
-    console.log('pass');
-} catch {
-    console.log('fail');
-}
-
-var foo4 = function foo4a(a = (function() { +x; })()) {
-    function bar() { eval(''); }
-    var x;
-};
-
-try {
-    foo4()
-    console.log('fail');
-} catch {
-    console.log('pass');
-}
-
-var foo5 = function foo5a(a = (function(){(function(b = 123) { +x; })()})()) {
-    function bar() { eval(''); }
-    var x;
-};
-
-try {
-    foo5();
-    console.log('fail');
-} catch {
-    console.log('pass');
-}
-
-function foo6(a, b = (function() {a; +x;})()) {
-    function bar() { eval(''); }
-    var x;
-};
-
-try {
-    foo6();
-    console.log('fail');
-} catch {
-    console.log('pass');
-}
-
-var foo8 = function foo8a(b, a = (function foo8b() { console.log(x); })()) {
-    a;
-    var x = 'fail';
-};
-
-try {
-    foo8()
-    console.log('fail');
-} catch {
-    console.log('pass');
-}
-
-var foo9 = function foo9a(b = 'pass', a = (function foo9b() { console.log(b); })()) {
-};
-
-try {
-    foo9()
-    console.log('pass');
-} catch {
-    console.log('fail');
+for (let fn of nonThrowingFunctions) {
+    try {
+        fn.body();
+        console.log("pass");
+    } catch {
+        console.log(`fail: ${fn.msg}`);
+    }
 }

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -582,15 +582,12 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
-<!--
-Re-enable after fixing ScopeInfo::SaveEnclosingScopeInfo to handle named function expressions
   <test>
     <default>
       <files>bug_OS18926499.js</files>
       <compile-flags>-force:deferparse</compile-flags>
     </default>
   </test>
--->
   <test>
     <default>
       <files>Bug19767482.js</files>


### PR DESCRIPTION
Previous fix for a similar issue #6157 didn't handle the case of a function expression in which the param and function expression scopes are merged with the body scope. In that case, the function defined in the param scope needs to have access to the body scope of the enclosing function.
