### PR TITLE
Give JavascriptRegExpConstructor the correct ConstructorCache

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1520,7 +1520,10 @@ namespace Js
         AddFunction(globalObject, PropertyIds::String, stringConstructor);
         regexConstructorType = DynamicType::New(scriptContext, TypeIds_Function, functionPrototype, JavascriptRegExp::NewInstance,
             DeferredTypeHandler<InitializeRegexConstructor>::GetDefaultInstance());
-        regexConstructor = RecyclerNewEnumClass(recycler, EnumFunctionClass, JavascriptRegExpConstructor, regexConstructorType);
+        regexConstructor = RecyclerNewEnumClass(recycler, EnumFunctionClass,
+            JavascriptRegExpConstructor,
+            regexConstructorType,
+            builtInConstructorCache);
         AddFunction(globalObject, PropertyIds::RegExp, regexConstructor);
 
         arrayBufferConstructor = CreateBuiltinConstructor(&ArrayBuffer::EntryInfo::NewInstance,

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -14,8 +14,8 @@ namespace Js
     const int JavascriptRegExpConstructor::NumCtorCaptures;
 #endif
 
-    JavascriptRegExpConstructor::JavascriptRegExpConstructor(DynamicType * type) :
-        RuntimeFunction(type, &JavascriptRegExp::EntryInfo::NewInstance),
+    JavascriptRegExpConstructor::JavascriptRegExpConstructor(DynamicType* type, ConstructorCache* cache) :
+        RuntimeFunction(type, &JavascriptRegExp::EntryInfo::NewInstance, cache),
         reset(false),
         invalidatedLastMatch(false),
         lastPattern(nullptr),

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -22,7 +22,7 @@ namespace Js
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptRegExpConstructor, RuntimeFunction, lastMatch);
 
     public:
-        JavascriptRegExpConstructor(DynamicType * type);
+        JavascriptRegExpConstructor(DynamicType* type, ConstructorCache* cache);
 
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId, _Inout_opt_ PropertyValueInfo* info) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -139,6 +139,14 @@ var tests = [
     }
   },
   {
+    name: "Using RegExp as newTarget should not assert",
+    body: function() {
+      var v0 = function() { this.a; };
+      var v1 = class extends v0 { constructor() { super(); } };
+      Reflect.construct(v1, [], RegExp);
+    }
+  },
+  {
     name: "getPrototypeOf Should not be called when set as prototype",
     body: function () {
       var p = new Proxy({}, { getPrototypeOf: function() {


### PR DESCRIPTION
Fixes #6228

Builtin constructors have the `FunctionInfo::SkipDefaultNewObject` flag set, which indicates that a new object should not be created prior to invoking them as constructors. The ConstructorCache associated with the function is also expected to have `skipDefaultNewObject` set appropriately. For the RegExp constructor, the `builtinConstructorCache` was not being used; this ends up causing nullptr exceptions when the RegExp constructor is used as `newTarget` in a `Reflect.construct` call.

This changes provides the appropriate `builtinConstructorCache` when creating the RegExp constructor.