### PR TITLE
Fix and Enable Jitting Generators

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1774,6 +1774,12 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
 
     BAILOUT_FLUSH(executeFunction);
 
+    if (executeFunction->IsCoroutine() && bailOutKind != IR::BailOutForGeneratorYield)
+    {
+        Js::ResumeYieldData* resumeYieldData = static_cast<Js::ResumeYieldData*>(args[1]);
+        newInstance->SetNonVarReg(executeFunction->GetYieldRegister(), resumeYieldData);
+    }
+
     executeFunction->BeginExecution();
 
     // Restart at the bailout byte code offset.

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -7835,6 +7835,9 @@ IRBuilder::GeneratorJumpTable::BuildJumpTable()
     instr->SetSrc1(curOffsetOpnd);
     this->m_irBuilder->AddInstr(instr, this->m_irBuilder->m_functionStartOffset);
 
+    // TODO: Improvements
+    // If the code falls through to here, it means that none of the offsets matched. This must be the first
+    // time we create the interpreter frame. Skip this bailout.
     IR::BranchInstr* skipBailOutForElidedYield = IR::BranchInstr::New(Js::OpCode::Br, functionBegin, this->m_func);
     this->m_irBuilder->AddInstr(skipBailOutForElidedYield, this->m_irBuilder->m_functionStartOffset);
 

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -7801,9 +7801,6 @@ IRBuilder::GeneratorJumpTable::BuildJumpTable()
     IR::Instr* createInterpreterFrame = IR::Instr::New(Js::OpCode::GeneratorCreateInterpreterStackFrame, genFrameOpnd /* dst */, genRegOpnd /* src */, this->m_func);
     this->m_irBuilder->AddInstr(createInterpreterFrame, this->m_irBuilder->m_functionStartOffset);
 
-    IR::BranchInstr* skipJumpTable = IR::BranchInstr::New(Js::OpCode::Br, functionBegin, this->m_func);
-    this->m_irBuilder->AddInstr(skipJumpTable, this->m_irBuilder->m_functionStartOffset);
-
     // Label to insert any initialization code
     // $initializationCode:
     this->m_irBuilder->AddInstr(initCode, this->m_irBuilder->m_functionStartOffset);
@@ -7837,6 +7834,9 @@ IRBuilder::GeneratorJumpTable::BuildJumpTable()
     instr = IR::Instr::New(Js::OpCode::GeneratorResumeJumpTable, this->m_func);
     instr->SetSrc1(curOffsetOpnd);
     this->m_irBuilder->AddInstr(instr, this->m_irBuilder->m_functionStartOffset);
+
+    IR::BranchInstr* skipBailOutForElidedYield = IR::BranchInstr::New(Js::OpCode::Br, functionBegin, this->m_func);
+    this->m_irBuilder->AddInstr(skipBailOutForElidedYield, this->m_irBuilder->m_functionStartOffset);
 
     this->m_func->m_bailOutForElidedYieldInsertionPoint = instr;
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -637,6 +637,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6ForLoopSemantics     (true)
 #define DEFAULT_CONFIG_ES6FunctionNameFull     (true)
 #define DEFAULT_CONFIG_ES6Generators           (true)
+#define DEFAULT_CONFIG_JitES6Generators        (true)
 #define DEFAULT_CONFIG_ES6IsConcatSpreadable   (true)
 #define DEFAULT_CONFIG_ES6Math                 (true)
 #ifdef COMPILE_DISABLE_ES6Module
@@ -1226,7 +1227,7 @@ FLAGR(Boolean, ESImportMeta, "Enable import.meta keyword", DEFAULT_CONFIG_ESImpo
 FLAGR(Boolean, ESGlobalThis, "Enable globalThis", DEFAULT_CONFIG_ESGlobalThis)
 
 // This flag to be removed once JITing generator functions is stable
-FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", false)
+FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", DEFAULT_CONFIG_JitES6Generators)
 
 FLAGNR(Boolean, FastLineColumnCalculation, "Enable fast calculation of line/column numbers from the source.", DEFAULT_CONFIG_FastLineColumnCalculation)
 FLAGR (String,  Filename              , "Jscript source file", nullptr)

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1226,8 +1226,6 @@ FLAGR(Boolean, ESImportMeta, "Enable import.meta keyword", DEFAULT_CONFIG_ESImpo
 //ES globalThis flag
 FLAGR(Boolean, ESGlobalThis, "Enable globalThis", DEFAULT_CONFIG_ESGlobalThis)
 
-FLAGNR(Boolean, RemoveDummyYield, "Remove first dummy yield in generator, used to evaluate default parameter expression, if not needed", false)
-
 // This flag to be removed once JITing generator functions is stable
 FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", DEFAULT_CONFIG_JitES6Generators)
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -636,8 +636,14 @@ PHASE(All)
 #define DEFAULT_CONFIG_ES6Destructuring        (true)
 #define DEFAULT_CONFIG_ES6ForLoopSemantics     (true)
 #define DEFAULT_CONFIG_ES6FunctionNameFull     (true)
+
+#ifdef _M_X64
+    // Jitting Generator functions and async functions - currently only works on x64
+    #define DEFAULT_CONFIG_JitES6Generators    (true)
+#else
+    #define DEFAULT_CONFIG_JitES6Generators    (false)
+#endif
 #define DEFAULT_CONFIG_ES6Generators           (true)
-#define DEFAULT_CONFIG_JitES6Generators        (true)
 #define DEFAULT_CONFIG_ES6IsConcatSpreadable   (true)
 #define DEFAULT_CONFIG_ES6Math                 (true)
 #ifdef COMPILE_DISABLE_ES6Module

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1226,6 +1226,8 @@ FLAGR(Boolean, ESImportMeta, "Enable import.meta keyword", DEFAULT_CONFIG_ESImpo
 //ES globalThis flag
 FLAGR(Boolean, ESGlobalThis, "Enable globalThis", DEFAULT_CONFIG_ESGlobalThis)
 
+FLAGNR(Boolean, RemoveDummyYield, "Remove first dummy yield in generator, used to evaluate default parameter expression, if not needed", false)
+
 // This flag to be removed once JITing generator functions is stable
 FLAGNR(Boolean, JitES6Generators        , "Enable JITing of ES6 generators", DEFAULT_CONFIG_JitES6Generators)
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -341,13 +341,13 @@ namespace Js
     bool
     FunctionBody::SkipAutoProfileForCoroutine() const
     {
-        return this->IsCoroutine() && CONFIG_ISENABLED(Js::JitES6GeneratorsFlag);
+        return this->IsCoroutine() && CONFIG_FLAG(JitES6Generators);
     }
 
     bool
     FunctionBody::IsGeneratorAndJitIsDisabled() const
     {
-        return this->IsCoroutine() && !(CONFIG_ISENABLED(Js::JitES6GeneratorsFlag) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsAsync());
+        return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsAsync());
     }
 
     ScriptContext* EntryPointInfo::GetScriptContext()

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -341,24 +341,17 @@ namespace Js
     bool
     FunctionBody::SkipAutoProfileForCoroutine() const
     {
-#if defined(_ARM64_) || defined(_ARM_)
-        return false;
-#else
         return this->IsCoroutine() && CONFIG_FLAG(JitES6Generators);
-#endif
     }
 
     bool
     FunctionBody::IsGeneratorAndJitIsDisabled() const
     {
-#if defined(_ARM64_) || defined(_ARM_)
-        return this->IsCoroutine(); // disabled for ARM
-#else
         if (!this->IsCoroutine())
         {
             return false;
         }
-        if (!CONFIG_FLAG(JitES6Generators) || this->GetHasTry() || this->IsInDebugMode())
+        if (!CONFIG_FLAG(JitES6Generators) || this->GetHasTry() || this->IsInDebugMode() || (this->IsAsync() && this->IsGenerator()))
         {
             return true;
         }
@@ -370,7 +363,6 @@ namespace Js
             return false;
 #endif
         }
-#endif
     }
 
     ScriptContext* EntryPointInfo::GetScriptContext()

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -341,13 +341,21 @@ namespace Js
     bool
     FunctionBody::SkipAutoProfileForCoroutine() const
     {
+#if defined(_ARM64_) || defined(_ARM_)
+        return false;
+#else
         return this->IsCoroutine() && CONFIG_FLAG(JitES6Generators);
+#endif
     }
 
     bool
     FunctionBody::IsGeneratorAndJitIsDisabled() const
     {
+#if defined(_ARM64_) || defined(_ARM_)
+        return this->IsCoroutine(); // disabled for ARM
+#else
         return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsAsync());
+#endif
     }
 
     ScriptContext* EntryPointInfo::GetScriptContext()

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -354,7 +354,7 @@ namespace Js
 #if defined(_ARM64_) || defined(_ARM_)
         return this->IsCoroutine(); // disabled for ARM
 #else
-        return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode() && !this->IsAsync());
+        return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode());
 #endif
     }
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -354,7 +354,22 @@ namespace Js
 #if defined(_ARM64_) || defined(_ARM_)
         return this->IsCoroutine(); // disabled for ARM
 #else
-        return this->IsCoroutine() && !(CONFIG_FLAG(JitES6Generators) && !this->GetHasTry() && !this->IsInDebugMode());
+        if (!this->IsCoroutine())
+        {
+            return false;
+        }
+        if (!CONFIG_FLAG(JitES6Generators) || this->GetHasTry() || this->IsInDebugMode())
+        {
+            return true;
+        }
+        else
+        {
+#if ENABLE_TTD
+            return this->GetScriptContext()->GetThreadContext()->IsRuntimeInTTDMode() && this->IsAsync();
+#else
+            return false;
+#endif
+        }
 #endif
     }
 

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -42,7 +42,8 @@ namespace Js
             Method                         = 0x400000, // The function is a method
             ComputedName                   = 0x800000,
             ActiveScript                   = 0x1000000,
-            HomeObj                        = 0x2000000
+            HomeObj                        = 0x2000000,
+            EvaluateNonSimpleParameterListForGenerator = 0x8000000
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
         FunctionInfo(JavascriptMethod entryPoint, _no_write_barrier_tag, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
@@ -82,6 +83,10 @@ namespace Js
         bool HasComputedName() const { return HasComputedName(this->attributes); }
         static bool HasHomeObj(Attributes attributes) { return (attributes & Attributes::HomeObj) != 0; }
         bool HasHomeObj() const { return HasHomeObj(this->attributes); }
+
+        bool ShouldEvaluateNonSimpleParameterListForGenerator() const {
+            return (attributes & Attributes::EvaluateNonSimpleParameterListForGenerator) != 0;
+        }
 
         BOOL HasBody() const { return functionBodyImpl != NULL; }
         BOOL HasParseableInfo() const { return this->HasBody() && !this->IsDeferredDeserializeFunction(); }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3064,7 +3064,16 @@ void ByteCodeGenerator::EmitOneFunction(ParseNodeFnc *pnodeFnc)
         // to be verified. Ideally if the function has simple parameter list then we can avoid inserting the opcode and the additional call.
         if (pnodeFnc->IsGenerator() && !pnodeFnc->IsModule())
         {
-            EmitDummyYield(this, funcInfo);
+            if (
+                this->GetScriptContext()->GetThreadContext()->IsRuntimeInTTDMode() ||
+                (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || pnodeFnc->HasNonSimpleParameterList()))
+            {
+                EmitDummyYield(this, funcInfo);
+            }
+            else
+            {
+                this->Writer()->Reg1(Js::OpCode::LdUndef, funcInfo->yieldRegister);
+            }
         }
 
         DefineUserVars(funcInfo);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1242,6 +1242,7 @@ static const Js::FunctionInfo::Attributes StableFunctionInfoAttributesMask = (Js
     Js::FunctionInfo::Attributes::ClassMethod |
     Js::FunctionInfo::Attributes::Method |
     Js::FunctionInfo::Attributes::Generator |
+    Js::FunctionInfo::Attributes::EvaluateNonSimpleParameterListForGenerator |
     Js::FunctionInfo::Attributes::Module |
     Js::FunctionInfo::Attributes::ComputedName |
     Js::FunctionInfo::Attributes::HomeObj
@@ -1293,6 +1294,10 @@ static Js::FunctionInfo::Attributes GetFunctionInfoAttributes(ParseNodeFnc * pno
     if (pnodeFnc->IsGenerator())
     {
         attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::Generator);
+        if (pnodeFnc->HasNonSimpleParameterList())
+        {
+            attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::EvaluateNonSimpleParameterListForGenerator);
+        }
     }
     if (pnodeFnc->IsAccessor())
     {

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1992,6 +1992,17 @@ skipThunk:
             else
             {
                 newInstance = CreateInterpreterStackFrameForGenerator(function, executeFunction, generator, doProfile);
+                if (generator->GetIsAsync())
+                {
+                    ResumeYieldData* resumeYieldData = static_cast<ResumeYieldData*>(args[1]);
+                    newInstance->SetNonVarReg(executeFunction->GetYieldRegister(), resumeYieldData);
+
+                    // The debugger relies on comparing stack addresses of frames to decide when a step_out is complete so
+                    // give the InterpreterStackFrame a legit enough stack address to make this comparison work.
+                    newInstance->m_stackAddress = reinterpret_cast<DWORD_PTR>(&generator);
+
+                    newInstance->retOffset = 0;
+                }
             }
         }
         else

--- a/lib/Runtime/Library/JavascriptGenerator.cpp
+++ b/lib/Runtime/Library/JavascriptGenerator.cpp
@@ -606,10 +606,12 @@ namespace Js
         FunctionInfo* funcInfo = this->scriptFunction->GetFunctionInfo();
 
         if (
+#if ENABLE_TTD
             scriptContext->GetThreadContext()->IsRuntimeInTTDMode() ||
+#endif
             funcInfo->IsModule() ||
-            (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
-        )
+            funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator()
+            )
         {
             BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
             {

--- a/lib/Runtime/Library/JavascriptGenerator.h
+++ b/lib/Runtime/Library/JavascriptGenerator.h
@@ -17,6 +17,10 @@ namespace Js
 
         ResumeYieldData(Var data, JavascriptExceptionObject* exceptionObj, JavascriptGenerator* generator = nullptr) :
             data(data), exceptionObj(exceptionObj), generator(generator) {}
+
+        static uint32 GetOffsetOfData() { return offsetof(ResumeYieldData, data); }
+
+        static uint32 GetOffsetOfExceptionObject() { return offsetof(ResumeYieldData, exceptionObj); }
     };
 
     struct AsyncGeneratorRequest

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -166,10 +166,8 @@ using namespace Js;
         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
         Arguments heapArgs(callInfo, unsafe_write_barrier_cast<Var*>(argsHeapCopy));
 
-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject();
+        DynamicObject* prototype = VarTo<DynamicObject>(JavascriptOperators::GetPropertyNoCache(function, Js::PropertyIds::prototype, scriptContext));
         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, generatorFunction->scriptFunction, prototype);
-        // Set the prototype from constructor
-        JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);
 
         // Call a next on the generator to execute till the beginning of the body
         BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
@@ -197,12 +195,10 @@ using namespace Js;
         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
         Arguments heapArgs(callInfo, unsafe_write_barrier_cast<Var*>(argsHeapCopy));
 
-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateAsyncGeneratorConstructorPrototypeObject();
+        DynamicObject* prototype = VarTo<DynamicObject>(JavascriptOperators::GetPropertyNoCache(function, Js::PropertyIds::prototype, scriptContext));
         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, asyncGeneratorFunction->scriptFunction, prototype);
         generator->SetIsAsync();
         generator->InitialiseAsyncGenerator(scriptContext);
-        // Set the prototype from constructor
-        JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);
         return generator;
     }
 

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -171,9 +171,11 @@ using namespace Js;
         FunctionInfo* funcInfo = generatorFunction->scriptFunction->GetFunctionInfo();
 
         if (
+#if ENABLE_TTD
             scriptContext->GetThreadContext()->IsRuntimeInTTDMode() ||
+#endif
             funcInfo->IsModule() ||
-            (!CONFIG_ISENABLED(Js::RemoveDummyYieldFlag) || funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator())
+            funcInfo->ShouldEvaluateNonSimpleParameterListForGenerator()
         )
         {
             // Call a next on the generator to execute till the beginning of the body

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -734,6 +734,9 @@ namespace Js
                 NullTypeHandler<false>::GetDefaultInstance(), true, true);
 
             generatorConstructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
+
+            generatorType = DynamicType::New(scriptContext, TypeIds_Generator, generatorPrototype, nullptr,
+                PathTypeHandlerNoAttr::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         }
 
         if (config->IsES2018AsyncIterationEnabled())
@@ -6120,8 +6123,9 @@ namespace Js
     JavascriptGenerator* JavascriptLibrary::CreateGenerator(Arguments& args, ScriptFunction* scriptFunction, RecyclableObject* prototype)
     {
         Assert(scriptContext->GetConfig()->IsES6GeneratorsEnabled());
-        DynamicType* generatorType = CreateGeneratorType(prototype);
-        return JavascriptGenerator::New(this->GetRecycler(), generatorType, args, scriptFunction);
+        JavascriptGenerator* generator = JavascriptGenerator::New(this->GetRecycler(), this->generatorType, args, scriptFunction);
+        JavascriptObject::ChangePrototype(generator, prototype, true, scriptContext);
+        return generator;
     }
 
     JavascriptError* JavascriptLibrary::CreateError()

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -279,6 +279,7 @@ namespace Js
         Field(DynamicType *) stringIteratorType;
         Field(DynamicType *) promiseType;
         Field(DynamicType *) listIteratorType;
+        Field(DynamicType *) generatorType;
 
         Field(JavascriptFunction*) builtinFunctions[BuiltinFunction::Count];
 


### PR DESCRIPTION
This PR incorporates the work done by @nhat-nguyen in #6245 and #6251 as well as a couple of fixes so it should work correctly and pass all tests:

1. Set ResumeYieldData after a bailout - not doing this caused a crash in AsyncGenerators
2. Fix the RemoveDummyYield and remove the flag for it - now it works it doesn't need a flag
3. Fix the Jitting of AsyncYieldIsReturn operation used as part of yield* within an AsyncGenerator
4. Under TTD disable jitting Async functions - jitting async functions works normally but fails under TTD
5. Disable on x86 - there was an x86 test error wasm/params.js (which uses a generator as part of its wasm test) it's an actual error with generators though, see longer comment below
6. Don't enable for AsyncGenerators as Yield* inside an asyncgenerator currently hits a failfast during jitting (possibly due to incorrect use/re-use of temporary registers), see longer comment below.

@zenparsing please could you take a look at this?