### PR TITLE
Fix value propagation on loop back-edge with aggressive value transfers

### DIFF
--- a/lib/Backend/GlobOptBlockData.h
+++ b/lib/Backend/GlobOptBlockData.h
@@ -261,7 +261,7 @@ private:
     template <typename CaptureList, typename CapturedItemsAreEqual>
     void                    MergeCapturedValues(SListBase<CaptureList>* toList, SListBase<CaptureList> * fromList, CapturedItemsAreEqual itemsAreEqual);
     void                    MergeValueMaps(BasicBlock *toBlock, BasicBlock *fromBlock, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge);
-    Value *                 MergeValues(Value *toDataValue, Value *fromDataValue, Sym *fromDataSym, bool isLoopBackEdge, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge);
+    Value *                 MergeValues(Value *toDataValue, Value *fromDataValue, Sym *fromDataSym, bool isLoopBackEdge, bool forceUniqueValue, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge);
     ValueInfo *             MergeValueInfo(Value *toDataVal, Value *fromDataVal, Sym *fromDataSym, bool isLoopBackEdge, bool sameValueNumber, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge);
     JsTypeValueInfo *       MergeJsTypeValueInfo(JsTypeValueInfo * toValueInfo, JsTypeValueInfo * fromValueInfo, bool isLoopBackEdge, bool sameValueNumber);
     ValueInfo *             MergeArrayValueInfo(const ValueType mergedValueType, const ArrayValueInfo *const toDataValueInfo, const ArrayValueInfo *const fromDataValueInfo, Sym *const arraySym, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge, bool isLoopBackEdge);

--- a/test/Optimizer/PrePassEntanglement.js
+++ b/test/Optimizer/PrePassEntanglement.js
@@ -1,0 +1,28 @@
+
+function test() {
+  var line = '"Value1InQuotes",Value2,Value 3 ,0.33,,,Last Value';
+  var inQuotes = false;
+  var quoted = false;
+  for (var i = 0; i < line.length; i++) {
+    if (inQuotes) {
+      if (line[i] === '"') {
+          inQuotes = false;
+      }
+    } else {
+      if (line[i] === '"') {
+        inQuotes = true;
+        quoted = true;
+      } else if (line[i] === ',') {
+        if (line[i - 1] === '"' && !quoted) {
+          WScript.Echo('Read from wrong var');
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+if (test() && test() && test()) {
+  WScript.Echo('Passed');
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1213,6 +1213,11 @@
   </test>
   <test>
     <default>
+      <files>PrePassEntanglement.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>missing_len.js</files>
       <baseline>missing_len.baseline</baseline>
     </default>

--- a/test/PRE/pre1.baseline
+++ b/test/PRE/pre1.baseline
@@ -19,7 +19,6 @@ testInlined
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
-TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
@@ -30,7 +29,6 @@ undefined
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop [in landing pad]: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
-TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdRootFld field: Direction 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: FORWARD 
 TestTrace fieldcopyprop: function inlinee ( (#1.3), #4) inlined caller function testInlined ( (#1.4), #5) opcode: LdFld field: count 


### PR DESCRIPTION
When using aggressive value transfer in loop prepasses, the data flow analyzer can incorrectly determine that two syms always share a value on the backedge, when in fact their values can diverge on subsequent iterations of the loop.

This change ensures that all syms assigned to within a loop are given unique value numbers when merging from the backedge.

The performance gains from the AVTInPrepass optimization (specifically Octane/deltablue) are retained with this fix.

Fixes #6252