### PR TITLE
globalThis needs to load the host global object

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1379,7 +1379,7 @@ namespace Js
 
         if (globalObject->GetScriptContext()->GetConfig()->IsESGlobalThisEnabled())
         {
-            AddMember(globalObject, PropertyIds::globalThis, globalObject, PropertyConfigurable | PropertyWritable);
+            AddMember(globalObject, PropertyIds::globalThis, globalObject->ToThis(), PropertyConfigurable | PropertyWritable);
         }
         AddMember(globalObject, PropertyIds::NaN, nan, PropertyNone);
         AddMember(globalObject, PropertyIds::Infinity, positiveInfinite, PropertyNone);


### PR DESCRIPTION
Currently, the globalThis property loads the Chakra GlobalObject from the library but if the host has set a HostObject, we should use that object instead.
