### PR TITLE
Inherit toString from Error.prototype

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -2442,14 +2442,13 @@ namespace Js
     } \
     bool JavascriptLibrary::Initialize##error##Prototype(DynamicObject* prototype, DeferredTypeHandlerBase* typeHandler, DeferredInitializeMode mode) \
     { \
-        typeHandler->Convert(prototype, mode, 4); \
+        typeHandler->Convert(prototype, mode, 3); \
         JavascriptLibrary* library = prototype->GetLibrary(); \
         library->AddMember(prototype, PropertyIds::constructor, library->Get##error##Constructor()); \
         bool hasNoEnumerableProperties = true; \
         PropertyAttributes prototypeNameMessageAttributes = PropertyConfigurable | PropertyWritable; \
         library->AddMember(prototype, PropertyIds::name, library->CreateStringFromCppLiteral(_u(#errorName)), prototypeNameMessageAttributes); \
         library->AddMember(prototype, PropertyIds::message, library->GetEmptyString(), prototypeNameMessageAttributes); \
-        library->AddFunctionToLibraryObject(prototype, PropertyIds::toString, &JavascriptError::EntryInfo::ToString, 0); \
         prototype->SetHasNoEnumerableProperties(hasNoEnumerableProperties); \
         return true; \
     }

--- a/test/Error/errorPrototypetoString.js
+++ b/test/Error/errorPrototypetoString.js
@@ -1,0 +1,34 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Test the fix for https://github.com/microsoft/ChakraCore/issues/6372
+
+
+function checkObject(object)
+{
+    if (object.prototype.hasOwnProperty('toString'))
+    {
+        throw new Error(`${object.name}.prototype should not have own property 'toString'`);
+    }
+    if(object.prototype.toString !== Error.prototype.toString)
+    {
+        throw new Error(`${object.name}.prototype.toString should === Error.prototype.toString`);
+    }
+}
+
+checkObject(EvalError);
+checkObject(RangeError);
+checkObject(ReferenceError);
+checkObject(SyntaxError);
+checkObject(URIError);
+
+if (typeof WebAssembly !== 'undefined')
+{
+  checkObject(WebAssembly.CompileError);
+  checkObject(WebAssembly.LinkError);
+  checkObject(WebAssembly.RuntimeError);
+}
+
+print('pass');

--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -178,4 +178,9 @@
       <compile-flags>-ExtendedErrorStackForTestHost -force:DeferParse</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>errorPrototypetoString.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
This is a trivial fix, we may not be ready to merge anything new yet but this can serve as an example for how to fix small issues.

This fixes a minor bug where Error subclasses all defined their own toString property instead of inheriting from the Error.prototype.

fix: #6372