### PR TITLE
don't record call site info until call completes

### DIFF
--- a/test/inlining/profilingbug.js
+++ b/test/inlining/profilingbug.js
@@ -1,0 +1,13 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+try {
+    function f(){}
+    function foo(){
+        f.call();
+        foo.call(0x1)++;
+    }
+    foo();
+} catch(e) {   }

--- a/test/inlining/profilingbug.js
+++ b/test/inlining/profilingbug.js
@@ -11,3 +11,5 @@ try {
     }
     foo();
 } catch(e) {   }
+
+print("Pass")

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -287,6 +287,11 @@
   </test>
   <test>
     <default>
+      <files>profilingbug.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug12528802.js</files>
     </default>
   </test>


### PR DESCRIPTION
We can end up with partially initialized profile data which leads to failfast when JITing

Fixes #6202