### PR TITLE
Fix collecting of still used weak references

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -3210,16 +3210,12 @@ Recycler::SweepWeakReference()
             return false;
         }
 
-        if (!weakRef->strongRefHeapBlock->TestObjectMarkedBit(weakRef->strongRef))
+        if (weakRef->strongRef && !weakRef->strongRefHeapBlock->TestObjectMarkedBit(weakRef->strongRef))
         {
-            hasCleanup = true;
             weakRef->strongRef = nullptr;
 
             // Put in a dummy heap block so that we can still do the isPendingConcurrentSweep check first.
             weakRef->strongRefHeapBlock = &CollectedRecyclerWeakRefHeapBlock::Instance;
-
-            // Remove
-            return false;
         }
 
         return true;


### PR DESCRIPTION
If the RecyclerWeakReference has been marked, it must not be removed just because the object it refers to will be collected.