### PR TITLE
Runtime improvements for generators

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -29253,11 +29253,35 @@ Lowerer::LowerGeneratorHelper::LowerGeneratorLoadResumeYieldData(IR::Instr* inst
 void
 Lowerer::LowerGeneratorHelper::LowerResumeGenerator(IR::Instr* instr)
 {
-    IR::Opnd* srcOpnd1 = instr->UnlinkSrc1();
-    IR::Opnd* srcOpnd2 = instr->m_opcode == Js::OpCode::ResumeYieldStar ? instr->UnlinkSrc2() : IR::AddrOpnd::NewNull(this->func);
-    this->lowererMD.LoadHelperArgument(instr, srcOpnd2);
-    this->lowererMD.LoadHelperArgument(instr, srcOpnd1);
-    this->lowererMD.ChangeToHelperCall(instr, IR::HelperResumeYield);
+    if (instr->m_opcode == Js::OpCode::ResumeYieldStar)
+    {
+        IR::Opnd* srcOpnd1 = instr->UnlinkSrc1();
+        IR::Opnd* srcOpnd2 = instr->UnlinkSrc2();
+        this->lowererMD.LoadHelperArgument(instr, srcOpnd2);
+        this->lowererMD.LoadHelperArgument(instr, srcOpnd1);
+        this->lowererMD.ChangeToHelperCall(instr, IR::HelperResumeYield);
+    }
+    else
+    {
+        Assert(instr->GetSrc1()->IsRegOpnd());
+        IR::RegOpnd* resumeYieldData = instr->UnlinkSrc1()->AsRegOpnd();
+        IR::IndirOpnd* exceptionObj = IR::IndirOpnd::New(resumeYieldData, Js::ResumeYieldData::GetOffsetOfExceptionObject(), TyMachPtr, this->func);
+        IR::IndirOpnd* resumeData = IR::IndirOpnd::New(resumeYieldData, Js::ResumeYieldData::GetOffsetOfData(), TyMachPtr, this->func);
+
+        IR::LabelInstr* helper = IR::LabelInstr::New(Js::OpCode::Label, this->func);
+        IR::LabelInstr* done = IR::LabelInstr::New(Js::OpCode::Label, this->func);
+
+        this->lowerer->InsertCompareBranch(exceptionObj, IR::AddrOpnd::NewNull(this->func), Js::OpCode::BrNotAddr_A, helper, instr);
+        this->lowerer->InsertMove(instr->UnlinkDst(), resumeData, instr);
+        this->lowerer->InsertBranch(Js::OpCode::Br, done, instr);
+        instr->InsertBefore(helper);
+
+        this->lowererMD.LoadHelperArgument(instr, IR::AddrOpnd::NewNull(this->func));
+        this->lowererMD.LoadHelperArgument(instr, resumeYieldData);
+        this->lowererMD.ChangeToHelperCall(instr, IR::HelperResumeYield);
+
+        instr->InsertAfter(done);
+    }
 }
 
 void

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1237,6 +1237,8 @@ FLAGR(Boolean, ESImportMeta, "Enable import.meta keyword", DEFAULT_CONFIG_ESImpo
 //ES globalThis flag
 FLAGR(Boolean, ESGlobalThis, "Enable globalThis", DEFAULT_CONFIG_ESGlobalThis)
 
+FLAGNR(Boolean, RemoveDummyYield, "Remove first dummy yield in generator, used to evaluate default parameter expression, if not needed", false)
+
 // This flag to be removed once JITing generator functions is stable
 FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", false)
 

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -42,7 +42,8 @@ namespace Js
             Method                         = 0x400000, // The function is a method
             ComputedName                   = 0x800000,
             ActiveScript                   = 0x1000000,
-            HomeObj                        = 0x2000000
+            HomeObj                        = 0x2000000,
+            EvaluateNonSimpleParameterListForGenerator = 0x8000000
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
         FunctionInfo(JavascriptMethod entryPoint, _no_write_barrier_tag, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
@@ -82,6 +83,10 @@ namespace Js
         bool HasComputedName() const { return HasComputedName(this->attributes); }
         static bool HasHomeObj(Attributes attributes) { return (attributes & Attributes::HomeObj) != 0; }
         bool HasHomeObj() const { return HasHomeObj(this->attributes); }
+
+        bool ShouldEvaluateNonSimpleParameterListForGenerator() const {
+            return (attributes & Attributes::EvaluateNonSimpleParameterListForGenerator) != 0;
+        }
 
         BOOL HasBody() const { return functionBodyImpl != NULL; }
         BOOL HasParseableInfo() const { return this->HasBody() && !this->IsDeferredDeserializeFunction(); }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3066,7 +3066,16 @@ void ByteCodeGenerator::EmitOneFunction(ParseNodeFnc *pnodeFnc)
         // to be verified. Ideally if the function has simple parameter list then we can avoid inserting the opcode and the additional call.
         if (pnodeFnc->IsGenerator() && !pnodeFnc->IsModule())
         {
-            EmitDummyYield(this, funcInfo);
+            if (
+                this->GetScriptContext()->GetThreadContext()->IsRuntimeInTTDMode() ||
+                (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || pnodeFnc->HasNonSimpleParameterList()))
+            {
+                EmitDummyYield(this, funcInfo);
+            }
+            else
+            {
+                this->Writer()->Reg1(Js::OpCode::LdUndef, funcInfo->yieldRegister);
+            }
         }
 
         DefineUserVars(funcInfo);

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3068,7 +3068,7 @@ void ByteCodeGenerator::EmitOneFunction(ParseNodeFnc *pnodeFnc)
         {
             if (
                 this->GetScriptContext()->GetThreadContext()->IsRuntimeInTTDMode() ||
-                (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || pnodeFnc->HasNonSimpleParameterList()))
+                (!CONFIG_FLAG(RemoveDummyYield) || pnodeFnc->HasNonSimpleParameterList()))
             {
                 EmitDummyYield(this, funcInfo);
             }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1242,6 +1242,7 @@ static const Js::FunctionInfo::Attributes StableFunctionInfoAttributesMask = (Js
     Js::FunctionInfo::Attributes::ClassMethod |
     Js::FunctionInfo::Attributes::Method |
     Js::FunctionInfo::Attributes::Generator |
+    Js::FunctionInfo::Attributes::EvaluateNonSimpleParameterListForGenerator |
     Js::FunctionInfo::Attributes::Module |
     Js::FunctionInfo::Attributes::ComputedName |
     Js::FunctionInfo::Attributes::HomeObj
@@ -1293,6 +1294,10 @@ static Js::FunctionInfo::Attributes GetFunctionInfoAttributes(ParseNodeFnc * pno
     if (pnodeFnc->IsGenerator())
     {
         attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::Generator);
+        if (pnodeFnc->HasNonSimpleParameterList())
+        {
+            attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::EvaluateNonSimpleParameterListForGenerator);
+        }
     }
     if (pnodeFnc->IsAccessor())
     {

--- a/lib/Runtime/Library/JavascriptGenerator.cpp
+++ b/lib/Runtime/Library/JavascriptGenerator.cpp
@@ -608,7 +608,7 @@ namespace Js
         if (
             scriptContext->GetThreadContext()->IsRuntimeInTTDMode() ||
             funcInfo->IsModule() ||
-            (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
+            (!CONFIG_FLAG(RemoveDummyYield) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
         )
         {
             BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())

--- a/lib/Runtime/Library/JavascriptGenerator.h
+++ b/lib/Runtime/Library/JavascriptGenerator.h
@@ -17,6 +17,10 @@ namespace Js
 
         ResumeYieldData(Var data, JavascriptExceptionObject* exceptionObj, JavascriptGenerator* generator = nullptr) :
             data(data), exceptionObj(exceptionObj), generator(generator) {}
+
+        static uint32 GetOffsetOfData() { return offsetof(ResumeYieldData, data); }
+
+        static uint32 GetOffsetOfExceptionObject() { return offsetof(ResumeYieldData, exceptionObj); }
     };
 
     struct AsyncGeneratorRequest

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -166,10 +166,8 @@ using namespace Js;
         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
         Arguments heapArgs(callInfo, unsafe_write_barrier_cast<Var*>(argsHeapCopy));
 
-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject();
+        DynamicObject* prototype = VarTo<DynamicObject>(JavascriptOperators::GetPropertyNoCache(function, Js::PropertyIds::prototype, scriptContext));
         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, generatorFunction->scriptFunction, prototype);
-        // Set the prototype from constructor
-        JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);
 
         // Call a next on the generator to execute till the beginning of the body
         BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
@@ -197,12 +195,10 @@ using namespace Js;
         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
         Arguments heapArgs(callInfo, unsafe_write_barrier_cast<Var*>(argsHeapCopy));
 
-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateAsyncGeneratorConstructorPrototypeObject();
+        DynamicObject* prototype = VarTo<DynamicObject>(JavascriptOperators::GetPropertyNoCache(function, Js::PropertyIds::prototype, scriptContext));
         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, asyncGeneratorFunction->scriptFunction, prototype);
         generator->SetIsAsync();
         generator->InitialiseAsyncGenerator(scriptContext);
-        // Set the prototype from constructor
-        JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);
         return generator;
     }
 

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -173,7 +173,7 @@ using namespace Js;
         if (
             scriptContext->GetThreadContext()->IsRuntimeInTTDMode() ||
             funcInfo->IsModule() ||
-            (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
+            (!CONFIG_FLAG(RemoveDummyYield) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
         )
         {
             // Call a next on the generator to execute till the beginning of the body

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -734,6 +734,9 @@ namespace Js
                 NullTypeHandler<false>::GetDefaultInstance(), true, true);
 
             generatorConstructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
+
+            generatorType = DynamicType::New(scriptContext, TypeIds_Generator, generatorPrototype, nullptr,
+                PathTypeHandlerNoAttr::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         }
 
         if (config->IsES2018AsyncIterationEnabled())
@@ -6120,8 +6123,9 @@ namespace Js
     JavascriptGenerator* JavascriptLibrary::CreateGenerator(Arguments& args, ScriptFunction* scriptFunction, RecyclableObject* prototype)
     {
         Assert(scriptContext->GetConfig()->IsES6GeneratorsEnabled());
-        DynamicType* generatorType = CreateGeneratorType(prototype);
-        return JavascriptGenerator::New(this->GetRecycler(), generatorType, args, scriptFunction);
+        JavascriptGenerator* generator = JavascriptGenerator::New(this->GetRecycler(), this->generatorType, args, scriptFunction);
+        JavascriptObject::ChangePrototype(generator, prototype, true, scriptContext);
+        return generator;
     }
 
     JavascriptError* JavascriptLibrary::CreateError()

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -279,6 +279,7 @@ namespace Js
         Field(DynamicType *) stringIteratorType;
         Field(DynamicType *) promiseType;
         Field(DynamicType *) listIteratorType;
+        Field(DynamicType *) generatorType;
 
         Field(JavascriptFunction*) builtinFunctions[BuiltinFunction::Count];
 


### PR DESCRIPTION
- Cache generator type
- Remove redundant prototype creation
- Remove extra dummy yield at the beginning of generator functions (used to evaluate default arguments, disabled by default, currently breaks async functions)