### PR TITLE
ModuleEvaluation should return undefined

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -1103,6 +1103,7 @@ namespace Js
             {
                 ResumeYieldData yieldData(scriptContext->GetLibrary()->GetUndefined(), nullptr);
                 ret = gen->CallGenerator(&yieldData, _u("Module Global"));
+                ret = JavascriptOperators::GetProperty(VarTo<RecyclableObject>(ret), PropertyIds::value, scriptContext);
             }
             END_SAFE_REENTRANT_CALL
         }


### PR DESCRIPTION
Picking up on discussion in #6266 this reverts an unintended side-effect of #6171 

The successful completion value of a module is `undefined` - this was not tested and the change in #6171 had resulted in it being  `{done : true}` instead.

With this change that is reverted additionally a crude test is added - every time a root module is evaluated in ch the completion value is checked to confirm that it is `undefined` - this would make every single module test fail if this error was ever re-introduced.

I note the discussion in #6266 was sparked by a desire for the return value to be the result of the last statement in the module - like with a script - this change will not do that as:
a) it seems that was not done before
b) that would be very complex and
c) that is not per specification see https://tc39.es/ecma262/#sec-moduleevaluation