### PR TITLE
Implement well-formed JSON.stringify

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -69,11 +69,6 @@ namespace utf8
         return ((0x5B >> (((prefix ^ 0xF0) >> 3) & 0x1E)) & 0x03) + 1;
     }
 
-    const char16 WCH_UTF16_HIGH_FIRST  =  char16(0xd800);
-    const char16 WCH_UTF16_HIGH_LAST   =  char16(0xdbff);
-    const char16 WCH_UTF16_LOW_FIRST   =  char16(0xdc00);
-    const char16 WCH_UTF16_LOW_LAST    =  char16(0xdfff);
-
     char16 GetUnknownCharacter(DecodeOptions options = doDefault)
     {
         if ((options & doThrowOnInvalidWCHARs) != 0)
@@ -83,24 +78,9 @@ namespace utf8
         return char16(UNICODE_UNKNOWN_CHAR_MARK);
     }
 
-    inline BOOL InRange(const char16 ch, const char16 chMin, const char16 chMax)
-    {
-        return (unsigned)(ch - chMin) <= (unsigned)(chMax - chMin);
-    }
-
     BOOL IsValidWideChar(char16 ch)
     {
         return (ch < 0xfdd0) || ((ch > 0xfdef) && (ch <= 0xffef)) || ((ch >= 0xfff9) && (ch <= 0xfffd));
-    }
-
-    inline BOOL IsHighSurrogateChar(char16 ch)
-    {
-        return InRange( ch, WCH_UTF16_HIGH_FIRST, WCH_UTF16_HIGH_LAST );
-    }
-
-    inline BOOL IsLowSurrogateChar(char16 ch)
-    {
-        return InRange( ch, WCH_UTF16_LOW_FIRST, WCH_UTF16_LOW_LAST );
     }
 
     _At_(ptr, _In_reads_(end - ptr) _Post_satisfies_(ptr >= _Old_(ptr) - 1 && ptr <= end))

--- a/lib/Common/Codex/Utf8Codex.h
+++ b/lib/Common/Codex/Utf8Codex.h
@@ -157,6 +157,26 @@ namespace utf8
 
     BOOL IsValidWideChar(char16 ch);
 
+    const char16 WCH_UTF16_HIGH_FIRST = char16(0xd800);
+    const char16 WCH_UTF16_HIGH_LAST = char16(0xdbff);
+    const char16 WCH_UTF16_LOW_FIRST = char16(0xdc00);
+    const char16 WCH_UTF16_LOW_LAST = char16(0xdfff);
+
+    inline BOOL InRange(const char16 ch, const char16 chMin, const char16 chMax)
+    {
+        return (unsigned)(ch - chMin) <= (unsigned)(chMax - chMin);
+    }
+
+    inline BOOL IsHighSurrogateChar(char16 ch)
+    {
+        return InRange(ch, WCH_UTF16_HIGH_FIRST, WCH_UTF16_HIGH_LAST);
+    }
+
+    inline BOOL IsLowSurrogateChar(char16 ch)
+    {
+        return InRange(ch, WCH_UTF16_LOW_FIRST, WCH_UTF16_LOW_LAST);
+    }
+
     // Decode the trail bytes after the UTF8 lead byte c1 but returning 0xFFFD if trail bytes are expected after end.
     _At_(ptr, _In_reads_(end - ptr) _Post_satisfies_(ptr >= _Old_(ptr) - 1 && ptr <= end))
     char16 DecodeTail(char16 c1, LPCUTF8& ptr, LPCUTF8 end, DecodeOptions& options, bool *chunkEndsAtTruncatedSequence = nullptr);

--- a/lib/Runtime/Library/JSONStringBuilder.h
+++ b/lib/Runtime/Library/JSONStringBuilder.h
@@ -23,6 +23,7 @@ private:
     void AppendCharacter(char16 character);
     void AppendBuffer(_In_ const char16* buffer, charcount_t length);
     void AppendString(_In_ JavascriptString* str);
+    void AppendEscapeSequence(_In_ const char16 character);
     void EscapeAndAppendString(_In_ JavascriptString* str);
     void AppendObjectString(_In_ JSONObject* valueList);
     void AppendArrayString(_In_ JSONArray* valueArray);

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -125,4 +125,10 @@
       <compile-flags>-ES2018AsyncIteration -args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>wellformedJSON.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/es7/wellformedJSON.js
+++ b/test/es7/wellformedJSON.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Broken surrogate pairs should be escaped during JSON.stringify",
+        body: function () {
+            assert.areEqual(JSON.stringify("\uD834"), '"\\ud834"',
+              'JSON.stringify("\\uD834")');
+            assert.areEqual(JSON.stringify("\uDF06"), '"\\udf06"',
+              'JSON.stringify("\\uDF06")');
+
+            assert.areEqual(JSON.stringify("\uD834\uDF06"), '"𝌆"',
+              'JSON.stringify("\\uD834\\uDF06")');
+            assert.areEqual(JSON.stringify("\uD834\uD834\uDF06\uD834"), '"\\ud834𝌆\\ud834"',
+              'JSON.stringify("\\uD834\\uD834\\uDF06\\uD834")');
+            assert.areEqual(JSON.stringify("\uD834\uD834\uDF06\uDF06"), '"\\ud834𝌆\\udf06"',
+              'JSON.stringify("\\uD834\\uD834\\uDF06\\uDF06")');
+            assert.areEqual(JSON.stringify("\uDF06\uD834\uDF06\uD834"), '"\\udf06𝌆\\ud834"',
+              'JSON.stringify("\\uDF06\\uD834\\uDF06\\uD834")');
+            assert.areEqual(JSON.stringify("\uDF06\uD834\uDF06\uDF06"), '"\\udf06𝌆\\udf06"',
+              'JSON.stringify("\\uDF06\\uD834\\uDF06\\uDF06")');
+
+            assert.areEqual(JSON.stringify("\uDF06\uD834"), '"\\udf06\\ud834"',
+              'JSON.stringify("\\uDF06\\uD834")');
+            assert.areEqual(JSON.stringify("\uD834\uDF06\uD834\uD834"), '"𝌆\\ud834\\ud834"',
+              'JSON.stringify("\\uD834\\uDF06\\uD834\\uD834")');
+            assert.areEqual(JSON.stringify("\uD834\uDF06\uD834\uDF06"), '"𝌆𝌆"',
+              'JSON.stringify("\\uD834\\uDF06\\uD834\\uDF06")');
+            assert.areEqual(JSON.stringify("\uDF06\uDF06\uD834\uD834"), '"\\udf06\\udf06\\ud834\\ud834"',
+              'JSON.stringify("\\uDF06\\uDF06\\uD834\\uD834")');
+            assert.areEqual(JSON.stringify("\uDF06\uDF06\uD834\uDF06"), '"\\udf06\\udf06𝌆"',
+              'JSON.stringify("\\uDF06\\uDF06\\uD834\\uDF06")');
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
The change to the spec makes unpaired surrogate code units serialize to their escape sequences instead of bad characters.

This is now in stage 4.

Fixes #5735
