### PR TITLE
Fix project building on Ubuntu 19.10

### DIFF
--- a/pal/src/misc/sysinfo.cpp
+++ b/pal/src/misc/sysinfo.cpp
@@ -27,9 +27,11 @@ Revision History:
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if HAVE_SYSCTL
+#if HAVE_SYSCONF || defined(__ANDROID__)
+// <unistd.h> already included
+#elif HAVE_SYSCTL
 #include <sys/sysctl.h>
-#elif !HAVE_SYSCONF && !defined(__ANDROID__)
+#else
 #error Either sysctl or sysconf is required for GetSystemInfo.
 #endif
 


### PR DESCRIPTION
I upgrade my Ubuntu version to 19.10 and realize that CC isn't building on this OS version.
It happened because `sysctl` is deprecated. I fixed that by preferring `sysconf`.

A similar issue happens in [Dotnet](https://github.com/dotnet/coreclr/pull/27048).