### PR TITLE
Fix module evaluation order

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -1079,10 +1079,13 @@ namespace Js
 
         try
         {
-            if (childrenModuleSet != nullptr)
+            if (requestedModuleList != nullptr)
             {
-                childrenModuleSet->EachValue([=](SourceTextModuleRecord* childModuleRecord)
-                {
+                requestedModuleList->Reverse();
+                requestedModuleList->Map([&](IdentPtr specifier) {
+                    SourceTextModuleRecord* childModuleRecord = nullptr;
+                    AssertOrFailFast(childrenModuleSet->TryGetValue(specifier->Psz(), &childModuleRecord));
+
                     childModuleRecord->ModuleEvaluation();
                     // if child module was evaluated before and threw need to re-throw now
                     // if child module has been dynamically imported and has exception need to throw

--- a/test/es6module/module-bugfixes.js
+++ b/test/es6module/module-bugfixes.js
@@ -95,6 +95,32 @@ var tests = [
         }
     },
     {
+        name: "Issue 6261: Specifier dependent module load order",
+        body: function() {
+            WScript.RegisterModuleSource("dep", `export const obj = {a:false, b: false, c: false};`);
+            WScript.RegisterModuleSource("one",`
+                import {obj} from "dep";
+                assert.isFalse(obj.b);
+                assert.isFalse(obj.c);
+                assert.isFalse(obj.a);
+                obj.a = true;`);
+            WScript.RegisterModuleSource("two",`
+                import {obj} from "dep";
+                assert.isFalse(obj.b);
+                assert.isFalse(obj.c);
+                assert.isTrue(obj.a);
+                obj.b = true;`);
+            WScript.RegisterModuleSource("three",`
+                import {obj} from "dep";
+                assert.isTrue(obj.b);
+                assert.isFalse(obj.c);
+                assert.isTrue(obj.a);
+                obj.c = true;`);
+            const start = 'import "one"; import "two"; import "three";';
+            testRunner.LoadModule(start);
+        }
+    },
+    {
         // https://github.com/Microsoft/ChakraCore/issues/5501
         name : "Issue 5501: Indirect exports excluded from namespace object - POC 1",
         body()


### PR DESCRIPTION
This PR should fix: #6261 

Child modules should be loaded in the order they're referenced in their parent - instead they were being loaded in an arbitrary order as the BasicDictionary they were stored in was sorted by specifier.

Fix this by referring back to the order they were referenced by the Parser.

This fix does not feel elegant - but a nicer fix would likely be significantly more involved for minimal benefit.