### PR TITLE
Reenable implicit function declaration warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,11 +294,6 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
 
     set(CMAKE_CXX_STANDARD 11)
 
-    # CC WARNING FLAGS
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
-        -Wno-implicit-function-declaration"
-    )
-
     # todo: fix general visibility of the interface
     # do not set to `fvisibility=hidden` as it is going to
     # prevent the required interface is being exported
@@ -330,7 +325,6 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
         -Wno-null-conversion\
         -Wno-return-type\
         -Wno-switch\
-        -Wno-implicit-function-declaration\
         -Wno-int-to-pointer-cast\
         -Wno-tautological-constant-compare\
         -Wno-enum-compare-switch\

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 #include "Backend.h"
+#include "CommonPal.h"
 #ifdef ENABLE_SCRIPT_DEBUGGING
 #include "Debug/DebuggingFlags.h"
 #include "Debug/DiagProbe.h"

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -516,6 +516,8 @@ __forceinline void * _AddressOfReturnAddress()
 {
     return (void*)((char*) __builtin_frame_address(0) + sizeof(void*));
 }
+#else
+extern "C" void * _AddressOfReturnAddress(void);
 #endif
 #else
 #error _AddressOfReturnAddress and _ReturnAddress not defined for this platform

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -47,6 +47,10 @@ Abstract:
 #include <ctype.h>
 #endif
 
+#if !defined(static_assert)
+#define static_assert _Static_assert
+#endif
+
 #if defined(__APPLE__)
 #ifndef __IOS__
 #include "TargetConditionals.h"


### PR DESCRIPTION
Drop `-Wno-implicit-function-declarations` and deal with the warning
fallout. Fix implicit function declarations in pal.h (static_assert).
Provide _AddressOfReturnAddress prototype.

For #6435