### PR TITLE
Allow for the possibility of no profile info for an inline call target

### DIFF
--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -1080,7 +1080,9 @@ JITTimeFunctionBody::GetCallApplyCallSiteIdForCallSiteId(Js::ProfileId callSiteI
     if (m_bodyData.callSiteToCallApplyCallSiteArray)
     {
         callApplyId = m_bodyData.callSiteToCallApplyCallSiteArray[callSiteId];
-        AssertOrFailFast(callApplyId < m_bodyData.profiledCallApplyCallSiteCount);
+        AssertOrFailFast(
+            callApplyId == Js::Constants::NoProfileId || 
+            callApplyId < m_bodyData.profiledCallApplyCallSiteCount);
     }
     
     return callApplyId;

--- a/test/inlining/bug_gh6303.js
+++ b/test/inlining/bug_gh6303.js
@@ -1,0 +1,12 @@
+let i = 0;
+
+function main() {
+  if (i++ > 2) return;
+  Array.prototype.sort.call(main, ()=>{})()++; // throws ref error
+	Array.prototype.sort.call(main, ()=>{});
+}
+
+try { main(); }
+catch {}
+
+print('PASSED');

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -341,4 +341,10 @@
       <compile-flags>-mic:1 -bgjit- -off:simplejit</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_gh6303.js</files>
+      <flags>exclude_nonative</flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes #6303  

A function body's `CallSiteToCallApplyCallSiteArray` can have `NoProfile` entries in some cases (for the POC, it's because we take the `EmitCallTargetNoEvalComponents` path in the bytecode emitter). This change loosens the fail fast to account for this possibility.

This should not create any security issues because the `GetCallApplyCallSiteIdForCallSiteId` function can already return `NoProfile` values, but we should review carefully.