### PR TITLE
MSFT:26791925 Exprgen:CAS:x64::DEBUG:InconsistentRepro: BREAKPOINT_80000003_chakra.dll!RpcFailure_unrecoverable_error ASSERTION : (E:\A\_work\221\s\core\lib\Backend\Lower.cpp, line 7287) false Failure: (false)

### DIFF
--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -152,7 +152,6 @@ private:
     void SetTypeIDWithFinalType(int symId, BasicBlock *block);
     void ClearTypeIDWithFinalType(int symId, BasicBlock *block);
     bool HasTypeIDWithFinalType(BasicBlock *block) const;
-    void CombineTypeIDsWithFinalType(BasicBlock *block, BasicBlock *blockSucc);
 
     template<class Fn> void ForEachAddPropertyCacheBucket(Fn fn);
     static ObjTypeGuardBucket MergeGuardedProperties(ObjTypeGuardBucket bucket1, ObjTypeGuardBucket bucket2);


### PR DESCRIPTION
Make sure symbols are cleared from the typeIDsWithFinalType set if the type is not available upstream.