### PR TITLE
Do not attempt to reuse Utf8SourceInfo if asmjs parse fails

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1995,23 +1995,20 @@ namespace Js
         else
         {
             // We do not own the memory passed into DefaultLoadScriptUtf8. We need to save it so we copy the memory.
-            if (*ppSourceInfo == nullptr)
-            {
 #ifndef NTBUILD
-                if (loadScriptFlag & LoadScriptFlag_ExternalArrayBuffer)
-                {
-                    *ppSourceInfo = Utf8SourceInfo::NewWithNoCopy(this,
-                        script, (int)length, cb, pSrcInfo, isLibraryCode,
-                        scriptSource);
-                }
-                else
+            if (loadScriptFlag & LoadScriptFlag_ExternalArrayBuffer)
+            {
+                *ppSourceInfo = Utf8SourceInfo::NewWithNoCopy(this,
+                    script, (int)length, cb, pSrcInfo, isLibraryCode,
+                    scriptSource);
+            }
+            else
 #endif
-                {
-                    // the 'length' here is not correct - we will get the length from the parser - however parser hasn't done yet.
-                    // Once the parser is done we will update the utf8sourceinfo's lenght correctly with parser's
-                    *ppSourceInfo = Utf8SourceInfo::New(this, script,
-                        (int)length, cb, pSrcInfo, isLibraryCode);
-                }
+            {
+                // The 'length' here is not correct (we will get the length from the parser) however parser isn't done yet.
+                // Once the parser is done we will update the utf8sourceinfo's length correctly
+                *ppSourceInfo = Utf8SourceInfo::New(this, script,
+                    (int)length, cb, pSrcInfo, isLibraryCode);
             }
         }
     }

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -148,14 +148,6 @@ namespace Js
         }
 #endif
 
-        void ClearFunctions()
-        {
-            if (this->functionBodyDictionary)
-            {
-                this->functionBodyDictionary->Clear();
-            }
-        }
-
         bool HasFunctions() const
         {
             return (this->functionBodyDictionary ? this->functionBodyDictionary->Count() > 0 : false);


### PR DESCRIPTION
Fixes #6222

When an asmjs parse fails, we reparse with asmjs disabled. However, currently we are reusing the same Utf8SourceInfo data, which contains a dictionary of FunctionBody objects. FunctionBody objects that were added in the first parse are still present in the source info dictionary. This causes an assert to fire in `DebugContext.cpp` because it expects there to be only one FunctionBody per source code function.

This PR simply discards the old Utf8SourceInfo when an asmjs parse fails. The downside is that the source data has to be re-memcpyd. Another (more complex) solution would be to try to fully clear out the existing Utf8SourceInfo.