### PR TITLE
CheckFixedFld invariants and CSE issues

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -14635,6 +14635,7 @@ GlobOpt::OptIsInvariant(IR::Opnd *src, BasicBlock *block, Loop *loop, Value *src
         sym = src->AsSymOpnd()->m_sym;
         if (src->AsSymOpnd()->IsPropertySymOpnd())
         {
+#if 0
             if (src->AsSymOpnd()->AsPropertySymOpnd()->IsTypeChecked())
             {
                 // We do not handle hoisting these yet.  We might be hoisting this across the instr with the type check protecting this one.
@@ -14642,6 +14643,7 @@ GlobOpt::OptIsInvariant(IR::Opnd *src, BasicBlock *block, Loop *loop, Value *src
                 // For CheckFixedFld, there is no benefit hoisting these if they don't have a type check as they won't generate code.
                 return false;
             }
+#endif
         }
 
         break;
@@ -14654,6 +14656,7 @@ GlobOpt::OptIsInvariant(IR::Opnd *src, BasicBlock *block, Loop *loop, Value *src
     default:
         return false;
     }
+
     return OptIsInvariant(sym, block, loop, srcVal, isNotTypeSpecConv, allowNonPrimitives);
 }
 
@@ -14868,15 +14871,23 @@ GlobOpt::OptIsInvariant(
         }
         break;
     case Js::OpCode::CheckObjType:
+    case Js::OpCode::CheckFixedFld:
         // Bug 11712101: If the operand is a field, ensure that its containing object type is invariant
         // before hoisting -- that is, don't hoist a CheckObjType over a DeleteFld on that object.
         // (CheckObjType only checks the operand and its immediate parent, so we don't need to go
         // any farther up the object graph.)
         Assert(instr->GetSrc1());
-        PropertySym *propertySym = instr->GetSrc1()->AsPropertySymOpnd()->GetPropertySym();
-        if (propertySym->HasObjectTypeSym()) {
-            StackSym *objectTypeSym = propertySym->GetObjectTypeSym();
+        IR::PropertySymOpnd *propertySymOpnd = instr->GetSrc1()->AsPropertySymOpnd();
+        if (propertySymOpnd->IsTypeCheckSeqCandidate() && !propertySymOpnd->IsTypeChecked()) {
+            StackSym *objectTypeSym = propertySymOpnd->GetObjectTypeSym();
             if (!this->OptIsInvariant(objectTypeSym, block, loop, this->CurrentBlockData()->FindValue(objectTypeSym), true, true)) {
+                return false;
+            }
+        }
+        if (propertySymOpnd->IsAuxSlotPtrSymAvailable())
+        {
+            StackSym* auxSlotPtrSym = propertySymOpnd->GetAuxSlotPtrSym();
+            if (!this->OptIsInvariant(auxSlotPtrSym, block, loop, this->CurrentBlockData()->FindValue(auxSlotPtrSym), true, true)) {
                 return false;
             }
         }
@@ -15033,6 +15044,22 @@ GlobOpt::OptHoistInvariant(
         if (src1->IsRegOpnd())
         {
             src1->AsRegOpnd()->m_isTempLastUse = false;
+        }
+
+        if (src1->IsSymOpnd() && src1->AsSymOpnd()->IsPropertySymOpnd())
+        {
+            IR::PropertySymOpnd* opnd = src1->AsSymOpnd()->AsPropertySymOpnd();
+            FinishOptPropOp(instr, opnd, loop->landingPad);
+
+            if (opnd->IsAuxSlotPtrSymAvailable())
+            {
+                block->globOptData.liveFields->Clear(opnd->GetAuxSlotPtrSym()->m_id);
+            }
+
+            if (opnd->IsTypeCheckSeqCandidate() && !opnd->IsTypeChecked())
+            {
+                block->globOptData.liveFields->Clear(opnd->GetObjectTypeSym()->m_id);
+            }
         }
 
         IR::Opnd* src2 = instr->GetSrc2();

--- a/test/fieldopts/auxslot_bug.js
+++ b/test/fieldopts/auxslot_bug.js
@@ -1,0 +1,27 @@
+var obj0 = {};
+var obj1 = {};
+var arrObj0 = {};
+var func1 = function () {
+  function func5() {
+  }
+  obj6 = func5();
+  while (obj1) {
+    obj6 = obj6;
+    if (ary.shift() >> new EvalError()) {
+      length;
+    } else {
+      break;
+    }
+  }
+};
+var func3 = function () {
+  func1();
+};
+obj0.method0 = func3;
+obj0.method1 = obj0.method0;
+arrObj0.method0 = obj0.method1;
+var ary = Array();
+
+for (var i = 0; i < 200; i++) arrObj0.method0();
+
+print("Passed");

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -2,6 +2,11 @@
 <regress-exe>
   <test>
     <default>
+      <files>auxslot_bug.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>depolymorph01.js</files>
     </default>
   </test>


### PR DESCRIPTION
Hoisting and CSE'ing CheckFixedFlds causes issues for objTypeSpec, as it can invalidate dependencies on the availability of the type sym or aux slot sym.
