### PR TITLE
Fix environment calculation for symbol captured in the param scope

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3855,6 +3855,11 @@ void ByteCodeGenerator::StartEmitFunction(ParseNodeFnc *pnodeFnc)
             else if (pnodeFnc->IsBodyAndParamScopeMerged() || bodyScope->GetScopeSlotCount() != 0)
             {
                 bodyScope->SetMustInstantiate(funcInfo->frameSlotsRegister != Js::Constants::NoRegister);
+
+                if (pnodeFnc->IsBodyAndParamScopeMerged() && paramScope && paramScope->GetHasNestedParamFunc())
+                {
+                    paramScope->SetMustInstantiate(funcInfo->frameSlotsRegister != Js::Constants::NoRegister);
+                }
             }
 
             if (!pnodeFnc->IsBodyAndParamScopeMerged())

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -185,7 +185,6 @@ namespace Js
             {
                 currentScope = func->GetParamScope();
                 Assert(currentScope->GetScopeType() == ScopeType_Parameter);
-                Assert(!currentScope->GetMustInstantiate());
             }
         }
 

--- a/test/Bugs/bug_OS23102586.js
+++ b/test/Bugs/bug_OS23102586.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// force:deferparse
+
+function test0() {
+  var k;
+  
+  function foo(a = function() { +k; }) {
+      a();
+      function bar() { a }
+  };
+  
+  eval('')
+  foo();
+}
+test0();
+console.log('pass')

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -618,4 +618,10 @@
       <compile-flags>-force:deferparse</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS23102586.js</files>
+      <compile-flags>-force:deferparse</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Consider this repro:

```javascript
function test0() {
  var k;

  function foo(a = function() { +k; }) {
      a();
      function bar() { a }
  };

  eval('')
  foo();
}
test0();
```

We're hitting a miscalculation of the environment index when we're attempting to look up the scope for symbol 'k'. In particular, the miscalculation occurs in ByteCodeGenerator::FindScopeForSym. In this function, we walk up the scope chain starting from the body scope of the anonymous function declared in the param scope of foo. Each scope we walk to for a function other than the anonymous function which requires instantiation will increment the environment index. The enclosing scope for the anonymous function body scope is the param scope of foo and the body scope of foo is not in the restored scope chain. When we walk to the param scope for foo, it does not have the must instantiate flag set so we (incorrectly) do not increment the environment index. Back when the body scope for foo was incorrectly enclosing the body scope of the anonymous function, we correctly calculated the environment index because the body scope for foo has the must instantiate flag set. Now that param scope for foo is in the scope chain instead of body scope, we need to mark the param scope as must instantiate so this lookup is correct.
