### PR TITLE
[test262] Contextual keywords cannot have unicode escape sequences

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -328,6 +328,16 @@ private:
     bool CheckStrictModeStrPid(IdentPtr pid);
     bool CheckAsmjsModeStrPid(IdentPtr pid);
 
+    bool CheckContextualKeyword(IdentPtr keywordPid)
+    {
+        if (m_token.tk == tkID && !GetScanner()->LastIdentifierHasEscape())
+        {
+            IdentPtr pid = m_token.GetIdentifier(GetHashTbl());
+            return pid == keywordPid;
+        }
+        return false;
+    }
+
     bool IsCurBlockInLoop() const;
 
     void InitPids();

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -492,6 +492,8 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
         break;
     }
 
+    m_lastIdentifierHasEscape = fHasEscape;
+
     Assert(p - pchMin > 0 && p - pchMin <= LONG_MAX);
 
     *pp = p;

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -493,6 +493,10 @@ public:
       return m_EscapeOnLastTkStrCon;
     }
 
+    bool LastIdentifierHasEscape()
+    {
+        return m_lastIdentifierHasEscape;
+    }
 
     bool IsOctOrLeadingZeroOnLastTKNumber()
     {
@@ -730,6 +734,7 @@ private:
     BOOL m_doubleQuoteOnLastTkStrCon :1;
     bool m_OctOrLeadingZeroOnLastTKNumber :1;
     bool m_EscapeOnLastTkStrCon:1;
+    bool m_lastIdentifierHasEscape:1;
     BOOL m_fNextStringTemplateIsTagged:1;   // the next string template scanned has a tag (must create raw strings)
     BYTE m_DeferredParseFlags:2;            // suppressStrPid and suppressIdPid    
     bool es6UnicodeMode;                // True if ES6Unicode Extensions are enabled.

--- a/test/es5/setget.js
+++ b/test/es5/setget.js
@@ -220,3 +220,7 @@ test(false);
 test(true);
 })();
 
+try {
+  eval("({ g\\u0065t foo() {} })");
+  write("Get and set cannot contain unicode escapes");
+} catch {}

--- a/test/es6module/module-syntax.js
+++ b/test/es6module/module-syntax.js
@@ -117,6 +117,8 @@ var tests = [
             testModuleScript('function () { export default null; }', 'Syntax error export in function', true);
             testModuleScript('export {foo}', 'Syntax error undefined export', true);
             testModuleScript('export {Array}', 'Syntax error exporting a global name with no local definition', true);
+            testModuleScript('var x; export { x \\u0061s y }', 'Syntax error if as keyword has unicode escape', true);
+            testModuleScript('export { x } \\u0066rom "module";', 'Syntax error if as keyword has unicode escape', true);
         }
     },
     {
@@ -164,6 +166,7 @@ var tests = [
             testModuleScript(`do import { default } from "module"
                                 while (false);`, 'Syntax error export in while', true);
             testModuleScript('function () { import { default } from "module"; }', 'Syntax error export in function', true);
+            testModuleScript('import { default \\u0061s y } from "module";', 'Syntax error if as keyword has unicode escape', true);
         }
     },
     {

--- a/test/es7/asyncawait-syntax.js
+++ b/test/es7/asyncawait-syntax.js
@@ -135,6 +135,14 @@ var tests = [
         }
     },
     {
+        name: "Async keyword cannot contain unicode escapes",
+        body: function () {
+            assert.throws(function () { eval("\\u0061sync function foo() {} }"); }, SyntaxError, "async keyword cannot contain unicode escapes");
+            assert.throws(function () { eval("({ \\u0061sync foo() {} })"); }, SyntaxError, "async keyword cannot contain unicode escapes");
+            assert.throws(function () { eval("class A { \\u0061sync foo() {} }"); }, SyntaxError, "async keyword cannot contain unicode escapes");
+        }
+    },
+    {
         name: "It is a Syntax Error if FormalParameters Contains AwaitExpression is true",
         body: function () {
             assert.throws(function () { eval("async function af(a, b = await a) { }"); }, SyntaxError, "await expressions not allowed in non-strict async function", "'await' expression not allowed in this context");


### PR DESCRIPTION
Example from test262:

https://github.com/tc39/test262/blob/master/test/language/export/escaped-as-export-specifier.js