### PR TITLE
[test262] Allow "in" in the middle operand of ternaries

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -9225,7 +9225,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
         // Special case the "?:" operator
         if (nop == knopQmark)
         {
-            pnodeT = ParseExpr<buildAST>(koplAsg, NULL, fAllowIn);
+            pnodeT = ParseExpr<buildAST>(koplAsg, NULL, TRUE);
             ChkCurTok(tkColon, ERRnoColon);
             ParseNodePtr pnodeT2 = ParseExpr<buildAST>(koplAsg, NULL, fAllowIn, 0, nullptr, nullptr, nullptr, nullptr, false, nullptr, plastRParen);
             if (buildAST)

--- a/test/Basics/TernaryOperator.js
+++ b/test/Basics/TernaryOperator.js
@@ -10,3 +10,9 @@ WScript.Echo(cond ? "True" : "False");
 WScript.Echo("Setting condition to false...");
 cond = false;
 WScript.Echo(cond ? "True" : "False");
+
+try {
+  for (1 ? 'x' in {} : 0;;) break;
+} catch {
+  WScript.Echo("In expression should be allowed in true part");
+}


### PR DESCRIPTION
https://github.com/tc39/test262/blob/master/test/language/expressions/conditional/in-branch-1.js