### PR TITLE
fix bug where try block swallows yield

### DIFF
--- a/lib/Runtime/Language/InterpreterLoop.inl
+++ b/lib/Runtime/Language/InterpreterLoop.inl
@@ -307,6 +307,7 @@ SWAP_BP_FOR_OPCODE:
 #ifndef INTERPRETER_ASMJS
         case INTERPRETER_OPCODE::Yield:
             {
+                this->retOffset = m_reader.GetCurrentOffset();
                 m_reader.Reg2_Small(ip);
                 return GetReg(GetFunctionBody()->GetYieldRegister());
             }

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1986,6 +1986,8 @@ skipThunk:
                 // The debugger relies on comparing stack addresses of frames to decide when a step_out is complete so
                 // give the InterpreterStackFrame a legit enough stack address to make this comparison work.
                 newInstance->m_stackAddress = reinterpret_cast<DWORD_PTR>(&generator);
+
+                newInstance->retOffset = 0;
             }
             else
             {

--- a/test/es7/misc_bugs.js
+++ b/test/es7/misc_bugs.js
@@ -26,6 +26,19 @@ var tests = [
                     }`); });
         }
     },
+    {
+        name: "Await in class body should not crash",
+        body: function () {
+            async function trigger(a=class b{
+                [a = class b{
+                    [await 0](){}
+                }](){}
+            }) {
+            }
+            
+            trigger();
+        }
+    },
 
 ];
 


### PR DESCRIPTION
If yield happened within a try block, the yield was being swallowed and immediately continued to the ResumeYield, which is a functional issue and also causes us to not set the ResumeYieldData.

Fixes #6203