### PR TITLE
Object.prototype.hasOwnProperty takes undefined when no arg passed in

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -78,15 +78,11 @@ Var JavascriptObject::EntryHasOwnProperty(RecyclableObject* function, CallInfo c
         JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("Object.prototype.hasOwnProperty"));
     }
 
-    // no property specified
-    if (args.Info.Count == 1)
-    {
-        return scriptContext->GetLibrary()->GetFalse();
-    }
+    Var propertyName = args.Info.Count == 1 ? scriptContext->GetLibrary()->GetUndefined() : args[1];
 
     const PropertyRecord* propertyRecord;
     PropertyString* propertyString;
-    JavascriptConversion::ToPropertyKey(args[1], scriptContext, &propertyRecord, &propertyString);
+    JavascriptConversion::ToPropertyKey(propertyName, scriptContext, &propertyRecord, &propertyString);
 
     if (JavascriptOperators::HasOwnProperty(dynamicObject, propertyRecord->GetPropertyId(), scriptContext, propertyString))
     {

--- a/test/Object/hasOwnProperty.baseline
+++ b/test/Object/hasOwnProperty.baseline
@@ -20,3 +20,5 @@ false
 true
 false
 true
+true
+true

--- a/test/Object/hasOwnProperty.js
+++ b/test/Object/hasOwnProperty.js
@@ -5,6 +5,9 @@
 
 function write(v) { WScript.Echo(v + ""); }
 
+function obj() { return this; }
+
+var z = obj();
 var o = new Object();
 var a = [11,12,13];
 
@@ -42,3 +45,6 @@ write(a.hasOwnProperty());
 write(a.hasOwnProperty(o));
 write(a.hasOwnProperty("o"));
 write(a.hasOwnProperty("[object Object]")); 
+
+write(z.hasOwnProperty());
+write(z.hasOwnProperty(undefined));


### PR DESCRIPTION
```javascript
function o() {return this} // this `this` contains all global objects
o().hasOwnProperty() // false, should true as other browsers return
o().hasOwnProperty(undefined) // true
```

close #6477 