### PR TITLE
Proxy [[Construct]] trap confuses super call flag

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6323,7 +6323,8 @@ SetElementIHelper_INDEX_TYPE_IS_NUMBER:
         JavascriptProxy * proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
         if (proxy)
         {
-            Arguments args(CallInfo(CallFlags_New, 1), &instance);
+            Var dummy = nullptr;
+            Arguments args(CallInfo(CallFlags_New, 1), &dummy);
             return requestContext->GetThreadContext()->ExecuteImplicitCall(proxy, Js::ImplicitCall_Accessor, [=]()->Js::Var
             {
                 return proxy->ConstructorTrap(args, requestContext, 0);

--- a/test/Bugs/bug_OS21193960.js
+++ b/test/Bugs/bug_OS21193960.js
@@ -1,0 +1,158 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "OS21193960: Proxy [[Construct]] trap confuses super call flag",
+        body: function () {
+            function test(){
+              let ctorCount = 0;
+              function ctor() {
+                  if (new.target !== undefined) {
+                      ctorCount++;
+                      this.prop0 = 123;
+                      assert.isTrue(proxy === new.target, "proxy === new.target");
+                  } else {
+                      assert.fail('call ctor');
+                  }
+              }
+
+              let ctor_prototype = ctor.prototype;
+              let getCount = 0;
+              let proxyHandler = {
+                ['get'](handler, prop, target) {
+                  getCount++;
+                  assert.isTrue(prop !== 'prop0', "prop !== 'prop0'");
+                  switch(prop) {
+                    case 'prototype':
+                      return ctor_prototype;
+                  }
+                }
+              };
+
+              var proxy = new Proxy(ctor, proxyHandler);
+              let newProxy = new proxy;
+
+              assert.isTrue(proxy !== newProxy, 'proxy !== newProxy');
+              assert.areEqual('object', typeof newProxy, '"object" === typeof newProxy');
+              assert.areEqual(1, ctorCount, "1 === ctorCount");
+
+              assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
+              assert.areEqual(0, getCount, "0 === getCount");
+            };
+
+            test();
+            test();
+        }
+    },
+    {
+        name: "Proxy target is a base class",
+        body: function () {
+            function test(){
+              let ctorCount = 0;
+              class ctor {
+                  constructor() {
+                  if (new.target !== undefined) {
+                      ctorCount++;
+                      this.prop0 = 123;
+                      assert.isTrue(proxy === new.target, "proxy === new.target");
+                  } else {
+                      assert.fail('call ctor');
+                  }
+                }
+              }
+
+              let ctor_prototype = ctor.prototype;
+              let getCount = 0;
+              let proxyHandler = {
+                ['get'](handler, prop, target) {
+                  getCount++;
+                  assert.isTrue(prop !== 'prop0', "prop !== 'prop0'");
+                  switch(prop) {
+                    case 'prototype':
+                      return ctor_prototype;
+                  }
+                }
+              };
+
+              var proxy = new Proxy(ctor, proxyHandler);
+              let newProxy = new proxy;
+
+              assert.isTrue(proxy !== newProxy, 'proxy !== newProxy');
+              assert.areEqual('object', typeof newProxy, '"object" === typeof newProxy');
+              assert.areEqual(1, ctorCount, "1 === ctorCount");
+
+              assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
+              assert.areEqual(1, getCount, "1 === getCount");
+            };
+
+            test();
+            test();
+        }
+    },
+    {
+        name: "Proxy target is a derived class",
+        body: function () {
+            function test(){
+              let baseCount = 0;
+              class base {
+                constructor() {
+                  if (new.target !== undefined) {
+                      baseCount++;
+                      assert.isTrue(proxy === new.target, "proxy === new.target");
+                  } else {
+                      assert.fail('call base');
+                  }
+                }
+              };
+
+              let ctorCount = 0;
+              class ctor extends base {
+                  constructor() {
+                  if (new.target !== undefined) {
+                      ctorCount++;
+                      super();
+                      this.prop0 = 123;
+                      assert.isTrue(proxy === new.target, "proxy === new.target");
+                  } else {
+                      assert.fail('call ctor');
+                  }
+                }
+              }
+
+              let ctor_prototype = ctor.prototype;
+              let getCount = 0;
+              let proxyHandler = {
+                ['get'](handler, prop, target) {
+                  getCount++;
+                  assert.isTrue(prop !== 'prop0', "prop !== 'prop0'");
+                  switch(prop) {
+                    case 'prototype':
+                      return ctor_prototype;
+                  }
+                }
+              };
+
+              var proxy = new Proxy(ctor, proxyHandler);
+              let newProxy = new proxy;
+
+              assert.isTrue(proxy !== newProxy, 'proxy !== newProxy');
+              assert.areEqual('object', typeof newProxy, '"object" === typeof newProxy');
+              assert.areEqual(1, ctorCount, "1 === ctorCount");
+              assert.areEqual(1, baseCount, "1 === baseCount");
+
+              assert.areEqual(123, newProxy.prop0, "123 === newProxy.prop0");
+              assert.areEqual(1, getCount, "1 === getCount");
+            };
+
+            test();
+            test();
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -606,4 +606,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS21193960.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:2 -args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When we call the proxy [[Construct]] method from a JIT helper, it passes an argument in the 0th slot. That makes `JavascriptOperators::GetAndAssertIsConstructorSuperCall` think that we have a `new.target` and are in a super call chain regardless of if we are or are not in a super call chain.

This flag is then used to control constructing the 'this' binding. When we get it wrong, 'this' is bound to the proxy itself instead of a new object.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems/edit/21193960/
