### PR TITLE
Rework how captured values are written to GeneratorBailInInstrs

### DIFF
--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -45,7 +45,6 @@ private:
     bool ProcessByteCodeUsesInstr(IR::Instr * instr);
     bool ProcessBailOutInfo(IR::Instr * instr);
     void ProcessBailOutInfo(IR::Instr * instr, BailOutInfo * bailOutInfo);
-    IR::Instr* ProcessPendingPreOpBailOutInfoForYield(IR::Instr* const currentInstr);
     IR::Instr* ProcessPendingPreOpBailOutInfo(IR::Instr *const currentInstr);
     void ClearDstUseForPostOpLazyBailOut(IR::Instr *instr);
     void ProcessBailOutArgObj(BailOutInfo * bailOutInfo, BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed);

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -1117,53 +1117,20 @@ public:
 class GeneratorBailInInstr : public LabelInstr
 {
 private:
-    GeneratorBailInInstr(JitArenaAllocator* allocator, IR::Instr* yieldInstr):
-        LabelInstr(allocator), allocator(allocator), yieldInstr(yieldInstr), upwardExposedUses(allocator)
+    GeneratorBailInInstr(JitArenaAllocator* allocator, IR::Instr* yieldInstr) :
+        LabelInstr(allocator),
+        yieldInstr(yieldInstr),
+        upwardExposedUses(allocator)
     {
         Assert(yieldInstr != nullptr && yieldInstr->m_opcode == Js::OpCode::Yield);
-        this->usedCapturedValues = JitAnew(allocator, CapturedValues);
     }
-
-    JitArenaAllocator* const allocator;
-    IR::Instr* const yieldInstr;
-    CapturedValues* usedCapturedValues;
-    BVSparse<JitArenaAllocator> upwardExposedUses;
 
 public:
+    IR::Instr* yieldInstr;
+    CapturedValues capturedValues;
+    BVSparse<JitArenaAllocator> upwardExposedUses;
+
     static GeneratorBailInInstr* New(IR::Instr* yieldInstr, Func* func);
-    
-    IR::Instr* GetYieldInstr() const
-    {
-        return this->yieldInstr;
-    }
-
-    const CapturedValues& GetCapturedValues() const
-    {
-        return *this->usedCapturedValues;
-    }
-
-    const BVSparse<JitArenaAllocator>& GetUpwardExposedUses() const
-    {
-        return this->upwardExposedUses;
-    }
-
-    void SetCopyPropSyms(const SListBase<CopyPropSyms>& copyPropSyms)
-    {
-        this->usedCapturedValues->copyPropSyms.Clear(this->allocator);
-        copyPropSyms.CopyTo(this->allocator , this->usedCapturedValues->copyPropSyms);
-    }
-
-    void SetConstantValues(const SListBase<ConstantStackSymValue>& constantValues)
-    {
-        this->usedCapturedValues->constantValues.Clear(this->allocator);
-        constantValues.CopyTo(this->allocator, this->usedCapturedValues->constantValues);
-    }
-
-    void SetUpwardExposedUses(const BVSparse<JitArenaAllocator>& other)
-    {
-        this->upwardExposedUses.ClearAll();
-        this->upwardExposedUses.Or(&other);
-    }
 };
 
 template <typename InstrType>

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -5004,7 +5004,7 @@ void LinearScan::GeneratorBailIn::SpillRegsForBailIn()
 //
 IR::Instr* LinearScan::GeneratorBailIn::GenerateBailIn(IR::GeneratorBailInInstr* bailInInstr)
 {
-    BailOutInfo* bailOutInfo = bailInInstr->GetYieldInstr()->GetBailOutInfo();
+    BailOutInfo* bailOutInfo = bailInInstr->yieldInstr->GetBailOutInfo();
 
     Assert(!bailOutInfo->capturedValues || bailOutInfo->capturedValues->constantValues.Empty());
     Assert(!bailOutInfo->capturedValues || bailOutInfo->capturedValues->copyPropSyms.Empty());
@@ -5045,14 +5045,14 @@ IR::Instr* LinearScan::GeneratorBailIn::GenerateBailIn(IR::GeneratorBailInInstr*
 
     this->BuildBailInSymbolList(
         *bailOutInfo->byteCodeUpwardExposedUsed,
-        bailInInstr->GetUpwardExposedUses(),
-        bailInInstr->GetCapturedValues()
+        bailInInstr->upwardExposedUses,
+        bailInInstr->capturedValues
     );
 
     this->InsertRestoreSymbols(
         *bailOutInfo->byteCodeUpwardExposedUsed,
-        bailInInstr->GetUpwardExposedUses(),
-        bailInInstr->GetCapturedValues(),
+        bailInInstr->upwardExposedUses,
+        bailInInstr->capturedValues,
         insertionPoint
     );
     Assert(!this->func->IsStackArgsEnabled());

--- a/test/es6/generator-jit-bugs.js
+++ b/test/es6/generator-jit-bugs.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Test 1 - const that is unused/replaced with undefined
+function* foo() {
+    const temp2 = null;
+    while (true) {
+        yield temp2;
+    }
+}
+
+const gen = foo();
+
+gen.next();
+gen.next();
+gen.next();
+
+print("Pass");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -128,6 +128,13 @@
   </test>
   <test>
     <default>
+      <files>generator-jit-bugs.js</files>
+      <compile-flags>-JitES6Generators</compile-flags>
+      <tags>exclude_nonative</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>proto_basic.js</files>
       <baseline>proto_basic.baseline</baseline>
     </default>


### PR DESCRIPTION
This PR fixes an existing bug in the generator JIT implementation found by @rhuanjl.

In order to generate bail-in code, the backward pass copies "captured value" information from a yield's `BailOutInfo` into the associated `GeneratorBailInInstr`. The current implementation was copying `bailOutInfo->capturedValues->constantValues` on every pass over the yield instr. However, in a loop the yield instr is passed over twice, and each time entries are moved from `bailOutInfo->capturedValues` into `bailOutInfo->usedCapturedValues`. On the second pass over the instr, the current implementation is overwriting the constant values list with an empty list.

The change adds a `bailInInstr` field to `BailOutInfo` objects. The code that transfers info into the `bailInInstr` is embedded more directly into the operations that process that data.

Other changes:

- Simplified the `GeneratorBailInInstr` type, removing unnecessary getters and setters.
- Drive-by readability improvements in `BailOut.h` using inline field initializers for most fields.