### PR TITLE
Fix:5678 update array spread implementation

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11645,10 +11645,13 @@ Case0:
                     JS_REENTRANT(jsReentLock, BOOL gotItem = JavascriptOperators::GetItem(srcArray, propertyObject, j, &element, scriptContext));
                     if (!gotItem)
                     {
-                        // Copy across missing values as undefined as per 12.2.5.2 SpreadElement : ... AssignmentExpression 5f.
-                        element = scriptContext->GetLibrary()->GetUndefined();
+                        // skip elided elements
+                        dstIndex++;
                     }
-                    dstArray->DirectSetItemAt(dstIndex++, element);
+                    else
+                    {
+                        dstArray->DirectSetItemAt(dstIndex++, element);
+                    }   
                 }
             };
 

--- a/test/es6/spread.js
+++ b/test/es6/spread.js
@@ -32,6 +32,14 @@ var tests = [
       }
   },
   {
+    name: "Bug Issue 5678, Spread should not set property descriptors on missing elements of target array",
+    body: function () {
+      var a = [1,,...[3]];
+      assert.isFalse(Reflect.has(a, 1));
+      assert.isUndefined(Object.getOwnPropertyDescriptor(a, 1));
+    }
+  },
+  {
     name: "Testing call with spread args (all should be the same)",
     body: function() {
       var a = [1, 2];


### PR DESCRIPTION
The implementation of https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation was doing a direct set to undefined of any elided elements in the target array - per a comment this may have been per a prior version of the specification but it is not instructed in the current spec - update per spec.

Fix: #5678 