### PR TITLE
Revert erroneous change to JsGetAndClearExceptionWIthMetadata

### DIFF
--- a/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
+++ b/lib/Runtime/Library/JavascriptExceptionMetadata.cpp
@@ -105,8 +105,8 @@ namespace Js {
 
         if (nextLine >= cache->GetLineCount())
         {
-            endByteOffset = startByteOffset + functionBody->LengthInBytes();
-            endCharOffset = startCharOffset + functionBody->LengthInChars();
+            endByteOffset = functionBody->LengthInBytes();
+            endCharOffset = functionBody->LengthInChars();
         }
         else
         {


### PR DESCRIPTION
Revert an erroneous edit made to JsGetAndClearExceptionWIthMetadata. And bring behaviour of this API back inline with version 1.11.

This relates to logic used for obtaining the source of the line of Js which generated the exception. This specific path is followed only when the error is on the last line of the script. In that case the line is measured by doing:

1. Obtain offset of the start of the line (characters/bytes from start of script to beginning of erroring line)
2. Obtain offset for end of the script (full size of script)
3. Work out the difference between the two

The error was that the output of (1) was being added to (2) - then upon working out the difference the result was always the full size of the script, not the length of the last line as wanted.

Note I have not added a test case for this as it would be rather complicated and this code is only used in this API and not for any other purpose - a better mechanism for testing some of these APIs should be developed at a later date.

Fix: #6408 
