### PR TITLE
Add missing ENABLE_JS_BUILTINS guards

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -1371,7 +1371,7 @@ void Inline::InsertOneInlinee(IR::Instr* callInstr, IR::RegOpnd* returnValueOpnd
         // Put the meta arguments that the stack walker expects to find on the stack.
         // As all the argouts are shared among the inlinees, do this only once.
         SetupInlineeFrame(inlinee, currentCallInstr, actualCount, currentCallInstr->GetSrc1());
-        
+
         IR::Instr* inlineeEndInstr = IR::Instr::New(Js::OpCode::InlineeEnd, inlinee);
         inlineeEndInstr->SetByteCodeOffset(inlinee->m_tailInstr->GetPrevRealInstr());
         inlineeEndInstr->SetSrc1(IR::IntConstOpnd::New(actualCount + Js::Constants::InlineeMetaArgCount, TyInt32, inlinee));
@@ -2050,11 +2050,11 @@ Inline::InlineBuiltInFunction(
     IR::Instr *callInstr,
     const FunctionJITTimeInfo * inlineeData,
     Js::OpCode inlineCallOpCode,
-    const FunctionJITTimeInfo * inlinerData, 
-    const StackSym *symCallerThis, 
-    bool* pIsInlined, 
-    uint profileId, 
-    uint recursiveInlineDepth, 
+    const FunctionJITTimeInfo * inlinerData,
+    const StackSym *symCallerThis,
+    bool* pIsInlined,
+    uint profileId,
+    uint recursiveInlineDepth,
     IR::Instr * funcObjCheckInsertInstr)
 {
     Assert(callInstr);
@@ -2854,7 +2854,7 @@ bool Inline::TryGetCallApplyAndTargetLdInstrs(IR::Instr * callInstr, _Outptr_res
     Assert(applyOpnd->IsRegOpnd());
     StackSym* applySym =  applyOpnd->AsRegOpnd()->m_sym->AsStackSym();
     if (!applySym->IsSingleDef() ||
-        !applySym->GetInstrDef()->GetSrc1()->IsSymOpnd() || 
+        !applySym->GetInstrDef()->GetSrc1()->IsSymOpnd() ||
         !applySym->GetInstrDef()->GetSrc1()->AsSymOpnd()->IsPropertySymOpnd())
     {
         *applyLdInstr = nullptr;
@@ -3120,15 +3120,15 @@ bool Inline::InlineApplyScriptTarget(IR::Instr *callInstr, const FunctionJITTime
 
 IR::Instr *
 Inline::InlineCallApplyTarget_Shared(
-    IR::Instr *callInstr, 
-    bool originalCallTargetOpndIsJITOpt, 
-    StackSym* originalCallTargetStackSym, 
+    IR::Instr *callInstr,
+    bool originalCallTargetOpndIsJITOpt,
+    StackSym* originalCallTargetStackSym,
     const FunctionJITTimeInfo *const inlineeData,
-    uint inlineCacheIndex, 
+    uint inlineCacheIndex,
     bool safeThis,
-    bool isApplyTarget, 
-    CallApplyTargetSourceType targetType, 
-    IR::Instr * inlineeDefInstr, 
+    bool isApplyTarget,
+    CallApplyTargetSourceType targetType,
+    IR::Instr * inlineeDefInstr,
     uint recursiveInlineDepth,
     IR::Instr * funcObjCheckInsertInstr)
 {
@@ -3409,7 +3409,9 @@ Inline::InlineCallTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* inline
         }
         case Js::BuiltinFunction::JavascriptFunction_Apply:
         case Js::BuiltinFunction::JavascriptFunction_Call:
+#ifdef ENABLE_JS_BUILTINS
         case Js::BuiltinFunction::EngineInterfaceObject_CallInstanceFunction:
+#endif
             return false;
         }
     }
@@ -3464,7 +3466,7 @@ Inline::AdjustArgoutsForCallTargetInlining(IR::Instr* callInstr, IR::Instr ** pE
                                                    // so that any bailout in the call sequence restores the argouts stack as the interpreter would expect it to be.
 
         StackSym * argSym = argInstr->GetDst()->AsSymOpnd()->GetStackSym();
-        
+
         Assert(argSym->m_offset == (argSym->GetArgSlotNum() - 1) * MachPtr);
         argSym->DecrementArgSlotNum(); // We will be removing implicit "this" argout
         if (argSym->GetArgSlotNum() != 0)
@@ -3632,14 +3634,14 @@ Inline::TryGetFixedMethodsForBuiltInAndTarget(IR::Instr *callInstr, const Functi
             this->topFunc->GetJITFunctionBody()->GetDisplayName(), this->topFunc->GetDebugNumberSet(debugStringBuffer3));
         return nullptr;
     }
-    
+
     useCallTargetInstr->SetRemovedOpndSymbol(originalCallTargetOpndJITOpt, originalCallTargetStackSym->m_id);
 
     callInstr->m_opcode = originalCallOpCode;
     callInstr->ReplaceSrc1(functionOpnd);
-        
+
     if (isCallback)
-    {      
+    {
         callInstr->InsertBefore(useCallTargetInstr);
         return useCallTargetInstr;
     }

--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -223,14 +223,14 @@ uint InliningDecider::InlinePolymorphicCallSite(Js::FunctionBody *const inliner,
     return inlineeCount;
 }
 
-Js::FunctionInfo *InliningDecider::Inline(Js::FunctionBody *const inliner, 
+Js::FunctionInfo *InliningDecider::Inline(Js::FunctionBody *const inliner,
     Js::FunctionInfo* functionInfo,
-    bool isConstructorCall, 
-    bool isPolymorphicCall, 
-    bool isCallback, 
-    uint16 constantArgInfo, 
-    Js::ProfileId callSiteId, 
-    uint recursiveInlineDepth, 
+    bool isConstructorCall,
+    bool isPolymorphicCall,
+    bool isCallback,
+    uint16 constantArgInfo,
+    Js::ProfileId callSiteId,
+    uint recursiveInlineDepth,
     bool allowRecursiveInlining)
 {
 #if defined(DBG_DUMP) || defined(ENABLE_DEBUG_CONFIG_OPTIONS)
@@ -574,9 +574,12 @@ bool InliningDecider::GetBuiltInInfoCommon(
     case Js::JavascriptBuiltInFunction::JavascriptFunction_Call:
         *inlineCandidateOpCode = Js::OpCode::InlineFunctionCall;
         break;
+
+#ifdef ENABLE_JS_BUILTINS
     case Js::JavascriptBuiltInFunction::EngineInterfaceObject_CallInstanceFunction:
         *inlineCandidateOpCode = Js::OpCode::InlineCallInstanceFunction;
         break;
+#endif
 
     // The following are not currently inlined, but are tracked for their return type
     // TODO: Add more built-ins that return objects. May consider tracking all built-ins.

--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -518,6 +518,8 @@ BUILTIN(AtomicsObject, Wait, EntryWait, FunctionInfo::ErrorOnNew)
 BUILTIN(AtomicsObject, Notify, EntryNotify, FunctionInfo::ErrorOnNew)
 BUILTIN(AtomicsObject, Xor, EntryXor, FunctionInfo::ErrorOnNew)
 
+#ifdef ENABLE_JS_BUILTINS
 BUILTIN(EngineInterfaceObject, CallInstanceFunction, Entry_CallInstanceFunction, FunctionInfo::ErrorOnNew | FunctionInfo::DoNotProfile)
+#endif
 
 #undef BUILTIN_TEMPLATE

--- a/lib/Runtime/LibraryFunction.h
+++ b/lib/Runtime/LibraryFunction.h
@@ -73,7 +73,9 @@ LIBRARY_FUNCTION(JavascriptArray,         Splice,             15,   BIF_UseSrc0 
 LIBRARY_FUNCTION(JavascriptArray,         Unshift,            15,   BIF_UseSrc0 | BIF_VariableArgsNumber | BIF_IgnoreDst  , JavascriptArray::EntryInfo::Unshift)
 LIBRARY_FUNCTION(JavascriptFunction,      Apply,              3,    BIF_UseSrc0 | BIF_IgnoreDst | BIF_VariableArgsNumber  , JavascriptFunction::EntryInfo::Apply)
 LIBRARY_FUNCTION(JavascriptFunction,      Call,               15,   BIF_UseSrc0 | BIF_IgnoreDst | BIF_VariableArgsNumber  , JavascriptFunction::EntryInfo::Call)
+#ifdef ENABLE_JS_BUILTINS
 LIBRARY_FUNCTION(EngineInterfaceObject, CallInstanceFunction, 15,   BIF_UseSrc0 | BIF_IgnoreDst | BIF_VariableArgsNumber  , EngineInterfaceObject::EntryInfo::CallInstanceFunction)
+#endif
 LIBRARY_FUNCTION(GlobalObject,  ParseInt,           1,    BIF_IgnoreDst                                         , GlobalObject::EntryInfo::ParseInt)
 LIBRARY_FUNCTION(JavascriptRegExp,        Exec,               2,    BIF_UseSrc0 | BIF_IgnoreDst                           , JavascriptRegExp::EntryInfo::Exec)
 LIBRARY_FUNCTION(JavascriptRegExp,        SymbolSearch,       2,    BIF_UseSrc0                                           , JavascriptRegExp::EntryInfo::SymbolSearch)


### PR DESCRIPTION
Currently, disabling `ENABLE_JS_BUILTINS` will not result in a successful build, because a backend optimization was added for `EngineInterfaceObject_CallInstanceFunction` which did not correctly use the guard.

This change adds the guard so that CC can be built with `ENABLE_JS_BUILTINS` disabled.

The whitespace changes are due to incorrect whitespace before newlines.