### PR TITLE
Set hasBailedOutBitPtr correctly for nested finally blocks

### DIFF
--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -277,6 +277,8 @@ protected:
     static uint32 BailOutFromLoopBodyHelper(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
         uint32 bailOutOffset, IR::BailOutKind bailOutKind, Js::Var branchValue, Js::Var * registerSaves, BailOutReturnValue * returnValue = nullptr);
 
+    static void SetHasBailedOutBit(BailOutRecord const * bailOutRecord, Js::ScriptContext * scriptContext);
+
     static void UpdatePolymorphicFieldAccess(Js::JavascriptFunction *  function, BailOutRecord const * bailOutRecord);
 
     static void ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind,

--- a/test/EH/hasBailedOutBug3.js
+++ b/test/EH/hasBailedOutBug3.js
@@ -32,4 +32,3 @@ test0();
 test0();
 test0();
 print("Passed\n");
-

--- a/test/EH/hasBailedOutBug4.js
+++ b/test/EH/hasBailedOutBug4.js
@@ -1,0 +1,38 @@
+var shouldBailout = false;
+var caught = false;
+
+function test0() {
+  function func0() {
+    if (shouldBailout) {
+      throw new Error('oops');
+    }
+  }
+
+  function func1() { func0() }
+  function func2() { func1() }
+  function func3() { shouldBailout ? obj0 : null }
+
+  var obj0 = { method0: func1 };
+  var obj1 = { method0: func2 };
+
+  try {
+    try {} finally { func3(); }
+  } catch {
+    caught = true;
+  }
+
+  func2();
+}
+
+// generate profile
+test0();
+test0();
+
+// run code with bailouts enabled
+shouldBailout = true;
+try {
+  test0();
+} catch {}
+if (!caught) {
+  print('Passed');
+}

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -196,6 +196,11 @@
   </test>
   <test>
     <default>
+       <files>hasBailedOutBug4.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
        <files>StackOverflow.js</files>
     </default>
   </test>


### PR DESCRIPTION
JITed functions use a stack of bits to determine whether a bailout occured within a try-catch or try-finally block. When a bailout occurs within a finally, the corresponding entry in the bit stack has already been popped, but we still need to set the bit correctly for the containing try block, if one exists.
