### PR TITLE
Show "Module code" in stack trace for ESM

### DIFF
--- a/lib/Runtime/Base/Constants.cpp
+++ b/lib/Runtime/Base/Constants.cpp
@@ -19,6 +19,7 @@ const char16 Constants::Anonymous[] = _u("anonymous");
 const char16 Constants::Empty[] = _u("");
 const char16 Constants::FunctionCode[] = _u("Function code");
 const char16 Constants::GlobalCode[] = _u("Global code");
+const char16 Constants::ModuleCode[] = _u("Module code");
 const char16 Constants::EvalCode[] = _u("eval code");
 const char16 Constants::GlobalFunction[] = _u("glo");
 const char16 Constants::UnknownScriptCode[] = _u("Unknown script code");

--- a/lib/Runtime/Base/Constants.h
+++ b/lib/Runtime/Base/Constants.h
@@ -153,6 +153,7 @@ namespace Js
         static const  char16 Empty[];
         static const  char16 FunctionCode[];
         static const  char16 GlobalCode[];
+        static const  char16 ModuleCode[];
         static const  char16 EvalCode[];
         static const  char16 GlobalFunction[];
         static const  char16 UnknownScriptCode[];
@@ -165,11 +166,12 @@ namespace Js
         static const charcount_t FunctionCodeLength      = _countof(_u("Function code")) - 1;
         static const charcount_t GlobalFunctionLength    = _countof(_u("glo")) - 1;
         static const charcount_t GlobalCodeLength        = _countof(_u("Global code")) - 1;
+        static const charcount_t ModuleCodeLength        = _countof(_u("Module code")) - 1;
         static const charcount_t EvalCodeLength          = _countof(_u("eval code")) - 1;
         static const charcount_t UnknownScriptCodeLength = _countof(_u("Unknown script code")) - 1;
-        static const charcount_t NullStringLength = _countof(_u("Null")) - 1;
-        static const charcount_t TrueStringLength = _countof(_u("True")) - 1;
-        static const charcount_t FalseStringLength = _countof(_u("False")) - 1;
+        static const charcount_t NullStringLength        = _countof(_u("Null")) - 1;
+        static const charcount_t TrueStringLength        = _countof(_u("True")) - 1;
+        static const charcount_t FalseStringLength       = _countof(_u("False")) - 1;
     };
 
     extern const FrameDisplay NullFrameDisplay;

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2791,6 +2791,7 @@ namespace Js
         if (srcName == Js::Constants::GlobalFunction ||
             srcName == Js::Constants::AnonymousFunction ||
             srcName == Js::Constants::GlobalCode ||
+            srcName == Js::Constants::ModuleCode ||
             srcName == Js::Constants::Anonymous ||
             srcName == Js::Constants::UnknownScriptCode ||
             srcName == Js::Constants::FunctionCode)

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2500,6 +2500,12 @@ FuncInfo* PreVisitFunction(ParseNodeFnc* pnodeFnc, ByteCodeGenerator* byteCodeGe
         //
         funcExprWithName = true;
     }
+    else if (pnodeFnc->IsModule())
+    {
+        funcName = Js::Constants::ModuleCode;
+        funcNameLength = Js::Constants::ModuleCodeLength;
+        functionNameOffset = 0;
+    }
 
     if (byteCodeGenerator->Trace())
     {

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -140,7 +140,7 @@ namespace Js
 
                 Utf8SourceInfo* pResultSourceInfo = nullptr;
                 this->parseTree = scriptContext->ParseScript(parser, sourceText,
-                    sourceLength, srcInfo, &se, &pResultSourceInfo, _u("module"),
+                    sourceLength, srcInfo, &se, &pResultSourceInfo, Constants::ModuleCode,
                     loadScriptFlag, &sourceIndex, nullptr);
                 this->pSourceInfo = pResultSourceInfo;
             }
@@ -939,7 +939,7 @@ namespace Js
         Assert(this->WasDeclarationInitialized());
         Assert(this == scriptContext->GetLibrary()->GetModuleRecord(this->pSourceInfo->GetSrcInfo()->moduleID));
 
-        this->rootFunction = scriptContext->GenerateRootFunction(parseTree, sourceIndex, this->parser, this->pSourceInfo->GetParseFlags(), &se, _u("module"));
+        this->rootFunction = scriptContext->GenerateRootFunction(parseTree, sourceIndex, this->parser, this->pSourceInfo->GetParseFlags(), &se, Constants::ModuleCode);
 
         // Parser uses a temporary guest arena to keep regex patterns alive. We need to release this arena only after we have no further use
         // for the regex pattern objects.
@@ -1105,7 +1105,7 @@ namespace Js
             BEGIN_SAFE_REENTRANT_CALL(scriptContext->GetThreadContext())
             {
                 ResumeYieldData yieldData(scriptContext->GetLibrary()->GetUndefined(), nullptr);
-                ret = gen->CallGenerator(&yieldData, _u("Module Global"));
+                ret = gen->CallGenerator(&yieldData, Constants::ModuleCode);
                 ret = JavascriptOperators::GetProperty(VarTo<RecyclableObject>(ret), PropertyIds::value, scriptContext);
             }
             END_SAFE_REENTRANT_CALL


### PR DESCRIPTION
This is a minor quality of life point.

Prior to #6171 The stack trace for an error in a module showed an outer "module" function scope on line one of the module source file and then an "Anonymous function" scope holding an error on the relevant line of the module source file.

#6171 removed the "module" function scope from the stack trace leaving just the "Anonymous function" - This change renames the "Anonymous function" to "Module" in order to make the stack trace make more sense.

Running the following example as a module:
```js
//a.js
try {
    throw new Error("bang");
} catch (e) {
    print(e.stack);
}
```
Currently prints:
```
Error: bang
   at Anonymous function (../a.js:3:5)
```
With this change will print:
```
Error: bang
   at Module code (../a.js:3:5)
```

I have not added a test as this is not fixing a bug. Note I've also removed 3 places where "module" or "Module code" were supplied as function names for internal methods that will never show in a stack trace instead giving them a global constant.