### PR TITLE
Implement JSON ⊂ ECMAScript

### DIFF
--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -1064,7 +1064,6 @@ tokens Scanner<EncodingPolicy>::ScanStringConstant(OLECHAR delim, EncodedCharPtr
                 ch = rawch = kchNWL;
             }
 
-LEcmaLineBreak:
             // Fall through
         case kchNWL:
             if (stringTemplateMode)
@@ -1124,18 +1123,7 @@ LEcmaLineBreak:
 LMainDefault:
             if (this->IsMultiUnitChar(ch))
             {
-                if ((ch == kchLS || ch == kchPS))
-                {
-                    goto LEcmaLineBreak;
-                }
-
                 rawch = ch = this->template ReadRest<true>(ch, p, last);
-                switch (ch)
-                {
-                case kchLS: // 0x2028, classifies as new line
-                case kchPS: // 0x2029, classifies as new line
-                    goto LEcmaLineBreak;
-                }
             }
             break;
 

--- a/test/es5/Lex_u3.baseline
+++ b/test/es5/Lex_u3.baseline
@@ -2,7 +2,7 @@ undefined
 undefined
 str const Left 
  str const right
-LS in string -  compile failure in ES5: expected.SyntaxError: Unterminated string constant
+str%20const%20Left%20%u2028%20str%20const%20right
 LS in regex literal -  compile failure in ES5: expected.SyntaxError: Expected '/'
 LS%20in%20escape%20sequence%20string%20literal%20%20%3Amore%20string
 BOM is WS :  91

--- a/test/es5/Lex_u3.js
+++ b/test/es5/Lex_u3.js
@@ -27,7 +27,7 @@ eval('x= \"str const Left \u2028 str const right\";write(escape(x))');
 }
 catch(e)
 {
-write("LS in string -  compile failure in ES5: expected." + e)
+write("LS in string -  compile failure in ES5: not expected." + e)
 }
 
 var re = /falls/

--- a/test/es7/json_superset.js
+++ b/test/es7/json_superset.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Unescaped <LS> and <PS> characters are allowed in string literals",
+        body: function () {
+            assert.areEqual(eval("'\u2028'"), "\u2028");
+            assert.areEqual(" ", "\u2028");
+            assert.areEqual(eval("'\u2029'"), "\u2029");
+            assert.areEqual(" ", "\u2029");
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -131,4 +131,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>json_superset.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
The JavaScript as a superset of JSON proposal has reached stage 4.

Only real change we need to make here is to allow unescaped <LS> and <PS> characters in string literals.
