### PR TITLE
Fix for the array inline segment assert.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11951,7 +11951,7 @@ Case0:
         SetHeadAndLastUsedSegment(dst);
         dst->CheckLengthvsSize();
 
-        Assert(IsInlineSegment(src, instance) == IsInlineSegment(dst, static_cast<T*>(this)));
+        Assert(!IsInlineSegment(src, instance) || IsInlineSegment(dst, static_cast<T*>(this)));
 
         CopyArray(dst->elements, dst->size, src->elements, sourceSize);
 

--- a/test/Bugs/bug_6277.js
+++ b/test/Bugs/bug_6277.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function inlinee() {
+    Number.isSafeInteger(1.1 * 0);
+    return inlinee.arguments[0];
+}
+function opt(convert_to_var_array) {
+    let stack_arr = [];
+
+    stack_arr[20] = 1.1;
+    stack_arr[10000] = 1.1;
+    stack_arr[20000] = 2.2;
+    let heap_arr = inlinee(stack_arr);
+}
+function main() {
+    for (let i = 0; i < 50000; i++) {
+        opt(new Function(''));
+        inlinee();
+        inlinee();
+    }
+    inlinee();
+    opt(heap_arr => {
+        heap_arr[10000] = {};
+        inlinee();
+        inlinee();
+    });
+}
+main();
+print("Pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -620,6 +620,11 @@
   </test>
   <test>
     <default>
+      <files>bug_6277.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug_OS23102586.js</files>
       <compile-flags>-force:deferparse</compile-flags>
     </default>


### PR DESCRIPTION
This assert is happening due to false positive. The array's head segment is not allocated as inlined - but it was allocated on the page boundary.
That makes this segement to just aligned with the array and we got the assert fired for wrong reason.
We don't need to check the assert for the source array to be not inlined as in the above 'else' condition we allocated the dest segment ourselve in the same function.
So I removed the part where we check the current array is not inlined.
