### PR TITLE
[test262] Class names should be parsed in strict mode

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7859,6 +7859,9 @@ ParseNodeClass * Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint,
         cbMinConstructor = this->GetScanner()->IecpMinTok();
     }
 
+    BOOL strictSave = m_fUseStrictMode;
+    m_fUseStrictMode = TRUE;
+
     this->GetScanner()->Scan();
     if (m_token.tk == tkID)
     {
@@ -7874,9 +7877,6 @@ ParseNodeClass * Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint,
     {
         GetCurrentFunctionNode()->grfpn |= PNodeFlags::fpnArguments_overriddenByDecl;
     }
-
-    BOOL strictSave = m_fUseStrictMode;
-    m_fUseStrictMode = TRUE;
 
     ParseNodeVar * pnodeDeclName = nullptr;
     if (isDeclaration)

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -73,6 +73,12 @@ var tests = [
     }
   },
   {
+    name: "Class names are parsed in strict mode",
+    body: function () {
+      assert.throws(function () { eval("class l\u0065t { }") }, SyntaxError);
+    }
+  },
+  {
     name: "Class methods may not have an octal name",
     body: function () {
       assert.throws(function () { eval("class E0 { 0123() {} }") }, SyntaxError, "0123");

--- a/test/es6/generators-syntax.js
+++ b/test/es6/generators-syntax.js
@@ -96,6 +96,7 @@ var tests = [
             assert.throws(function () { eval("function* gf() { var gfe = function* yield() { } }"); }, SyntaxError, "Cannot name generator function expression 'yield' in generator body", "The use of a keyword for an identifier is invalid");
 
             assert.throws(function () { eval("function* gf() { class yield { } }"); }, SyntaxError, "Cannot name class 'yield' in generator body", "The use of a keyword for an identifier is invalid");
+            assert.throws(function () { eval("function f() { class yield { } }"); }, SyntaxError, "Can name class 'yield'");
 
             // TODO: Is this correct or a spec bug that will be fixed?
             // var yield = 10; function* gf() { var o = { yield }; } gf();
@@ -133,8 +134,6 @@ var tests = [
             assert.doesNotThrow(function () { eval("function f() { function yield() { } }"); }, "Can name function 'yield' in non-generator body");
             assert.doesNotThrow(function () { eval("function f() { function* yield() { } }"); }, "Can name generator function 'yield' in non-generator body");
             assert.doesNotThrow(function () { eval("function f() { var fe = function yield() { } }"); }, "Can name function expression 'yield' in non-generator body");
-
-            assert.doesNotThrow(function () { eval("function f() { class yield { } }"); }, "Can name class 'yield' in non-generator body");
 
             assert.doesNotThrow(function () { eval("function f() { var o = { yield: 10 } }"); }, "Can name object literal property 'yield' in non-generator body");
             assert.doesNotThrow(function () { eval("function f() { var o = { get yield() { } } }"); }, "Can name accessor method 'yield' in non-generator body");


### PR DESCRIPTION
https://github.com/tc39/test262/blob/master/test/language/expressions/class/class-name-ident-let.js