### PR TITLE
Fixes #6053: stop boxing stack function from continually recursing into itself

### DIFF
--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -693,14 +693,14 @@ namespace Js
 
     ScriptFunction * StackScriptFunction::BoxState::BoxStackFunction(ScriptFunction * scriptFunction)
     {
-        // Box the frame display first, which may in turn box the function
-        FrameDisplay * frameDisplay = scriptFunction->GetEnvironment();
-        FrameDisplay * boxedFrameDisplay = BoxFrameDisplay(frameDisplay);
-
         if (!ThreadContext::IsOnStack(scriptFunction))
         {
             return scriptFunction;
         }
+
+        // Box the frame display first, which may in turn box the function
+        FrameDisplay * frameDisplay = scriptFunction->GetEnvironment();
+        FrameDisplay * boxedFrameDisplay = BoxFrameDisplay(frameDisplay);
 
         StackScriptFunction * stackFunction = VarTo<StackScriptFunction>(scriptFunction);
         ScriptFunction * boxedFunction = stackFunction->boxedScriptFunction;

--- a/test/stackfunc/boxStackSlots.js
+++ b/test/stackfunc/boxStackSlots.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+try {
+    function p(c) {
+        (function () {
+            try {
+                throw p(d);
+            } catch (a) {
+                (function () {
+                    return ParseInt();
+                }());
+                c;
+            }
+        }());
+        function d() {
+        }
+    }
+    throw p();
+}
+catch (e) {
+    console.log("PASS");
+}

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -703,4 +703,15 @@
       <compile-flags>-forcedeferparse -forcejitloopbody -force:rejit -force:inline</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>boxStackSlots.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>boxStackSlots.js</files>
+      <compile-flags>-mic:1 -off:simplejit -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Given the test case input, the call stack would look like:

...
BoxStackFunction
BoxScopeSlots
BoxFrameDisplay
BoxStackFunction
BoxScopeSlots
BoxFrameDisplay
BoxStackFunction
...

In BoxStackFunction before trying to box the function's environment see if the function is on the stack.